### PR TITLE
Import new tokens - 2026-08-07-0844

### DIFF
--- a/duckduckgo.pot
+++ b/duckduckgo.pot
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -338,6 +344,12 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -571,6 +583,12 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -1460,6 +1478,14 @@ msgid "Advanced Models"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -2211,6 +2237,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3706,6 +3738,12 @@ msgid "Chat privately with AI"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4451,6 +4489,12 @@ msgid "Close"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4492,6 +4536,12 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -4864,6 +4914,12 @@ msgid "Continue Blocking Ads"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4929,6 +4985,12 @@ msgid "Cookie data:"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4973,6 +5035,12 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -5089,6 +5157,12 @@ msgid "Create Image"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5129,6 +5203,14 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -5281,6 +5363,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -5567,9 +5655,21 @@ msgid "Delete Server Data?"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -5602,6 +5702,12 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -5909,6 +6015,12 @@ msgid "Dismiss promotion"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6111,6 +6223,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -6322,6 +6440,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6445,6 +6569,12 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -7023,6 +7153,12 @@ msgid "Enable Most-Visited Sites"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7312,6 +7448,12 @@ msgid "Entertainment guide"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -7473,6 +7615,18 @@ msgid "Explicit lyrics"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7571,6 +7725,12 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -7973,6 +8133,12 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -8481,6 +8647,12 @@ msgid "Get computer help"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8516,6 +8688,18 @@ msgid "Get the Latest Version"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8535,6 +8719,12 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -9203,6 +9393,12 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -10777,6 +10973,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr ""
 
@@ -10844,6 +11047,12 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -11937,6 +12146,12 @@ msgid "More than 20 minutes"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12416,6 +12631,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -13080,6 +13301,12 @@ msgid "On but no numbers"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13283,6 +13510,12 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -14004,9 +14237,21 @@ msgid "Pin"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -14024,6 +14269,12 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -14332,6 +14583,12 @@ msgid "Poor formatting"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14537,6 +14794,12 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -15076,6 +15339,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15108,6 +15383,12 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -15255,6 +15536,12 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -15617,6 +15904,12 @@ msgid "Reset All Settings"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -15626,6 +15919,12 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -16307,6 +16606,12 @@ msgid "Search %s to find results closer to you?"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Search Anonymously"
 msgstr ""
 
@@ -16640,6 +16945,12 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -17138,6 +17449,12 @@ msgid "Set as Homepage"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17201,6 +17518,18 @@ msgid "Seychelles"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17235,6 +17564,13 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -17293,6 +17629,12 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -17426,6 +17768,12 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -17576,6 +17924,12 @@ msgid "Show more"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -17608,6 +17962,12 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -17973,6 +18333,12 @@ msgid "Something went wrong, please try again later."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18254,6 +18620,12 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -18831,6 +19203,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -18962,6 +19342,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19046,6 +19432,22 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -19491,9 +19893,21 @@ msgid "This Month"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -19611,6 +20025,22 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -19915,6 +20345,12 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -20323,8 +20759,20 @@ msgid "Try Them Out"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -20390,6 +20838,12 @@ msgid "Try for free"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -20401,6 +20855,12 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -20428,6 +20888,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -20669,6 +21135,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -21026,6 +21498,12 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -21375,6 +21853,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -22464,6 +22948,12 @@ msgid "What brought you back today?"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -22873,6 +23363,14 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -23286,6 +23784,13 @@ msgid "You can only attach %s images per conversation."
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -23413,6 +23918,12 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -23453,6 +23964,12 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -23803,6 +24320,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -24380,4 +24905,10 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,7 @@ msgstr "!Knal-soeksnelsleutels"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
+msgstr "\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -128,7 +127,7 @@ msgstr "%1$s bespeur"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s lêers is gebruik"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,7 +364,7 @@ msgstr "%1$s gebruik"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s gebruik limiete 2-5x vinniger as basiese modelle op %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -429,8 +428,7 @@ msgstr "%1$s woorde"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
+msgstr "%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -493,8 +491,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
+msgstr "%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -620,7 +617,7 @@ msgstr "1 dag gelede"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 lêer is gebruik"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -841,8 +838,7 @@ msgstr "6-uur-gebruikslimiet is bereik."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
+msgstr "6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1317,8 +1313,7 @@ msgstr "Voeg DuckDuckGo-uitbreiding by"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
+msgstr "Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1538,7 +1533,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
+msgstr "Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1752,8 +1747,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
+msgstr "Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1824,8 +1818,7 @@ msgstr "Laat anonieme lêerhersiening vir hierdie kletsgesprek toe?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
+msgstr "Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2158,8 +2151,7 @@ msgstr "Is jy nog daar?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
+msgstr "Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2331,7 +2323,7 @@ msgstr "Vra privaat"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Vra privaat"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2371,8 +2363,8 @@ msgstr ""
 "verskyn: Nooit (verwyder Assist UI heeltemal uit soekresultate), Op aanvraag "
 "(wys slegs KI-gesteunde antwoorde as jy op die Assist-knoppie klik), Soms "
 "(wys slegs KI-gesteunde antwoorde wanneer dit baie relevant is) of Dikwels "
-"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is KI-"
-"gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
+"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is "
+"KI-gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2478,8 +2470,7 @@ msgstr ""
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
+msgstr "Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2527,8 +2518,7 @@ msgstr "Outo-antwoord"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
+msgstr "Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2733,8 +2723,7 @@ msgstr "Strepieskode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
+msgstr "Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3655,8 +3644,7 @@ msgstr "Verander hoe resultaat-URL'e vertoon word"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
+msgstr "Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3808,10 +3796,10 @@ msgid ""
 msgstr ""
 "Met Chat (via ons Duck.ai-diens) kan jy anonieme gesprekke voer met "
 "derdeparty-KI-kletsmodelle, wat modelle van OpenAI, Anthropic en meer "
-"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en -"
-"skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
-"Chat kry wanneer hierdie instelling afgeskakel is, deur %1$shttps://duck."
-"ai%2$s direk te besoek."
+"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en "
+"-skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
+"Chat kry wanneer hierdie instelling afgeskakel is, deur "
+"%1$shttps://duck.ai%2$s direk te besoek."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3866,16 +3854,14 @@ msgstr "Gesels privaat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
+msgstr "Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
+msgstr "Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3893,7 +3879,7 @@ msgstr "Gesels privaat met KI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Gesels privaat met gewilde KI’s"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3944,9 +3930,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Kletse word plaaslik op jou toestel gestoor in plaas van op DuckDuckGo-"
-"bedieners of afgeleë bedieners. As jy kletsgeskiedenis deaktiveer, sal "
-"vasgespelde kletse uitgevee word."
+"Kletse word plaaslik op jou toestel gestoor in plaas van op "
+"DuckDuckGo-bedieners of afgeleë bedieners. As jy kletsgeskiedenis "
+"deaktiveer, sal vasgespelde kletse uitgevee word."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4486,8 +4472,7 @@ msgstr "Klik %1$sJa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
+msgstr "Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4689,7 +4674,7 @@ msgstr "Sluit"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Maak toe"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4739,7 +4724,7 @@ msgstr "Maak soektog toe"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Sluit tweede opinie"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5117,6 +5102,8 @@ msgstr "Hou aan om advertensies te blokkeer"
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
+"Gaan hier voort met onlangse kletsgesprekke. Of vee dit uit met die Fire "
+"Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5187,7 +5174,7 @@ msgstr "Koekiedata:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Gekopieer"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5240,7 +5227,7 @@ msgstr "Kopieer kode"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopieer skakel"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5310,8 +5297,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
+msgstr "Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5360,7 +5346,7 @@ msgstr "Skep prent"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Skep deelskakel"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5412,6 +5398,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"As jy ’n skakel skep, maak dit ’n kopie van die kletsgesprek wat deur "
+"enigiemand wat dit oopmaak, bekyk kan word."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5570,7 +5558,7 @@ msgstr "Pasmaak antwoorde"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Pasmaak antwoorde"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5862,7 +5850,7 @@ msgstr "Wil jy bedienerdata skrap?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Wis gedeelde skakel uit"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5874,7 +5862,7 @@ msgstr "Verwyder transkripsie"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Vee ’n kletsgesprek uit"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5912,7 +5900,7 @@ msgstr "Skrap prent?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Skrap my"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5924,8 +5912,7 @@ msgstr "Wil jy oudste kletsgesprekke skrap om stoorplek te maak?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
+msgstr "Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5971,8 +5958,7 @@ msgstr "Beskryf veranderinge gebaseer op die beeld"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
+msgstr "Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6228,7 +6214,7 @@ msgstr "Wys promosie van die hand"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Wys toer af"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6252,8 +6238,7 @@ msgstr "Vertoon taal"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
+msgstr "Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6445,7 +6430,7 @@ msgstr "Laai DuckDuckGo af"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Laai DuckDuckGo af"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6666,7 +6651,7 @@ msgstr "Duck.ai deur DuckDuckGo. Privaat KI-geselsie. Gratis."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai kan nou PDF’s ontleed. Probeer dit!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6774,8 +6759,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai laat jou privaat met gewilde KI-modelle gesels. As jy dit afskakel, "
-"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds %1$sduck."
-"ai%2$s direk besoek."
+"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds "
+"%1$sduck.ai%2$s direk besoek."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6827,7 +6812,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai ondersteun modelle van Anthropic, OpenAI en ander."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6855,9 +6840,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme KI-"
-"klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, oopbron "
-"KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
+"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme "
+"KI-klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, "
+"oopbron KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7026,8 +7011,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
+msgstr "DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7146,8 +7130,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, e-"
-"posadresse, telefoonnommers en identifiserende metadata, te verwyder."
+"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, "
+"e-posadresse, telefoonnommers en identifiserende metadata, te verwyder."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7247,8 +7231,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
+msgstr "DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7477,7 +7460,7 @@ msgstr "Aktiveer mees besoekte webwerwe"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Aktiveer nou"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7527,8 +7510,7 @@ msgstr "Aktiveer diktasie in Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
+msgstr "Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7781,7 +7763,7 @@ msgstr "Vermaakgids"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Hele kletsgesprek"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7851,8 +7833,7 @@ msgstr "Vou kaart uit"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
+msgstr "Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7949,13 +7930,13 @@ msgstr "Eksplisiete lirieke"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Verken Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Verken Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8062,7 +8043,7 @@ msgstr "Gratis"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRATIS & OPSIONEEL"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8121,8 +8102,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
-"verbeterings."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
+"-verbeterings."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8131,8 +8112,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
-"verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
+"-verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8275,8 +8256,7 @@ msgstr "Vind <b>%1$s</b> in jou aflaaivouer"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
+msgstr "Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8313,8 +8293,7 @@ msgstr "Vind resultate nader aan jou."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
+msgstr "Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8484,7 +8463,7 @@ msgstr "Maak stoorplek skoon"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Gratis en altyd privaat"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8496,8 +8475,7 @@ msgstr "Gratis en privaat geselsies, geanonimiseer deur ons"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
+msgstr "Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8610,8 +8588,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is ..."
-"</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
+"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is "
+"...</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
 "opdatering</strong>."
 
 # smartling.placeholder_format=C
@@ -8976,8 +8954,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n DuckDuckGo-"
-"intekening, wat ook ons VPN en ander premium "
+"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n "
+"DuckDuckGo-intekening, wat ook ons VPN en ander premium "
 "privaatheidsbeskermingsmaatreëls insluit."
 
 # smartling.placeholder_format=C
@@ -9007,7 +8985,7 @@ msgstr "Kry rekenaarhulp"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Kry hoër gebruikslimiete met ’n DuckDuckGo-intekening."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9018,8 +8996,7 @@ msgstr "Kry ons blaaier om nooit jou instellings te verloor nie."
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
+msgstr "Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9049,13 +9026,15 @@ msgstr "Kry die nuutste weergawe"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Kry die app"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te "
+"blokkeer.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9083,7 +9062,7 @@ msgstr "Bring jou vriende saam en help ons om te groei!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Begin-kontrolelys"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9114,9 +9093,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel › Kopieer tekskode%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel › Kopieer tekskode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9125,9 +9104,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9137,9 +9116,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s en skandeer hierdie kode:"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s en skandeer hierdie kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9149,9 +9128,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9685,8 +9664,7 @@ msgstr "Help jou vriende en familie om by die Duck-kant aan te sluit!"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
+msgstr "Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9774,7 +9752,7 @@ msgstr "Verberg wenke"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Verberg tutoriaal"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9823,8 +9801,7 @@ msgstr "Versteek jou e-posadres"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
+msgstr "Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10072,8 +10049,7 @@ msgstr "Hoe dikwels wil jy KI-gesteunde antwoorde sien?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
+msgstr "Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10316,8 +10292,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
+msgstr "Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10466,8 +10441,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en -"
-"kleur"
+"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en "
+"-kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10897,8 +10872,7 @@ msgstr "Dit is vinnig, gratis en gee jou selfs meer aanlyn beskerming."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
+msgstr "Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11401,7 +11375,7 @@ msgstr "Laat jou anoniem soek met DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11477,7 +11451,7 @@ msgstr "Lynskrums gewen"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Skakel verval oor 7 dae."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11493,8 +11467,7 @@ msgstr "Skakels:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
+msgstr "Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12131,8 +12104,7 @@ msgstr "Mikronesië"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
+msgstr "Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12579,7 +12551,7 @@ msgstr "Langer as 20 minute"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Meer wenke"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12902,11 +12874,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n DuckDuckGo-"
-"bediener gestoor nadat dit gestuur is om te help om ’n klets te herstel as "
-"jy jou internetverbinding verloor. As jy kletsgeskiedenis deaktiveer, sal "
-"vasgespelde kletse uitgevee word en die tydelike berging van nuwe "
-"aanporrings en antwoorde deaktiveer."
+"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n "
+"DuckDuckGo-bediener gestoor nadat dit gestuur is om te help om ’n klets te "
+"herstel as jy jou internetverbinding verloor. As jy kletsgeskiedenis "
+"deaktiveer, sal vasgespelde kletse uitgevee word en die tydelike berging van "
+"nuwe aanporrings en antwoorde deaktiveer."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13073,7 +13045,7 @@ msgstr "Nee, dankie"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nee, dankie"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13221,8 +13193,7 @@ msgstr "Geen resultate gevind nie."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
+msgstr "Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13742,7 +13713,7 @@ msgstr "Aan maar geen nommers nie"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Oriëntasie is voltooi"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13960,7 +13931,7 @@ msgstr "Maak voorstelle vir die skep en redigering van beelde oop"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Maak begin-kontrolelys oop"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14025,8 +13996,7 @@ msgstr "Maak die paneel oop oor hoe Duck.ai werk."
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
+msgstr "Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14633,8 +14603,8 @@ msgid ""
 msgstr ""
 "As jy jou soektog as 'n vraag en in 'n volsin fraseer, sal DuckAssist meer "
 "geneig wees om outomaties te verskyn en dikwels beter antwoorde lewer. Om "
-"dit af te skakel en die Assist-knoppie te verberg, kan jy na %1$sDuckAssist-"
-"instellings%2$s gaan."
+"dit af te skakel en die Assist-knoppie te verberg, kan jy na "
+"%1$sDuckAssist-instellings%2$s gaan."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14714,7 +14684,7 @@ msgstr "Speld vas"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Speld ’n kletsgesprek vas"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14726,7 +14696,7 @@ msgstr "Speld kletse hier vas vanaf die %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Speld my vas"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14749,7 +14719,7 @@ msgstr "Vasgespeld"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15079,6 +15049,8 @@ msgstr "Swak formatering"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Beskikbare gewilde KI-modelle. Geen rekening is nodig nie. Kletsgesprekke "
+"geanonimiseer deur ons."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15292,7 +15264,7 @@ msgstr "Vorige-oortjies"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Vorige wenke"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15587,8 +15559,7 @@ msgstr "Vra my"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
+msgstr "Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15837,13 +15808,13 @@ msgstr "Redenerende KI met medium ingeboude moderering"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Redenasievermoë kan beter antwoorde op ingewikkelde vrae gee."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15884,7 +15855,7 @@ msgstr "Onlangse kletsberging kan in %1$s aangepas word."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Onlangse kletsgesprekke"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16045,7 +16016,7 @@ msgstr "Verminder gebruik"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Verminder gebruik met ’n doeltreffender model"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16427,7 +16398,7 @@ msgstr "Stel alle instellings terug"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Stel tutoriaal terug"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16445,7 +16416,7 @@ msgstr "Resolusie"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Reaksie"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16937,8 +16908,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met end-tot-"
-"end-enkripsie."
+"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met "
+"end-tot-end-enkripsie."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17115,8 +17086,7 @@ msgstr "Rol af en soek %1$sjou blaaier%2$s op die lys."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
+msgstr "Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17150,7 +17120,7 @@ msgstr "Wil jy soek %1$s vir resultate nader aan jou?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Soek-en-Duck.ai-skakelaar"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17352,8 +17322,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte POST-"
-"versoeke gebruik)"
+"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte "
+"POST-versoeke gebruik)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17502,8 +17472,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Stoor jou gesprekke veilig op ons bediener met behulp van punt-tot-punt-"
-"enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
+"Stoor jou gesprekke veilig op ons bediener met behulp van "
+"punt-tot-punt-enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17525,7 +17495,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Word veilig gestoor op ons geënkripteerde bediener."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17636,8 +17606,7 @@ msgstr "Kyk na 'n paar van ons nuutste opdaterings"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
+msgstr "Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17664,8 +17633,7 @@ msgstr "Kies %1$s%2$s%3$s, dan %4$sSoekenjin%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
+msgstr "Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17820,8 +17788,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
+msgstr "Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18040,7 +18007,7 @@ msgstr "Stel in as tuisblad"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Stel die toon en styl van Duck.ai se antwoorde in."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18062,8 +18029,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
+msgstr "Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18112,13 +18078,13 @@ msgstr "Seychelle"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Deel"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Deel"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18156,15 +18122,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. Duck."
-"ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
+"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. "
+"Duck.ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Deel kletsgesprek"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18228,7 +18194,7 @@ msgstr "Deel positiewe terugvoer"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Deel omvang"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18369,7 +18335,7 @@ msgstr "Wys detail"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Wys Duck.ai-tutoriaal"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18380,8 +18346,7 @@ msgstr "Wys DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
+msgstr "Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18523,7 +18488,7 @@ msgstr "Wys meer"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Wys meer modelle"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18564,7 +18529,7 @@ msgstr "Wys sybalk"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Wys stap-vir-stap-wenke om die meeste uit Duck.ai te kry."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18691,8 +18656,7 @@ msgstr "Wys voorstelle onder die soekkassie soos jy tik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
+msgstr "Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18707,8 +18671,7 @@ msgstr "Wys verwelkomingsboodskap bo-aan die bladsy met soekresultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
+msgstr "Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18780,8 +18743,7 @@ msgstr "Webwerfname"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
+msgstr "Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18925,8 +18887,7 @@ msgstr "Iets het skeefgeloop"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
+msgstr "Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18946,7 +18907,7 @@ msgstr "Iets het verkeerd geloop, probeer asseblief later weer."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Iets het verkeerd geloop. Probeer asseblief weer."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18964,8 +18925,7 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
+msgstr "Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19022,8 +18982,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om Duck."
-"ai te vra."
+"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om "
+"Duck.ai te vra."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19039,8 +18999,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
+msgstr "Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19246,7 +19205,7 @@ msgstr "Begin om die weeklikse limiet te gebruik"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Begin ’n nuwe kletsgesprek"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19834,7 +19793,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Skakel oor na hierdie tweede opinie"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19903,8 +19862,7 @@ msgstr "Sync & Backup is geaktiveer!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
+msgstr "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19953,8 +19911,8 @@ msgid ""
 msgstr ""
 "Sinkronisasieherstelkode\n"
 "\n"
-"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en Duck.ai-"
-"kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
+"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en "
+"Duck.ai-kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
 "gesinkroniseerde data terug te kry as jy toegang tot ’n toestel verloor.\n"
 "\n"
 "Hou hierdie inligting veilig en seker.\n"
@@ -19995,7 +19953,7 @@ msgstr "Sinchronisasie en rugsteun is tydelik onbeskikbaar"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sinchroniseer kletsgesprekke tussen toestelle"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20091,6 +20049,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Neem Duck.ai oral saam met jou. Kry dit ingebou in ons gratis app vir "
+"vinniger toegang, waar jy ook al is."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20099,6 +20059,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Neem Duck.ai oral saam met jou. Kry dit ingebou in ons gratis blaaier vir "
+"vinniger toegang, waar jy ook al blaai."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20372,8 +20334,7 @@ msgstr "Die aangehegte lêers oorskry die totale groottelimiet van %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
+msgstr "Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20398,8 +20359,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
+msgstr "Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20490,8 +20450,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
+msgstr "Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20563,8 +20522,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
+msgstr "Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20576,7 +20534,7 @@ msgstr "Vandeesmaand"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Hierdie reaksie"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20588,7 +20546,7 @@ msgstr "Vandeesweek"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Hierdie kletsgesprek bly in Duck.ai en bly privaat vir jou."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20665,8 +20623,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
+msgstr "Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20674,8 +20631,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
+msgstr "Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20731,6 +20687,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Dit is net ’n voorbeeldkletsgesprek. Maak sy kieslys (die drie kolletjies) "
+"oop, en kies dan “Speld vas” sodat dit bo-aan jou kletsgesprekke bly!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20739,6 +20697,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Dit is net ’n voorbeeldkletsgesprek. Gebruik die Fire Button in die "
+"sykieslys om dit uit te vee!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20786,8 +20746,7 @@ msgstr "Hierdie bladsy vereis Javascript om te funksioneer."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
+msgstr "Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20818,8 +20777,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
-"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
+"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
+"antwoorde sien."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20829,10 +20789,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
-"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien. Ons "
-"het egter ook 'n beginbladsy wat nooit KI-gesteunde antwoorde by %1$s wys "
-"nie."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
+"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
+"antwoorde sien. Ons het egter ook 'n beginbladsy wat nooit KI-gesteunde "
+"antwoorde by %1$s wys nie."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20903,8 +20863,7 @@ msgstr "Dit sal alle instellings wis. Gaan voort?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
+msgstr "Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21017,8 +20976,7 @@ msgstr "Om voort te gaan, moet jy instem tot Duck.ai se %1$s en %2$s"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
+msgstr "Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21050,8 +21008,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou DuckDuckGo-"
-"blaaier by tot die nuutste weergawe en probeer weer."
+"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou "
+"DuckDuckGo-blaaier by tot die nuutste weergawe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21083,6 +21041,8 @@ msgstr "Vandag"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Wissel heen en weer om privaat KI-klets te probeer of %1$sdeaktiveer dit in "
+"die %2$s-kieslys.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21499,7 +21459,7 @@ msgstr "Probeer hulle"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Probeer ’n ander model"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21510,7 +21470,7 @@ msgstr "Probeer 'n soektog!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Probeer ’n voorstel"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21560,8 +21520,7 @@ msgstr "Probeer om anonieme ligging te aktiveer vir meer akkurate resultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
+msgstr "Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21581,7 +21540,7 @@ msgstr "Probeer gratis"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Probeer dit gratis"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21601,7 +21560,7 @@ msgstr "Probeer gratis! 'n Veilige VPN, gevorderde en private KI, en meer."
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Probeer gratis vir 7 dae"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21634,7 +21593,7 @@ msgstr "Probeer ons tuisblad wat nooit hierdie boodskappe toon nie:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Probeer redenasievermoë"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21881,14 +21840,13 @@ msgstr "Skakel %1$s\"Presiese Ligging\"%2$s aan vir meer akkurate resultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
+msgstr "Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Skakel Duck.ai-wisselaar aan"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22093,14 +22051,13 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in https://"
-"duckduckgo.com"
+"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
+msgstr "Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22127,8 +22084,7 @@ msgstr "Onder %1$sSoek%2$s-afdeling, klik %3$sBestuur soekenjins …%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
+msgstr "Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22234,8 +22190,7 @@ msgstr "Ontsluit met 'n DuckDuckGo-intekening"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
+msgstr "Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22260,7 +22215,7 @@ msgstr "Ontsluit gevorderde KI met jou intekening!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Ontsluit gevorderde modelle"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22292,8 +22247,7 @@ msgstr "Onbevestigde inligting"
 #. Text explaining the limit on the number of recent chats that can be stored. Example: 'Up to 30 of your most recent chats can be saved at a time.'
 msgctxt "Information about the limit of recent chats that can be saved"
 msgid "Up to %s of your most recent chats can be saved at a time."
-msgstr ""
-"Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
+msgstr "Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22626,7 +22580,7 @@ msgstr "Gebruik in Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22787,8 +22741,7 @@ msgstr "Bekyk pryse vir jou verblyf"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
+msgstr "Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22838,8 +22791,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
+msgstr "Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22890,9 +22842,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak Duck.ai-"
-"instellings oop. Kies “Skakel aan” onder Sync & Backup en kies “Sinkroniseer "
-"met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
+"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak "
+"Duck.ai-instellings oop. Kies “Skakel aan” onder Sync & Backup en kies "
+"“Sinkroniseer met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23191,8 +23143,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
+msgstr "Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23410,8 +23361,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
+msgstr "Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23667,8 +23617,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
+msgstr "Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -23706,10 +23655,11 @@ msgid ""
 "experience."
 msgstr ""
 "Wat is die voordele daarvan om die DuckDuckGo-blaaier af te laai vir iemand "
-"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike DuckDuckGo-"
-"bronne. Verdeel die antwoord in duidelike afdelings met titels, met ’n fokus "
-"op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, eenvoudig en "
-"maklik om te verstaan vir mense met of sonder veel KI- of tegniese ervaring."
+"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike "
+"DuckDuckGo-bronne. Verdeel die antwoord in duidelike afdelings met titels, "
+"met ’n fokus op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, "
+"eenvoudig en maklik om te verstaan vir mense met of sonder veel KI- of "
+"tegniese ervaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23794,8 +23744,7 @@ msgstr "Wat is die beste geregte wat jy hier kan probeer?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
+msgstr "Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23825,7 +23774,7 @@ msgstr "Wat het jou oortuig om vandag na ons terug te keer?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Wat kan jy doen?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23946,8 +23895,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL parameter-"
-"boekmerkie?"
+"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL "
+"parameter-boekmerkie?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24056,8 +24005,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
+msgstr "Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24253,6 +24201,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Met Duck.ai word jou kletsgesprekke geanonimiseer en nooit gebruik om KI op "
+"te lei nie. Skakel dit enige tyd aan of af in die ‘%1$s’-kieslys."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24506,8 +24456,7 @@ msgstr "Ja, nuwe gebruiker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
+msgstr "Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24567,8 +24516,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
+msgstr "Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -24644,8 +24592,7 @@ msgstr "Jy kan aanhou gesels deur jou maandelikse limiet te gebruik."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
+msgstr "Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24688,7 +24635,7 @@ msgstr "Jy kan slegs %1$s beelde per gesprek aanheg."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Jy kan slegs %1$s oortjies op ’n slag aanheg."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24746,8 +24693,7 @@ msgstr "Jy kan oor begin op hierdie nuwe domein (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
+msgstr "Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -24822,8 +24768,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
+msgstr "Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24839,7 +24784,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Jy’s gereed!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24892,7 +24837,7 @@ msgstr "Jy het 1 webwerf geblokkeer"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Jy het die basiese beginsels van Duck.ai onder die knie"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24927,8 +24872,7 @@ msgstr "Jy het die maksimum stemkletsduur vir een sessie bereik."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
+msgstr "Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25094,8 +25038,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
+msgstr "Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25103,8 +25046,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
-"modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
+"KI-modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25112,8 +25055,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
-"modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
+"KI-modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25205,8 +25148,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
+msgstr "Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25235,8 +25177,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure Hash-"
-"algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
+"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure "
+"Hash-algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
 "instellingslêer verlaat jou blaaier. Ons stoor die instellingslêer deur die "
 "sleutel as naam te gebruik. DuckDuckGo ken nooit jou kenfrase nie."
 
@@ -25302,6 +25244,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Jou instellings word gestoor, maar as jy koekies uitvee, sal dit teruggestel "
+"word. Aktiveer die %1$sDuckDuckGo No AI%2$s-uitbreiding om dit permanent te "
+"maak."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25470,8 +25415,7 @@ msgstr "deur %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
+msgstr "deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25902,4 +25846,4 @@ msgstr "j"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,8 @@ msgstr "!Knal-soeksnelsleutels"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
+msgstr ""
+"\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -122,6 +123,12 @@ msgstr "%1$s dae gelede"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s bespeur"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +362,12 @@ msgid "%s used"
 msgstr "%1$s gebruik"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s kyk"
@@ -416,7 +429,8 @@ msgstr "%1$s woorde"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
+msgstr ""
+"%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -479,7 +493,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
+msgstr ""
+"%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -600,6 +615,12 @@ msgstr "1 poging geblokkeer deur DuckDuckGo in die afgelope 24 uur"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 dag gelede"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -820,7 +841,8 @@ msgstr "6-uur-gebruikslimiet is bereik."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
+msgstr ""
+"6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1295,7 +1317,8 @@ msgstr "Voeg DuckDuckGo-uitbreiding by"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
+msgstr ""
+"Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1510,6 +1533,14 @@ msgid "Advanced Models"
 msgstr "Gevorderde modelle"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Adverteer op Soek"
@@ -1721,7 +1752,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
+msgstr ""
+"Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1792,7 +1824,8 @@ msgstr "Laat anonieme lêerhersiening vir hierdie kletsgesprek toe?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
+msgstr ""
+"Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2125,7 +2158,8 @@ msgstr "Is jy nog daar?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
+msgstr ""
+"Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2294,6 +2328,12 @@ msgid "Ask privately"
 msgstr "Vra privaat"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2331,8 +2371,8 @@ msgstr ""
 "verskyn: Nooit (verwyder Assist UI heeltemal uit soekresultate), Op aanvraag "
 "(wys slegs KI-gesteunde antwoorde as jy op die Assist-knoppie klik), Soms "
 "(wys slegs KI-gesteunde antwoorde wanneer dit baie relevant is) of Dikwels "
-"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is "
-"KI-gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
+"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is KI-"
+"gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2438,7 +2478,8 @@ msgstr ""
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
+msgstr ""
+"Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2486,7 +2527,8 @@ msgstr "Outo-antwoord"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
+msgstr ""
+"Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2691,7 +2733,8 @@ msgstr "Strepieskode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr "Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
+msgstr ""
+"Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3612,7 +3655,8 @@ msgstr "Verander hoe resultaat-URL'e vertoon word"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
+msgstr ""
+"Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3764,10 +3808,10 @@ msgid ""
 msgstr ""
 "Met Chat (via ons Duck.ai-diens) kan jy anonieme gesprekke voer met "
 "derdeparty-KI-kletsmodelle, wat modelle van OpenAI, Anthropic en meer "
-"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en "
-"-skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
-"Chat kry wanneer hierdie instelling afgeskakel is, deur "
-"%1$shttps://duck.ai%2$s direk te besoek."
+"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en -"
+"skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
+"Chat kry wanneer hierdie instelling afgeskakel is, deur %1$shttps://duck."
+"ai%2$s direk te besoek."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3822,14 +3866,16 @@ msgstr "Gesels privaat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
+msgstr ""
+"Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
+msgstr ""
+"Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3842,6 +3888,12 @@ msgstr "Gesels privaat met %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Gesels privaat met KI"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3892,9 +3944,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Kletse word plaaslik op jou toestel gestoor in plaas van op "
-"DuckDuckGo-bedieners of afgeleë bedieners. As jy kletsgeskiedenis "
-"deaktiveer, sal vasgespelde kletse uitgevee word."
+"Kletse word plaaslik op jou toestel gestoor in plaas van op DuckDuckGo-"
+"bedieners of afgeleë bedieners. As jy kletsgeskiedenis deaktiveer, sal "
+"vasgespelde kletse uitgevee word."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4434,7 +4486,8 @@ msgstr "Klik %1$sJa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
+msgstr ""
+"Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4633,6 +4686,12 @@ msgid "Close"
 msgstr "Sluit"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4675,6 +4734,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Maak soektog toe"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5048,6 +5113,12 @@ msgid "Continue Blocking Ads"
 msgstr "Hou aan om advertensies te blokkeer"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5113,6 +5184,12 @@ msgid "Cookie data:"
 msgstr "Koekiedata:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5158,6 +5235,12 @@ msgstr "Kopieer en plak %1$sabout:preferences#search%2$s in die adresbalk"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopieer kode"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5227,7 +5310,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
+msgstr ""
+"Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5273,6 +5357,12 @@ msgid "Create Image"
 msgstr "Skep prent"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5314,6 +5404,14 @@ msgstr "Geskep deur"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Geskep deur %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5467,6 +5565,12 @@ msgstr "Pasmaak antwoorde"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Pasmaak antwoorde"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5755,10 +5859,22 @@ msgid "Delete Server Data?"
 msgstr "Wil jy bedienerdata skrap?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Verwyder transkripsie"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5793,6 +5909,12 @@ msgid "Delete image?"
 msgstr "Skrap prent?"
 
 # smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats to free up storage?"
@@ -5802,7 +5924,8 @@ msgstr "Wil jy oudste kletsgesprekke skrap om stoorplek te maak?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
+msgstr ""
+"Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5848,7 +5971,8 @@ msgstr "Beskryf veranderinge gebaseer op die beeld"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
+msgstr ""
+"Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6101,6 +6225,12 @@ msgid "Dismiss promotion"
 msgstr "Wys promosie van die hand"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6122,7 +6252,8 @@ msgstr "Vertoon taal"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
+msgstr ""
+"Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6309,6 +6440,12 @@ msgstr "Klaar afgelaai"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Laai DuckDuckGo af"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6526,6 +6663,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai deur DuckDuckGo. Privaat KI-geselsie. Gratis."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6631,8 +6774,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai laat jou privaat met gewilde KI-modelle gesels. As jy dit afskakel, "
-"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds "
-"%1$sduck.ai%2$s direk besoek."
+"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds %1$sduck."
+"ai%2$s direk besoek."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6681,6 +6824,12 @@ msgstr ""
 "akkuraatheid nagegaan nie."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6706,9 +6855,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme "
-"KI-klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, "
-"oopbron KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
+"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme KI-"
+"klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, oopbron "
+"KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6877,7 +7026,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
+msgstr ""
+"DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6996,8 +7146,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, "
-"e-posadresse, telefoonnommers en identifiserende metadata, te verwyder."
+"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, e-"
+"posadresse, telefoonnommers en identifiserende metadata, te verwyder."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7097,7 +7247,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
+msgstr ""
+"DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7323,6 +7474,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Aktiveer mees besoekte webwerwe"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7370,7 +7527,8 @@ msgstr "Aktiveer diktasie in Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
+msgstr ""
+"Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7620,6 +7778,12 @@ msgid "Entertainment guide"
 msgstr "Vermaakgids"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Ekwatoriaal-Guinee"
 
@@ -7687,7 +7851,8 @@ msgstr "Vou kaart uit"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
+msgstr ""
+"Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7779,6 +7944,18 @@ msgstr "Eksplisiete inhoud"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Eksplisiete lirieke"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7882,6 +8059,12 @@ msgid "FREE"
 msgstr "Gratis"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7938,8 +8121,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
-"-verbeterings."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
+"verbeterings."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7948,8 +8131,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
-"-verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
+"verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8092,7 +8275,8 @@ msgstr "Vind <b>%1$s</b> in jou aflaaivouer"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
+msgstr ""
+"Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8129,7 +8313,8 @@ msgstr "Vind resultate nader aan jou."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
+msgstr ""
+"Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8296,6 +8481,12 @@ msgid "Free Up Storage"
 msgstr "Maak stoorplek skoon"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8305,7 +8496,8 @@ msgstr "Gratis en privaat geselsies, geanonimiseer deur ons"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
+msgstr ""
+"Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8418,8 +8610,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is "
-"...</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
+"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is ..."
+"</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
 "opdatering</strong>."
 
 # smartling.placeholder_format=C
@@ -8784,8 +8976,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n "
-"DuckDuckGo-intekening, wat ook ons VPN en ander premium "
+"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n DuckDuckGo-"
+"intekening, wat ook ons VPN en ander premium "
 "privaatheidsbeskermingsmaatreëls insluit."
 
 # smartling.placeholder_format=C
@@ -8812,6 +9004,12 @@ msgid "Get computer help"
 msgstr "Kry rekenaarhulp"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8820,7 +9018,8 @@ msgstr "Kry ons blaaier om nooit jou instellings te verloor nie."
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
+msgstr ""
+"Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8847,6 +9046,18 @@ msgid "Get the Latest Version"
 msgstr "Kry die nuutste weergawe"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8867,6 +9078,12 @@ msgstr "Kry hierdie liedjie by:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Bring jou vriende saam en help ons om te groei!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8897,9 +9114,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel › Kopieer tekskode%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel › Kopieer tekskode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8908,9 +9125,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8920,9 +9137,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel%4$s en skandeer hierdie kode:"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel%4$s en skandeer hierdie kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8932,9 +9149,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9468,7 +9685,8 @@ msgstr "Help jou vriende en familie om by die Duck-kant aan te sluit!"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
+msgstr ""
+"Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9553,6 +9771,12 @@ msgid "Hide Tips"
 msgstr "Verberg wenke"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9599,7 +9823,8 @@ msgstr "Versteek jou e-posadres"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
+msgstr ""
+"Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9847,7 +10072,8 @@ msgstr "Hoe dikwels wil jy KI-gesteunde antwoorde sien?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
+msgstr ""
+"Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10090,7 +10316,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
+msgstr ""
+"Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10239,8 +10466,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en "
-"-kleur"
+"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en -"
+"kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10670,7 +10897,8 @@ msgstr "Dit is vinnig, gratis en gee jou selfs meer aanlyn beskerming."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
+msgstr ""
+"Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11169,6 +11397,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Laat jou anoniem soek met DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberië"
 
@@ -11239,6 +11474,12 @@ msgid "Lineouts Won"
 msgstr "Lynskrums gewen"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Skakellettertipe:"
@@ -11252,7 +11493,8 @@ msgstr "Skakels:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
+msgstr ""
+"Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11889,7 +12131,8 @@ msgstr "Mikronesië"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
+msgstr ""
+"Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12333,6 +12576,12 @@ msgid "More than 20 minutes"
 msgstr "Langer as 20 minute"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12653,11 +12902,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n "
-"DuckDuckGo-bediener gestoor nadat dit gestuur is om te help om ’n klets te "
-"herstel as jy jou internetverbinding verloor. As jy kletsgeskiedenis "
-"deaktiveer, sal vasgespelde kletse uitgevee word en die tydelike berging van "
-"nuwe aanporrings en antwoorde deaktiveer."
+"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n DuckDuckGo-"
+"bediener gestoor nadat dit gestuur is om te help om ’n klets te herstel as "
+"jy jou internetverbinding verloor. As jy kletsgeskiedenis deaktiveer, sal "
+"vasgespelde kletse uitgevee word en die tydelike berging van nuwe "
+"aanporrings en antwoorde deaktiveer."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12821,6 +13070,12 @@ msgid "No Thanks"
 msgstr "Nee, dankie"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "Geen nasporing. Ooit."
@@ -12966,7 +13221,8 @@ msgstr "Geen resultate gevind nie."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
+msgstr ""
+"Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13483,6 +13739,12 @@ msgid "On but no numbers"
 msgstr "Aan maar geen nommers nie"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13695,6 +13957,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Maak voorstelle vir die skep en redigering van beelde oop"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13757,7 +14025,8 @@ msgstr "Maak die paneel oop oor hoe Duck.ai werk."
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
+msgstr ""
+"Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14364,8 +14633,8 @@ msgid ""
 msgstr ""
 "As jy jou soektog as 'n vraag en in 'n volsin fraseer, sal DuckAssist meer "
 "geneig wees om outomaties te verskyn en dikwels beter antwoorde lewer. Om "
-"dit af te skakel en die Assist-knoppie te verberg, kan jy na "
-"%1$sDuckAssist-instellings%2$s gaan."
+"dit af te skakel en die Assist-knoppie te verberg, kan jy na %1$sDuckAssist-"
+"instellings%2$s gaan."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14442,10 +14711,22 @@ msgid "Pin"
 msgstr "Speld vas"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Speld kletse hier vas vanaf die %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14463,6 +14744,12 @@ msgstr "Pienk"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Vasgespeld"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14788,6 +15075,12 @@ msgid "Poor formatting"
 msgstr "Swak formatering"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14994,6 +15287,12 @@ msgstr "Vorige prent"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Vorige-oortjies"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15288,7 +15587,8 @@ msgstr "Vra my"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
+msgstr ""
+"Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15534,6 +15834,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Redenerende KI met medium ingeboude moderering"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15567,6 +15879,12 @@ msgstr "Onlangse oortjies"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Onlangse kletsberging kan in %1$s aangepas word."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15722,6 +16040,12 @@ msgstr "Probeer weer soek sonder hierdie webwerf"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Verminder gebruik"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16100,6 +16424,12 @@ msgid "Reset All Settings"
 msgstr "Stel alle instellings terug"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16110,6 +16440,12 @@ msgstr "Stel terug oor %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Resolusie"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16601,8 +16937,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met "
-"end-tot-end-enkripsie."
+"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met end-tot-"
+"end-enkripsie."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16779,7 +17115,8 @@ msgstr "Rol af en soek %1$sjou blaaier%2$s op die lys."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
+msgstr ""
+"Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16808,6 +17145,12 @@ msgstr "Soek"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Wil jy soek %1$s vir resultate nader aan jou?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17009,8 +17352,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte "
-"POST-versoeke gebruik)"
+"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte POST-"
+"versoeke gebruik)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17159,8 +17502,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Stoor jou gesprekke veilig op ons bediener met behulp van "
-"punt-tot-punt-enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
+"Stoor jou gesprekke veilig op ons bediener met behulp van punt-tot-punt-"
+"enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17177,6 +17520,12 @@ msgid ""
 msgstr ""
 "Veilig gestoor op DuckDuckGo se bediener met punt-tot-punt-enkripsie. "
 "Niemand behalwe jy kan jou data sien nie, nie eens ons nie."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17287,7 +17636,8 @@ msgstr "Kyk na 'n paar van ons nuutste opdaterings"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
+msgstr ""
+"Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17314,7 +17664,8 @@ msgstr "Kies %1$s%2$s%3$s, dan %4$sSoekenjin%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
+msgstr ""
+"Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17469,7 +17820,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
+msgstr ""
+"Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17685,6 +18037,12 @@ msgid "Set as Homepage"
 msgstr "Stel in as tuisblad"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17704,7 +18062,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
+msgstr ""
+"Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17750,6 +18109,18 @@ msgid "Seychelles"
 msgstr "Seychelle"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17785,8 +18156,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. "
-"Duck.ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
+"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. Duck."
+"ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17845,6 +18223,12 @@ msgstr "Deel bladsy-URL"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Deel positiewe terugvoer"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17982,6 +18366,12 @@ msgid "Show Detail"
 msgstr "Wys detail"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "Wys DuckAssist <sup>BETA</sup>"
@@ -17990,7 +18380,8 @@ msgstr "Wys DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
+msgstr ""
+"Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18129,6 +18520,12 @@ msgid "Show more"
 msgstr "Wys meer"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18162,6 +18559,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Wys sybalk"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18288,7 +18691,8 @@ msgstr "Wys voorstelle onder die soekkassie soos jy tik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
+msgstr ""
+"Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18303,7 +18707,8 @@ msgstr "Wys verwelkomingsboodskap bo-aan die bladsy met soekresultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
+msgstr ""
+"Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18375,7 +18780,8 @@ msgstr "Webwerfname"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
+msgstr ""
+"Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18519,7 +18925,8 @@ msgstr "Iets het skeefgeloop"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
+msgstr ""
+"Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18534,6 +18941,12 @@ msgstr ""
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Iets het verkeerd geloop, probeer asseblief later weer."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18551,7 +18964,8 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
+msgstr ""
+"Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18608,8 +19022,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om "
-"Duck.ai te vra."
+"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om Duck."
+"ai te vra."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18625,7 +19039,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
+msgstr ""
+"Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18826,6 +19241,12 @@ msgstr "Begin om maandelikse limiet te gebruik"
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "Begin om die weeklikse limiet te gebruik"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19408,6 +19829,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Skakel oor na die soekenjin wat jou nooit naspoor nie. Nooit nie."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19474,7 +19903,8 @@ msgstr "Sync & Backup is geaktiveer!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
+msgstr ""
+"Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19523,8 +19953,8 @@ msgid ""
 msgstr ""
 "Sinkronisasieherstelkode\n"
 "\n"
-"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en "
-"Duck.ai-kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
+"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en Duck.ai-"
+"kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
 "gesinkroniseerde data terug te kry as jy toegang tot ’n toestel verloor.\n"
 "\n"
 "Hou hierdie inligting veilig en seker.\n"
@@ -19560,6 +19990,12 @@ msgstr "Sinkroniseer met ’n ander toestel"
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sinchronisasie en rugsteun is tydelik onbeskikbaar"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19647,6 +20083,22 @@ msgstr "Tadjikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Neem jou privaatheid terug!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19920,7 +20372,8 @@ msgstr "Die aangehegte lêers oorskry die totale groottelimiet van %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
+msgstr ""
+"Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -19945,7 +20398,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
+msgstr ""
+"Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20036,7 +20490,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
+msgstr ""
+"Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20108,7 +20563,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
+msgstr ""
+"Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20117,10 +20573,22 @@ msgid "This Month"
 msgstr "Vandeesmaand"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Vandeesweek"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20197,7 +20665,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
+msgstr ""
+"Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20205,7 +20674,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
+msgstr ""
+"Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20255,6 +20725,22 @@ msgid "This information isn’t useful"
 msgstr "Hierdie inligting is nie nuttig nie"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20300,7 +20786,8 @@ msgstr "Hierdie bladsy vereis Javascript om te funksioneer."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
+msgstr ""
+"Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20331,9 +20818,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
-"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
-"antwoorde sien."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
+"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20343,10 +20829,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
-"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
-"antwoorde sien. Ons het egter ook 'n beginbladsy wat nooit KI-gesteunde "
-"antwoorde by %1$s wys nie."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
+"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien. Ons "
+"het egter ook 'n beginbladsy wat nooit KI-gesteunde antwoorde by %1$s wys "
+"nie."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20417,7 +20903,8 @@ msgstr "Dit sal alle instellings wis. Gaan voort?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
+msgstr ""
+"Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20530,7 +21017,8 @@ msgstr "Om voort te gaan, moet jy instem tot Duck.ai se %1$s en %2$s"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
+msgstr ""
+"Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20562,8 +21050,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou "
-"DuckDuckGo-blaaier by tot die nuutste weergawe en probeer weer."
+"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou DuckDuckGo-"
+"blaaier by tot die nuutste weergawe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20589,6 +21077,12 @@ msgstr "Vandag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Vandag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21002,9 +21496,21 @@ msgid "Try Them Out"
 msgstr "Probeer hulle"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Probeer 'n soektog!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21054,7 +21560,8 @@ msgstr "Probeer om anonieme ligging te aktiveer vir meer akkurate resultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
+msgstr ""
+"Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21071,6 +21578,12 @@ msgid "Try for free"
 msgstr "Probeer gratis"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21083,6 +21596,12 @@ msgstr "Probeer dit gratis"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "Probeer gratis! 'n Veilige VPN, gevorderde en private KI, en meer."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21110,6 +21629,12 @@ msgstr "Probeer ons blaaier"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Probeer ons tuisblad wat nooit hierdie boodskappe toon nie:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21356,7 +21881,14 @@ msgstr "Skakel %1$s\"Presiese Ligging\"%2$s aan vir meer akkurate resultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
+msgstr ""
+"Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21561,13 +22093,14 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in "
-"https://duckduckgo.com"
+"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
+msgstr ""
+"Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21594,7 +22127,8 @@ msgstr "Onder %1$sSoek%2$s-afdeling, klik %3$sBestuur soekenjins …%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
+msgstr ""
+"Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21700,7 +22234,8 @@ msgstr "Ontsluit met 'n DuckDuckGo-intekening"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
+msgstr ""
+"Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21720,6 +22255,12 @@ msgstr "Ontsluit gevorderde KI-modelle met 'n DuckDuckGo-intekening"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Ontsluit gevorderde KI met jou intekening!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -21751,7 +22292,8 @@ msgstr "Onbevestigde inligting"
 #. Text explaining the limit on the number of recent chats that can be stored. Example: 'Up to 30 of your most recent chats can be saved at a time.'
 msgctxt "Information about the limit of recent chats that can be saved"
 msgid "Up to %s of your most recent chats can be saved at a time."
-msgstr "Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
+msgstr ""
+"Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22081,6 +22623,12 @@ msgid "Use in Safari"
 msgstr "Gebruik in Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22239,7 +22787,8 @@ msgstr "Bekyk pryse vir jou verblyf"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
+msgstr ""
+"Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22289,7 +22838,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
+msgstr ""
+"Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22340,9 +22890,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak "
-"Duck.ai-instellings oop. Kies “Skakel aan” onder Sync & Backup en kies "
-"“Sinkroniseer met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
+"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak Duck.ai-"
+"instellings oop. Kies “Skakel aan” onder Sync & Backup en kies “Sinkroniseer "
+"met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22641,7 +23191,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
+msgstr ""
+"Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22859,7 +23410,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
+msgstr ""
+"Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23115,7 +23667,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
+msgstr ""
+"Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -23153,11 +23706,10 @@ msgid ""
 "experience."
 msgstr ""
 "Wat is die voordele daarvan om die DuckDuckGo-blaaier af te laai vir iemand "
-"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike "
-"DuckDuckGo-bronne. Verdeel die antwoord in duidelike afdelings met titels, "
-"met ’n fokus op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, "
-"eenvoudig en maklik om te verstaan vir mense met of sonder veel KI- of "
-"tegniese ervaring."
+"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike DuckDuckGo-"
+"bronne. Verdeel die antwoord in duidelike afdelings met titels, met ’n fokus "
+"op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, eenvoudig en "
+"maklik om te verstaan vir mense met of sonder veel KI- of tegniese ervaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23242,7 +23794,8 @@ msgstr "Wat is die beste geregte wat jy hier kan probeer?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
+msgstr ""
+"Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23267,6 +23820,12 @@ msgstr "Wat het jou die meeste gepla?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Wat het jou oortuig om vandag na ons terug te keer?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23387,8 +23946,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL "
-"parameter-boekmerkie?"
+"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL parameter-"
+"boekmerkie?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23497,7 +24056,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
+msgstr ""
+"Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23685,6 +24245,14 @@ msgstr "Oorwinnings"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Sneeureën"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -23938,7 +24506,8 @@ msgstr "Ja, nuwe gebruiker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
+msgstr ""
+"Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23998,7 +24567,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
+msgstr ""
+"Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -24074,7 +24644,8 @@ msgstr "Jy kan aanhou gesels deur jou maandelikse limiet te gebruik."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
+msgstr ""
+"Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24111,6 +24682,13 @@ msgstr "Jy kan slegs %1$s beelde per gesprek aanheg"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Jy kan slegs %1$s beelde per gesprek aanheg."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24168,7 +24746,8 @@ msgstr "Jy kan oor begin op hierdie nuwe domein (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
+msgstr ""
+"Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -24243,7 +24822,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
+msgstr ""
+"Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24254,6 +24834,12 @@ msgid ""
 msgstr ""
 "Jy sal outomaties app-opdaterings vir DuckDuckGo ontvang sodra jy die "
 "nuutste weergawe het."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24303,6 +24889,12 @@ msgid "You've blocked 1 site"
 msgstr "Jy het 1 webwerf geblokkeer"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24335,7 +24927,8 @@ msgstr "Jy het die maksimum stemkletsduur vir een sessie bereik."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
+msgstr ""
+"Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24501,7 +25094,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
+msgstr ""
+"Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24509,8 +25103,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
-"KI-modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
+"modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24518,8 +25112,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
-"KI-modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
+"modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24611,7 +25205,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
+msgstr ""
+"Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24640,8 +25235,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure "
-"Hash-algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
+"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure Hash-"
+"algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
 "instellingslêer verlaat jou blaaier. Ons stoor die instellingslêer deur die "
 "sleutel as naam te gebruik. DuckDuckGo ken nooit jou kenfrase nie."
 
@@ -24699,6 +25294,14 @@ msgstr "Jou rol"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Jou soektogte kan nie na jou teruggekoppel word nie"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -24867,7 +25470,8 @@ msgstr "deur %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
+msgstr ""
+"deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25293,3 +25897,9 @@ msgstr "jare"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "j"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -483,6 +493,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1223,6 +1238,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1844,6 +1866,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3078,6 +3105,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3674,6 +3706,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3709,6 +3746,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4014,6 +4056,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4068,6 +4115,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4105,6 +4157,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4201,6 +4258,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4235,6 +4297,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4360,6 +4429,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4596,9 +4670,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4626,6 +4710,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4879,6 +4968,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5045,6 +5139,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5220,6 +5319,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5327,6 +5431,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5821,6 +5930,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6060,6 +6174,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6193,6 +6312,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6274,6 +6403,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6603,6 +6737,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7024,6 +7163,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7053,6 +7197,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7069,6 +7223,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7620,6 +7779,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8921,6 +9085,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8976,6 +9146,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9872,6 +10047,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10266,6 +10446,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10814,6 +10999,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "تشغيل لكن بدون أرقام"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10982,6 +11172,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11582,9 +11777,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11599,6 +11804,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11855,6 +12065,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12024,6 +12239,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12466,6 +12686,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12493,6 +12723,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12615,6 +12850,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12917,6 +13157,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "إعادة ضبط الإعدادات"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12925,6 +13170,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13482,6 +13732,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13766,6 +14021,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14163,6 +14423,11 @@ msgstr "اضبط كمحرك بحث إفتراضي"
 msgid "Set as Homepage"
 msgstr "اجـعلـنا صفـحتـك الرئـيسيـة"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14215,6 +14480,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14244,6 +14519,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14292,6 +14573,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14403,6 +14689,11 @@ msgstr "إظهر بيانات الإشارات المرجعية والإعداد
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14527,6 +14818,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14555,6 +14851,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14853,6 +15154,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15085,6 +15391,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15565,6 +15876,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15677,6 +15995,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15746,6 +16069,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16115,9 +16452,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16218,6 +16565,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16474,6 +16835,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16811,8 +17177,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16867,6 +17243,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16877,6 +17258,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16899,6 +17285,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17099,6 +17490,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17383,6 +17779,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17678,6 +18079,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18593,6 +18999,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18932,6 +19343,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19276,6 +19694,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19384,6 +19808,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19418,6 +19847,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19715,6 +20149,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20187,6 +20628,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/ar_EG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_EG/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "تم اكتشاف %s"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -483,6 +493,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1225,6 +1240,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1848,6 +1870,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3082,6 +3109,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3679,6 +3711,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3714,6 +3751,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4021,6 +4063,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4075,6 +4122,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4112,6 +4164,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4208,6 +4265,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4242,6 +4304,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4367,6 +4436,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4603,9 +4677,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4633,6 +4717,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4886,6 +4975,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5052,6 +5146,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5227,6 +5326,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5334,6 +5438,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5840,6 +5949,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6079,6 +6193,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6212,6 +6331,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6293,6 +6422,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6624,6 +6758,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7045,6 +7184,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7074,6 +7218,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7090,6 +7244,11 @@ msgstr "أحصل على هذه الأغنية من:"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7641,6 +7800,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8943,6 +9107,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8998,6 +9168,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9894,6 +10069,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10288,6 +10468,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10836,6 +11021,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "مفعل لكن بدون أرقام"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11006,6 +11196,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11602,9 +11797,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11619,6 +11824,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11875,6 +12085,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12044,6 +12259,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12486,6 +12706,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12513,6 +12743,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12635,6 +12870,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12937,6 +13177,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "اعادة ضبط كل الاعدات"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12945,6 +13190,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13502,6 +13752,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13786,6 +14041,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14185,6 +14445,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "تعيين كصفحة رئيسية"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14237,6 +14502,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14266,6 +14541,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14314,6 +14595,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14425,6 +14711,11 @@ msgstr "اظهر بيانات الاشارات المرجعة و الاعداد�
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14549,6 +14840,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14577,6 +14873,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14875,6 +15176,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15107,6 +15413,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15585,6 +15896,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15697,6 +16015,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15766,6 +16089,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16135,9 +16472,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16238,6 +16585,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16494,6 +16855,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16831,9 +17197,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "جرّب البحث!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16887,6 +17263,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16897,6 +17278,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16919,6 +17305,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17119,6 +17510,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17403,6 +17799,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17699,6 +18100,11 @@ msgstr ""
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "استخدمه في سفاري"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18611,6 +19017,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18950,6 +19361,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19296,6 +19714,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19404,6 +19828,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19438,6 +19867,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19737,6 +20171,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20209,6 +20650,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/ar_JO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_JO/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -483,6 +493,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1225,6 +1240,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1846,6 +1868,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3080,6 +3107,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3676,6 +3708,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3711,6 +3748,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4018,6 +4060,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4072,6 +4119,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4109,6 +4161,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4205,6 +4262,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4239,6 +4301,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4364,6 +4433,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4600,9 +4674,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4630,6 +4714,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4883,6 +4972,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5049,6 +5143,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5224,6 +5323,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5331,6 +5435,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5837,6 +5946,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6076,6 +6190,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6209,6 +6328,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6290,6 +6419,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6619,6 +6753,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7040,6 +7179,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7069,6 +7213,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7085,6 +7239,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7636,6 +7795,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8933,6 +9097,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8988,6 +9158,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9884,6 +10059,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10278,6 +10458,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10826,6 +11011,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "إعداد"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10994,6 +11184,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11590,9 +11785,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11607,6 +11812,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11863,6 +12073,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12032,6 +12247,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12474,6 +12694,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12501,6 +12731,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12623,6 +12858,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12925,6 +13165,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12933,6 +13178,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13490,6 +13740,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13772,6 +14027,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14169,6 +14429,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "اجعل الموقع صفحتك الرئيسية"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14221,6 +14486,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14250,6 +14525,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14298,6 +14579,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14409,6 +14695,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14533,6 +14824,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14561,6 +14857,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14859,6 +15160,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15091,6 +15397,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15569,6 +15880,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15681,6 +15999,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15750,6 +16073,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16119,9 +16456,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16222,6 +16569,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16478,6 +16839,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16815,8 +17181,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16871,6 +17247,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16881,6 +17262,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16903,6 +17289,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17103,6 +17494,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17387,6 +17783,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17682,6 +18083,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18595,6 +19001,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18934,6 +19345,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19279,6 +19697,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19387,6 +19811,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19421,6 +19850,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19718,6 +20152,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20190,6 +20631,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/ar_SA/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_SA/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -483,6 +493,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1227,6 +1242,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1848,6 +1870,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3082,6 +3109,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3681,6 +3713,11 @@ msgstr "قصاصة فنية"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3716,6 +3753,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4023,6 +4065,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4077,6 +4124,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4114,6 +4166,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4210,6 +4267,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4244,6 +4306,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4369,6 +4438,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4605,9 +4679,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4635,6 +4719,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4888,6 +4977,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5054,6 +5148,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5229,6 +5328,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5336,6 +5440,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5828,6 +5937,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6070,6 +6184,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6203,6 +6322,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6284,6 +6413,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6614,6 +6748,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7035,6 +7174,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7064,6 +7208,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7081,6 +7235,11 @@ msgstr "قم بتشغيل هذه الأغنية :"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "أخبر أصدقائك أن يختارونا و ساعدنا في التقدم! "
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7631,6 +7790,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8932,6 +9096,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8987,6 +9157,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9883,6 +10058,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "اكثر من 20 دقيقة"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10279,6 +10459,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10829,6 +11014,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "مفعّل، بدون أرقام"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10997,6 +11187,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11596,9 +11791,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11613,6 +11818,11 @@ msgstr "وردي"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11869,6 +12079,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12038,6 +12253,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12480,6 +12700,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12507,6 +12737,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12629,6 +12864,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12931,6 +13171,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "استعادة كافة الإعدادات"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12939,6 +13184,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13498,6 +13748,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13780,6 +14035,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14181,6 +14441,11 @@ msgstr "ضبط كمحرك بحث إفتراضي"
 msgid "Set as Homepage"
 msgstr "اجعلنا صفحتك الرئيسية"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14233,6 +14498,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14262,6 +14537,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14310,6 +14591,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14421,6 +14707,11 @@ msgstr "عرض بيانات الإعدادات والمفضلة"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14545,6 +14836,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14573,6 +14869,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14871,6 +15172,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15103,6 +15409,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15583,6 +15894,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15695,6 +16013,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15765,6 +16088,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "تحكم في خصوصيتك"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16133,9 +16470,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16236,6 +16583,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16492,6 +16853,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16829,9 +17195,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "جرب البحث !"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16885,6 +17261,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16895,6 +17276,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16918,6 +17304,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "جرّب صفحتنا الرئيسية التي لا تعرض أبداً هذه الرسائل: "
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17117,6 +17508,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17405,6 +17801,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17701,6 +18102,11 @@ msgstr "استعمله في متصفح فايرفوكس"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "للإستخدم في متصفح سفاري"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18615,6 +19021,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18956,6 +19367,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19302,6 +19720,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19410,6 +19834,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19444,6 +19873,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19743,6 +20177,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20217,6 +20658,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/ast_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ast_ES/LC_MESSAGES/duckduckgo.po
@@ -104,6 +104,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -285,6 +290,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -477,6 +487,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1219,6 +1234,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1840,6 +1862,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4013,6 +4055,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4067,6 +4114,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4104,6 +4156,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4200,6 +4257,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4234,6 +4296,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4359,6 +4428,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4595,9 +4669,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4625,6 +4709,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4878,6 +4967,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5044,6 +5138,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5219,6 +5318,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5326,6 +5430,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5814,6 +5923,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6053,6 +6167,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6186,6 +6305,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6267,6 +6396,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6596,6 +6730,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7017,6 +7156,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7046,6 +7190,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7062,6 +7216,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7613,6 +7772,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8910,6 +9074,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8965,6 +9135,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9861,6 +10036,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Más de 20 minutos"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10255,6 +10435,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10803,6 +10988,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Sí pero ensin númberos"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10971,6 +11161,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11571,9 +11766,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11588,6 +11793,11 @@ msgstr "Rosa"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11844,6 +12054,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12013,6 +12228,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12455,6 +12675,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12482,6 +12712,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12604,6 +12839,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12906,6 +13146,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12914,6 +13159,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13471,6 +13721,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13751,6 +14006,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14148,6 +14408,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14200,6 +14465,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14230,6 +14505,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14278,6 +14559,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14389,6 +14675,11 @@ msgstr "Amosar los datos del bookmarklet y los datos"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14513,6 +14804,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14541,6 +14837,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14839,6 +15140,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15071,6 +15377,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15549,6 +15860,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Cambia al motor de gueta que nun te rastrexa. Daveres."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15661,6 +15979,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15731,6 +16054,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "¡Recupera la to privacidá!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16099,9 +16436,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16202,6 +16549,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16458,6 +16819,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16795,8 +17161,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16851,6 +17227,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16861,6 +17242,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16884,6 +17270,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Prueba la páxina d'aniciu qu'enxamás amuesa estos mensaxes:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17083,6 +17474,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17367,6 +17763,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17662,6 +18063,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18575,6 +18981,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18914,6 +19325,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19260,6 +19678,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19368,6 +19792,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19402,6 +19831,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19701,6 +20135,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20173,6 +20614,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/az_AZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/az_AZ/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -483,6 +493,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 gün əvvəl"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1846,6 +1868,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3080,6 +3107,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3679,6 +3711,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3714,6 +3751,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4021,6 +4063,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4075,6 +4122,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4112,6 +4164,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4208,6 +4265,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4242,6 +4304,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4367,6 +4436,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4603,9 +4677,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4633,6 +4717,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4886,6 +4975,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5052,6 +5146,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5227,6 +5326,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5334,6 +5438,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5822,6 +5931,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6061,6 +6175,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6194,6 +6313,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6275,6 +6404,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6606,6 +6740,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7027,6 +7166,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7056,6 +7200,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7073,6 +7227,11 @@ msgstr "Bu mahnını əldə edin:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Bizi keçməyə və böyüməyə kömək etmək üçün yoldaşlarınızı alın!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7623,6 +7782,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8924,6 +9088,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8979,6 +9149,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9875,6 +10050,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10269,6 +10449,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10817,6 +11002,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Açıq amma nömrəsiz"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10987,6 +11177,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11587,9 +11782,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11604,6 +11809,11 @@ msgstr "Çəhrayı"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11860,6 +12070,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12029,6 +12244,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12471,6 +12691,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12498,6 +12728,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12620,6 +12855,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12922,6 +13162,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Bütün Parametrləri təkrar yenilə"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12930,6 +13175,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13487,6 +13737,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13769,6 +14024,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14166,6 +14426,11 @@ msgstr "Standart Axtarış Motoru kimi qurun"
 msgid "Set as Homepage"
 msgstr "Ana Səhifə olaraq qur"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14218,6 +14483,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14248,6 +14523,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14296,6 +14577,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14407,6 +14693,11 @@ msgstr "Əlfəcinləri və Nizamlama Məlumatlarını göstər"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14531,6 +14822,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14559,6 +14855,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14857,6 +15158,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15089,6 +15395,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15567,6 +15878,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15679,6 +15997,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15749,6 +16072,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Gizliliğinizi geri alın!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16117,9 +16454,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16220,6 +16567,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16476,6 +16837,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16813,9 +17179,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Axtarmağı yoxlayın!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16869,6 +17245,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16879,6 +17260,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16902,6 +17288,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Bu mesajları heç vaxt göstərməyən ana səhifəmizi sınayın:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17101,6 +17492,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17387,6 +17783,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17683,6 +18084,11 @@ msgstr "Firefox-da istifadə edin"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Safari istifadə edin"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18597,6 +19003,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18937,6 +19348,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19283,6 +19701,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19393,6 +19817,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19427,6 +19856,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19728,6 +20162,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20200,6 +20641,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -122,6 +123,12 @@ msgstr "%1$s сут таму"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s — выяўленая мова"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -354,6 +361,12 @@ msgid "%s used"
 msgstr "Выкарыстана %1$s"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s прагляд"
@@ -466,8 +479,8 @@ msgstr "%1$sДаведацца больш%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага "
-"месцазнаходжання.%2$s"
+"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага месцазнаходжання."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -490,7 +503,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
+msgstr ""
+"%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -605,6 +619,12 @@ msgstr "1 спроба заблакіравана DuckDuckGo за апошнія
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 дзень таму"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1014,10 +1034,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "У цяперашні час ў адказах з дапамогай штучнага інтэлекту не падтрымліваюцца "
-"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс "
-"%1$sDuck.ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш "
-"прыватны чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад "
-"OpenAI, Anthropic і іншых."
+"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс %1$sDuck."
+"ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш прыватны "
+"чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад OpenAI, "
+"Anthropic і іншых."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1516,6 +1536,14 @@ msgid "Advanced Models"
 msgstr "Пашыраныя мадэлі"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Рэклама ў Пошуку"
@@ -1726,7 +1754,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
+msgstr ""
+"Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1849,7 +1878,8 @@ msgstr "Ужо сінхранізавана."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
+msgstr ""
+"Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2151,7 +2181,8 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr "Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
+msgstr ""
+"Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2297,6 +2328,12 @@ msgstr "Спытайце прыватна"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask privately"
 msgstr "Спытайце прыватна"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2877,7 +2914,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
+msgstr ""
+"Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3639,7 +3677,8 @@ msgstr "Змяняе колер фону на ўсім сайце"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
+msgstr ""
+"Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3772,8 +3811,8 @@ msgstr ""
 "мадэлямі чата на базе штучнага інтэлекту, якімі падтрымліваюцца мадэлі "
 "OpenAI, Anthropic і іншыя. Адключэнне гэтай налады схавае кнопкі і спасылкі "
 "чата ў DuckDuckGo Search. Тым не менш, можна атрымаць доступ да чата, калі "
-"гэты параметр выключаны. Для гэтага трэба перайсці на сайт "
-"%1$shttps://duck.ai%2$s ."
+"гэты параметр выключаны. Для гэтага трэба перайсці на сайт %1$shttps://duck."
+"ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3838,8 +3877,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі "
-"Duck.ai ў нашым бясплатным браўзеры."
+"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі Duck."
+"ai ў нашым бясплатным браўзеры."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3852,6 +3891,12 @@ msgstr "Размаўляйце прыватна з %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Размаўляйце прыватна з AI"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4013,7 +4058,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
+msgstr ""
+"Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4078,7 +4124,8 @@ msgstr "Выбар мадэляў штучнага інтэлекту, у тым
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
+msgstr ""
+"Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4488,7 +4535,8 @@ msgstr "Націсніце на %1$sПастаўшчыкі пошуку%2$s па
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
+msgstr ""
+"Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4645,6 +4693,12 @@ msgid "Close"
 msgstr "Закрыць"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4687,6 +4741,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Закрыць пошук"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5060,6 +5120,12 @@ msgid "Continue Blocking Ads"
 msgstr "Працягваць блакіраваць рэкламу"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5125,6 +5191,12 @@ msgid "Cookie data:"
 msgstr "Даныя файлаў cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5170,6 +5242,12 @@ msgstr "Скапіруйце і ўстаўце %1$sabout:preferences#search%2$s 
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Скапіраваць код"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5287,6 +5365,12 @@ msgid "Create Image"
 msgstr "Стварыце відарыс"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5328,6 +5412,14 @@ msgstr "Аўтар:"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Створана %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5481,6 +5573,12 @@ msgstr "Наладзіць адказы"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Наладзіць адказы"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5769,10 +5867,22 @@ msgid "Delete Server Data?"
 msgstr "Выдаліць даныя сервера?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Выдаліць тэкст размовы"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5805,6 +5915,12 @@ msgstr "Выдаліць відарыс"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Выдаліць відарыс?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6116,6 +6232,12 @@ msgid "Dismiss promotion"
 msgstr "Адхіліць рэкламу"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6325,6 +6447,12 @@ msgstr "Спампоўванне завершана"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Спампаваць DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6542,6 +6670,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai ад DuckDuckGo. Прыватны AI-чат. Бясплатна."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6695,6 +6829,12 @@ msgstr ""
 "дакладнасць."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6710,7 +6850,8 @@ msgstr "Duck.ai абноўлены!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
+msgstr ""
+"Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6720,10 +6861,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны "
-"AI-чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI "
-"з адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без "
-"уліковага запісу"
+"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны AI-"
+"чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI з "
+"адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без уліковага "
+"запісу"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6889,7 +7030,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
+msgstr ""
+"DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7343,6 +7485,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Паказваць сайты, якія часта наведваюцца"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7502,7 +7650,8 @@ msgstr "Падабаецца Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7514,19 +7663,22 @@ msgstr "Упэўніцеся, што %1$sўключана%2$s налада \"С�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7544,7 +7696,8 @@ msgstr "Упэўніцеся, што %1$sдазволены%2$s доступ д�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
+msgstr ""
+"Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7645,6 +7798,12 @@ msgid "Entertainment guide"
 msgstr "Гід па забавах"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Экватарыяльная Гвінея"
 
@@ -7652,7 +7811,8 @@ msgstr "Экватарыяльная Гвінея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
+msgstr ""
+"Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7712,7 +7872,8 @@ msgstr "Разгарнуць карту"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
+msgstr ""
+"Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7804,6 +7965,18 @@ msgstr "Кантэнт для дарослых"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Нецэнзурныя словы"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7905,6 +8078,12 @@ msgstr "ГПМ"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Бясплатна"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8061,7 +8240,8 @@ msgstr "Фільтры неэфектыўныя"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
+msgstr ""
+"Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8326,6 +8506,12 @@ msgid "Free Up Storage"
 msgstr "Вызваліць месца ў сховішчы"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8367,7 +8553,8 @@ msgstr "Можна абагульваць і выкарыстоўваць у к�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
+msgstr ""
+"Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8841,6 +9028,12 @@ msgid "Get computer help"
 msgstr "Атрымаць камп'ютарную дапамогу"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8849,7 +9042,8 @@ msgstr "Усталюйце наш браўзер, каб ніколі не гу�
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
+msgstr ""
+"У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8876,6 +9070,18 @@ msgid "Get the Latest Version"
 msgstr "Атрымаць апошнюю версію"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8895,7 +9101,14 @@ msgstr "Атрымаць гэту песню на:"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr "Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
+msgstr ""
+"Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9583,6 +9796,12 @@ msgid "Hide Tips"
 msgstr "Схаваць парады"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9879,7 +10098,8 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
+msgstr ""
+"Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -11210,6 +11430,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Дазваляе вам шукаць ананімна з дапамогай DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Ліберыя"
 
@@ -11278,6 +11505,12 @@ msgstr "Лінейная графіка"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Выйграныя калідоры"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11584,7 +11817,8 @@ msgstr "Пераканайцеся, што ўсе словы напісаны п
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
+msgstr ""
+"Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12374,6 +12608,12 @@ msgid "More than 20 minutes"
 msgstr "Больш за 20 хвілін"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12861,6 +13101,12 @@ msgid "No Thanks"
 msgstr "Не, дзякуй"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "Ніякага адсочвання. Ніколі."
@@ -13006,7 +13252,8 @@ msgstr "Вынікі не знойдзены."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
+msgstr ""
+"Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13475,7 +13722,8 @@ msgstr "Аман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
+msgstr ""
+"Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13521,6 +13769,12 @@ msgstr ""
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Уключыць, але без нумароў"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13737,6 +13991,12 @@ msgstr "Прапановы адкрытага чата"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Адкрыць прапановы па стварэнні і рэдагаванні відарысаў"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14485,10 +14745,22 @@ msgid "Pin"
 msgstr "Замацаваць"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Замацуйце чаты тут з %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14506,6 +14778,12 @@ msgstr "Ружовы"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Замацавана"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14546,7 +14824,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
+msgstr ""
+"Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14554,7 +14833,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
+msgstr ""
+"Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14582,7 +14862,8 @@ msgstr "Калі ласка, увядзіце кодавую фразу"
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
 msgctxt "Description for the wrong code error screen"
 msgid "Please make sure the correct code was entered or scanned."
-msgstr "Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
+msgstr ""
+"Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
 
 # smartling.placeholder_format=C
 #. Disclaimer text displayed in a modal that informs the user that starting a new chat with any AI model will delete their current chat session.
@@ -14825,6 +15106,12 @@ msgid "Poor formatting"
 msgstr "Дрэннае фарматаванне"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15031,6 +15318,12 @@ msgstr "Папярэдні відарыс"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Папярэднія ўкладкі"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15573,6 +15866,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "AI з абгрунтаваннем і ўбудаванай мадэрацыяй сярэдняй ступені"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15606,6 +15911,12 @@ msgstr "Апошнія ўкладкі"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Налады сховішча нядаўніх чатаў можна змяніць у раздзеле \"%1$s\"."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15762,6 +16073,12 @@ msgid "Reduce Usage"
 msgstr "Зменшыць выкарыстанне"
 
 # smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
@@ -15909,8 +16226,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку "
-"&quot;Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
+"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку &quot;"
+"Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16140,6 +16457,12 @@ msgid "Reset All Settings"
 msgstr "Скінуць усе налады"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16150,6 +16473,12 @@ msgstr "Скід праз %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Рашэнне"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16426,7 +16755,8 @@ msgstr "SE"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
+msgstr ""
+"Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -16855,6 +17185,12 @@ msgid "Search %s to find results closer to you?"
 msgstr "Шукаць \"%1$s\", каб знайсці вынікі паблізу?"
 
 # smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Search Anonymously"
 msgstr "Ананімны пошук"
 
@@ -16981,7 +17317,8 @@ msgstr "Бачнасць пошуку"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
+msgstr ""
+"Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17056,8 +17393,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць "
-"POST-запыты)"
+"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць POST-"
+"запыты)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17231,6 +17568,12 @@ msgstr ""
 "шыфравання. Ніхто, акрамя вас, не можа бачыць вашы даныя, нават мы."
 
 # smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "Security issue"
 msgstr "Праблема бяспекі"
@@ -17339,7 +17682,8 @@ msgstr "Паглядзіце апошнія абнаўленні"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
+msgstr ""
+"Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17418,7 +17762,8 @@ msgstr "Выберыце %1$sDuckDuckGo%2$s у спісе сайтаў пошу�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
+msgstr ""
+"Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17599,7 +17944,8 @@ msgstr "Выбраны тэкст з %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
+msgstr ""
+"Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17742,6 +18088,12 @@ msgid "Set as Homepage"
 msgstr "Зрабіць хатняй старонкай"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17809,6 +18161,18 @@ msgid "Seychelles"
 msgstr "Сейшэльскія выспы"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17847,6 +18211,13 @@ msgstr ""
 "Падзяліцеся месцазнаходжаннем на ўзроўні горада з мадэлямі штучнага "
 "інтэлекту, каб палепшыць рэлевантнасць. Duck.ai ніколі не раскрывае ваша "
 "дакладнае месцазнаходжанне нам ці мадэлям штучнага інтэлекту."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17905,6 +18276,12 @@ msgstr "Абагуліць URL-адрасы старонкі"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Абагуліць станоўчы водгук"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18040,6 +18417,12 @@ msgstr "Паказваць даныя закладак і налад"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Паказаць падрабязней"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18191,6 +18574,12 @@ msgid "Show more"
 msgstr "Паказаць больш"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18224,6 +18613,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Паказаць бакавую панэль"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18443,7 +18838,8 @@ msgstr "Пошук па сайце часова недаступны. Мы пр�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
+msgstr ""
+"Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18582,7 +18978,8 @@ msgstr "Адбылася памылка"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
+msgstr ""
+"Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18595,6 +18992,12 @@ msgstr "Падчас уключэння Sync & Backup нешта пайшло н
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Штосьці пайшло не так, паспрабуйце пазней."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18891,6 +19294,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Пачаць выкарыстоўваць тыднёвы ліміт"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Пачаць пошук!"
@@ -18949,13 +19358,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr ""
+"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr ""
+"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19088,8 +19499,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў "
-"Duck.ai, або вярніцеся пазней, каб стварыць больш відарысаў."
+"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў Duck."
+"ai, або вярніцеся пазней, каб стварыць больш відарысаў."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19416,7 +19827,8 @@ msgstr "Пераключыць мадэль"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr "Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
+msgstr ""
+"Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -19469,6 +19881,14 @@ msgstr "Перайдзіце на больш эфектыўную мадэль"
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Перайдзіце на пошукавую сістэму, якая не адсочвае вас. Ніколі."
+
+# smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19626,6 +20046,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Сінхранізацыя і рэзервовае капіраванне часова недаступныя"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19711,6 +20137,22 @@ msgstr "Таджыкістан"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Вярніце сваю прыватнасць!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20180,10 +20622,22 @@ msgid "This Month"
 msgstr "Гэты месяц"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Гэты тыдзень"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20317,6 +20771,22 @@ msgid "This information isn’t useful"
 msgstr "Гэтыя звесткі не карысныя"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20364,7 +20834,8 @@ msgstr "Для работы гэтай старонкі патрабуецца J
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
+msgstr ""
+"Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20434,13 +20905,15 @@ msgstr "Гэты пераклад няправільны"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
+msgstr ""
+"Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
+msgstr ""
+"На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20579,7 +21052,8 @@ msgstr "Падкрэсліванне загалоўка"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
+msgstr ""
+"Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -20604,8 +21078,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны "
-"маршрут.%3$sНацісніце на значок друку.%4$s"
+"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны маршрут."
+"%3$sНацісніце на значок друку.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20654,6 +21128,12 @@ msgstr "Сёння"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Сёння"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20829,8 +21309,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя "
-"DuckDuckGo.Спіс будзе абнаўляцца па меры вашага выкарыстання."
+"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя DuckDuckGo."
+"Спіс будзе абнаўляцца па меры вашага выкарыстання."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21069,9 +21549,21 @@ msgid "Try Them Out"
 msgstr "Паспрабуйце"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Паспрабуйце пошук!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21114,14 +21606,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
+msgstr ""
+"Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
+msgstr ""
+"Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21138,6 +21632,12 @@ msgid "Try for free"
 msgstr "Паспрабаваць бясплатна"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21152,6 +21652,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Паспрабуйце бясплатна! Бяспечны VPN, перадавы і прыватны штучны інтэлект і "
 "многае іншае."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21178,7 +21684,14 @@ msgstr "Паспрабуйце наш браўзер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
+msgstr ""
+"Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21247,13 +21760,15 @@ msgstr "Паспрабуйце новы прыватны галасавы чат
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
+msgstr ""
+"Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
+msgstr ""
+"Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -21425,6 +21940,12 @@ msgstr "Для больш рэлевантных вынікаў %1$sДаклад
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Уключыце Duck Player, каб глядзець YouTube без мэтавай рэкламы"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21662,8 +22183,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі "
-"сістэмамі...%4$s"
+"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі сістэмамі..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21787,13 +22308,15 @@ msgstr ""
 msgctxt ""
 "Text that shows users they can unlock advanced AI models with a subscription."
 msgid "Unlock advanced AI models with a %s"
-msgstr "Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
+msgstr ""
+"Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
 
 # smartling.placeholder_format=C
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
+msgstr ""
+"Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -21802,10 +22325,17 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "Атрымайце доступ да перадавога штучнага інтэлекту з падпіскай!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
+msgstr ""
+"Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -22028,7 +22558,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
+msgstr ""
+"Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22138,7 +22669,8 @@ msgstr "Выкарыстаць прыватны пошук DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
+msgstr ""
+"Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22163,6 +22695,12 @@ msgid "Use in Safari"
 msgstr "Скарыстаць у Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22185,7 +22723,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
+msgstr ""
+"Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22388,8 +22927,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады "
-"Duck.ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
+"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады Duck."
+"ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
 "%7$sСінхранізаваць з іншай прыладай%8$s."
 
 # smartling.placeholder_format=C
@@ -22705,7 +23244,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
+msgstr ""
+"Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22907,8 +23447,8 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду "
-"вэб-старонак."
+"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду вэб-"
+"старонак."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22942,7 +23482,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
+msgstr ""
+"Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23202,7 +23743,8 @@ msgstr "Якія фактары варта ўлічваць пры куплі м
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
+msgstr ""
+"Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23210,7 +23752,8 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
+msgstr ""
+"Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23344,6 +23887,12 @@ msgstr "Што вас больш за ўсё турбавала?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Што прывяло вас сёння?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23766,6 +24315,14 @@ msgstr "Перамогі"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Снег з дажджом"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24194,6 +24751,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Вы можаце далучыць да размовы абмежаваную колькасць відарысаў (%1$s)."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24338,6 +24902,12 @@ msgstr ""
 "будзе апошняя версія."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24386,6 +24956,12 @@ msgid "You've blocked 1 site"
 msgstr "Вы заблакіравалі 1 сайт"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24411,14 +24987,16 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
+msgstr ""
+"Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
+msgstr ""
+"Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24648,8 +25226,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у "
-"Duck.ai."
+"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24787,6 +25365,14 @@ msgstr "Ваша роля"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Вашы пошукавыя запыты нельга звязаць з вамі"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25379,3 +25965,9 @@ msgstr "гады"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "г."
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -128,7 +127,7 @@ msgstr "%1$s — выяўленая мова"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Выкарыстана файлаў: %1$s"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -364,7 +363,7 @@ msgstr "Выкарыстана %1$s"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s выкарыстоўвае ліміты да 2-5 разоў хутчэй за базавыя мадэлі %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -479,8 +478,8 @@ msgstr "%1$sДаведацца больш%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага месцазнаходжання."
-"%2$s"
+"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага "
+"месцазнаходжання.%2$s"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -503,8 +502,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
+msgstr "%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -624,7 +622,7 @@ msgstr "1 дзень таму"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "Выкарыстаны 1 файл"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1034,10 +1032,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "У цяперашні час ў адказах з дапамогай штучнага інтэлекту не падтрымліваюцца "
-"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс %1$sDuck."
-"ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш прыватны "
-"чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад OpenAI, "
-"Anthropic і іншых."
+"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс "
+"%1$sDuck.ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш "
+"прыватны чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад "
+"OpenAI, Anthropic і іншых."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1542,6 +1540,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Пашыраныя мадэлі могуць выкарыстоўваць ліміты ў 2-5 разоў хутчэй за іншыя "
+"мадэлі. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1754,8 +1754,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
+msgstr "Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1878,8 +1877,7 @@ msgstr "Ужо сінхранізавана."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
+msgstr "Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2181,8 +2179,7 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr ""
-"Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
+msgstr "Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2333,7 +2330,7 @@ msgstr "Спытайце прыватна"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Спытайце прыватна"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2914,8 +2911,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
+msgstr "Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3677,8 +3673,7 @@ msgstr "Змяняе колер фону на ўсім сайце"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
+msgstr "Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3811,8 +3806,8 @@ msgstr ""
 "мадэлямі чата на базе штучнага інтэлекту, якімі падтрымліваюцца мадэлі "
 "OpenAI, Anthropic і іншыя. Адключэнне гэтай налады схавае кнопкі і спасылкі "
 "чата ў DuckDuckGo Search. Тым не менш, можна атрымаць доступ да чата, калі "
-"гэты параметр выключаны. Для гэтага трэба перайсці на сайт %1$shttps://duck."
-"ai%2$s ."
+"гэты параметр выключаны. Для гэтага трэба перайсці на сайт "
+"%1$shttps://duck.ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3877,8 +3872,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі Duck."
-"ai ў нашым бясплатным браўзеры."
+"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі "
+"Duck.ai ў нашым бясплатным браўзеры."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3896,7 +3891,7 @@ msgstr "Размаўляйце прыватна з AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Размаўляйце прыватна з папулярнымі AI"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4058,8 +4053,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
+msgstr "Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4124,8 +4118,7 @@ msgstr "Выбар мадэляў штучнага інтэлекту, у тым
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
+msgstr "Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4535,8 +4528,7 @@ msgstr "Націсніце на %1$sПастаўшчыкі пошуку%2$s па
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
+msgstr "Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4696,7 +4688,7 @@ msgstr "Закрыць"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Закрыць"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4746,7 +4738,7 @@ msgstr "Закрыць пошук"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Закрыць другое меркаванне"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5123,7 +5115,7 @@ msgstr "Працягваць блакіраваць рэкламу"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Працягвайце апошнія чаты тут. Або выдаліце іх з дапамогай Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5194,7 +5186,7 @@ msgstr "Даныя файлаў cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Скапіравана"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5247,7 +5239,7 @@ msgstr "Скапіраваць код"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Скапіраваць спасылку"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5368,7 +5360,7 @@ msgstr "Стварыце відарыс"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Стварыць спасылку для абагульвання"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5420,6 +5412,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Пасля стварэння спасылкі ствараецца копія чата, якую можа праглядаць кожны, "
+"хто яе адкрые."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5578,7 +5572,7 @@ msgstr "Наладзіць адказы"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Наладзіць адказы"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5870,7 +5864,7 @@ msgstr "Выдаліць даныя сервера?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Выдаліць абагуленую спасылку"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5882,7 +5876,7 @@ msgstr "Выдаліць тэкст размовы"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Выдаліць чат"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5920,7 +5914,7 @@ msgstr "Выдаліць відарыс?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Выдалі мяне"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6235,7 +6229,7 @@ msgstr "Адхіліць рэкламу"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Адхіліць агляд"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6452,7 +6446,7 @@ msgstr "Спампаваць DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Спампаваць DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6673,7 +6667,7 @@ msgstr "Duck.ai ад DuckDuckGo. Прыватны AI-чат. Бясплатна.
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Цяпер Duck.ai можа аналізаваць PDF-файлы. Паспрабуйце!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6832,7 +6826,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai падтрымлівае мадэлі ад Anthropic, OpenAI і іншых."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6850,8 +6844,7 @@ msgstr "Duck.ai абноўлены!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
+msgstr "Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6861,10 +6854,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны AI-"
-"чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI з "
-"адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без уліковага "
-"запісу"
+"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны "
+"AI-чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI "
+"з адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без "
+"уліковага запісу"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7030,8 +7023,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
+msgstr "DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7488,7 +7480,7 @@ msgstr "Паказваць сайты, якія часта наведваюцц�
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Уключыць зараз"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7650,8 +7642,7 @@ msgstr "Падабаецца Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7663,22 +7654,19 @@ msgstr "Упэўніцеся, што %1$sўключана%2$s налада \"С�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7696,8 +7684,7 @@ msgstr "Упэўніцеся, што %1$sдазволены%2$s доступ д�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
+msgstr "Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7801,7 +7788,7 @@ msgstr "Гід па забавах"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Увесь чат"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7811,8 +7798,7 @@ msgstr "Экватарыяльная Гвінея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
+msgstr "Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7872,8 +7858,7 @@ msgstr "Разгарнуць карту"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
+msgstr "Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7970,13 +7955,13 @@ msgstr "Нецэнзурныя словы"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Даследаваць Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Даследуйце Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8083,7 +8068,7 @@ msgstr "Бясплатна"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "БЯСПЛАТНА І НЕАБАВЯЗКОВА"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8240,8 +8225,7 @@ msgstr "Фільтры неэфектыўныя"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
+msgstr "Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8509,7 +8493,7 @@ msgstr "Вызваліць месца ў сховішчы"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Бясплатна і заўсёды прыватна"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8553,8 +8537,7 @@ msgstr "Можна абагульваць і выкарыстоўваць у к�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
+msgstr "Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9031,7 +9014,7 @@ msgstr "Атрымаць камп'ютарную дапамогу"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Атрымайце вышэйшыя ліміты выкарыстання з падпіскай DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9042,8 +9025,7 @@ msgstr "Усталюйце наш браўзер, каб ніколі не гу�
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
+msgstr "У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9073,13 +9055,15 @@ msgstr "Атрымаць апошнюю версію"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Спампаваць праграму"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Спампуйце бясплатны браўзер DuckDuckGo, %1$sкаб блакіраваць рэкламу на "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9101,14 +9085,13 @@ msgstr "Атрымаць гэту песню на:"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr ""
-"Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
+msgstr "Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Чэк-ліст для пачатку працы"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9799,7 +9782,7 @@ msgstr "Схаваць парады"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Схаваць навучанне"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10098,8 +10081,7 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
+msgstr "Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -11434,7 +11416,7 @@ msgstr "Дазваляе вам шукаць ананімна з дапамог�
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11510,7 +11492,7 @@ msgstr "Выйграныя калідоры"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Тэрмін дзеяння спасылкі заканчваецца праз 7 дзён."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11817,8 +11799,7 @@ msgstr "Пераканайцеся, што ўсе словы напісаны п
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
+msgstr "Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12611,7 +12592,7 @@ msgstr "Больш за 20 хвілін"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Больш парад"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13104,7 +13085,7 @@ msgstr "Не, дзякуй"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Не, дзякуй"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13252,8 +13233,7 @@ msgstr "Вынікі не знойдзены."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
+msgstr "Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13722,8 +13702,7 @@ msgstr "Аман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
+msgstr "Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13774,7 +13753,7 @@ msgstr "Уключыць, але без нумароў"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Рэгістрацыя завершана"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13996,7 +13975,7 @@ msgstr "Адкрыць прапановы па стварэнні і рэдаг�
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Адкрыць чэк-ліст першых крокаў"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14748,7 +14727,7 @@ msgstr "Замацаваць"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Замацаваць чат"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14760,7 +14739,7 @@ msgstr "Замацуйце чаты тут з %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Замацуй мяне"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14783,7 +14762,7 @@ msgstr "Замацавана"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Замацаваныя чаты з'явяцца ўверсе вашых нядаўніх чатаў."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14824,8 +14803,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
+msgstr "Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14833,8 +14811,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
+msgstr "Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14862,8 +14839,7 @@ msgstr "Калі ласка, увядзіце кодавую фразу"
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
 msgctxt "Description for the wrong code error screen"
 msgid "Please make sure the correct code was entered or scanned."
-msgstr ""
-"Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
+msgstr "Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
 
 # smartling.placeholder_format=C
 #. Disclaimer text displayed in a modal that informs the user that starting a new chat with any AI model will delete their current chat session.
@@ -15110,6 +15086,8 @@ msgstr "Дрэннае фарматаванне"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Даступныя папулярныя мадэлі штучнага інтэлекту. Уліковы запіс не патрэбны. "
+"Чаты, якія мы зрабілі ананімнымі."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15323,7 +15301,7 @@ msgstr "Папярэднія ўкладкі"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Папярэднія парады"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15869,13 +15847,15 @@ msgstr "AI з абгрунтаваннем і ўбудаванай мадэра�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Разважанне можа дазволіць атрымаць лепшыя адказы на складаныя пытанні."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Разважанне больш грунтоўнае, але ліміты выкарыстоўваюцца ў 2-5 разоў хутчэй. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15916,7 +15896,7 @@ msgstr "Налады сховішча нядаўніх чатаў можна з�
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Апошнія чаты"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16076,7 +16056,7 @@ msgstr "Зменшыць выкарыстанне"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Паменшыце выкарыстанне з дапамогай больш эфектыўнай мадэлі"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16226,8 +16206,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку &quot;"
-"Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
+"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку "
+"&quot;Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16460,7 +16440,7 @@ msgstr "Скінуць усе налады"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Скінуць навучанне"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16478,7 +16458,7 @@ msgstr "Рашэнне"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Адказ"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16755,8 +16735,7 @@ msgstr "SE"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
+msgstr "Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17188,7 +17167,7 @@ msgstr "Шукаць \"%1$s\", каб знайсці вынікі паблізу
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Пераключальнік «Пошук і Duck.ai»"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17317,8 +17296,7 @@ msgstr "Бачнасць пошуку"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
+msgstr "Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17393,8 +17371,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць POST-"
-"запыты)"
+"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць "
+"POST-запыты)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17571,7 +17549,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Надзейна захоўваецца на нашым зашыфраваным серверы."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17682,8 +17660,7 @@ msgstr "Паглядзіце апошнія абнаўленні"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
+msgstr "Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17762,8 +17739,7 @@ msgstr "Выберыце %1$sDuckDuckGo%2$s у спісе сайтаў пошу�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
+msgstr "Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17944,8 +17920,7 @@ msgstr "Выбраны тэкст з %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
+msgstr "Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18091,7 +18066,7 @@ msgstr "Зрабіць хатняй старонкай"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Задайце тон і стыль адказаў Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18164,13 +18139,13 @@ msgstr "Сейшэльскія выспы"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Абагуліць"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Абагульванне"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18217,7 +18192,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Абагульванне чата"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18281,7 +18256,7 @@ msgstr "Абагуліць станоўчы водгук"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Вобласць абагульвання"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18422,7 +18397,7 @@ msgstr "Паказаць падрабязней"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Паказаць навучанне Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18577,7 +18552,7 @@ msgstr "Паказаць больш"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Паказаць больш мадэляў"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18618,7 +18593,7 @@ msgstr "Паказаць бакавую панэль"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Паказаць пакрокавыя парады, як атрымаць максімум ад Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18838,8 +18813,7 @@ msgstr "Пошук па сайце часова недаступны. Мы пр�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
+msgstr "Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18978,8 +18952,7 @@ msgstr "Адбылася памылка"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
+msgstr "Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18997,7 +18970,7 @@ msgstr "Штосьці пайшло не так, паспрабуйце пазн
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Адбылася памылка. Паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19297,7 +19270,7 @@ msgstr "Пачаць выкарыстоўваць тыднёвы ліміт"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Пачаць новы чат"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19358,15 +19331,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19499,8 +19470,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў Duck."
-"ai, або вярніцеся пазней, каб стварыць больш відарысаў."
+"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў "
+"Duck.ai, або вярніцеся пазней, каб стварыць больш відарысаў."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19827,8 +19798,7 @@ msgstr "Пераключыць мадэль"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
+msgstr "Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -19888,7 +19858,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Перайсці на гэта другое меркаванне"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20049,7 +20019,7 @@ msgstr "Сінхранізацыя і рэзервовае капіраванн�
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Сінхранізаваць чаты на розных прыладах"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20145,6 +20115,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Бярыце Duck.ai з сабой паўсюль. Атрымайце яго ўбудаваным у нашу бясплатную "
+"праграму для хутчэйшага доступу, дзе б вы ні былі."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20153,6 +20125,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Бярыце Duck.ai з сабой паўсюль. Атрымайце яго ўбудаваным у наш бясплатны "
+"браўзер для хутчэйшага доступу, дзе б вы ні праглядалі кантэнт."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20625,7 +20599,7 @@ msgstr "Гэты месяц"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Гэты адказ"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20637,7 +20611,7 @@ msgstr "Гэты тыдзень"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Гэты чат застаецца ў Duck.ai і застаецца прыватным для вас."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20777,6 +20751,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Гэта проста прыклад чата. Адкрый яго меню (тры кропкі), а потым выберы "
+"«Замацаваць», каб трымаць яго ўверсе сваіх чатаў!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20785,6 +20761,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Гэта проста прыклад чата. Выкарыстайце Fire Button у бакавым меню, каб "
+"выдаліць яго!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20834,8 +20812,7 @@ msgstr "Для работы гэтай старонкі патрабуецца J
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
+msgstr "Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20905,15 +20882,13 @@ msgstr "Гэты пераклад няправільны"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
+msgstr "Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
+msgstr "На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21052,8 +21027,7 @@ msgstr "Падкрэсліванне загалоўка"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
+msgstr "Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21078,8 +21052,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны маршрут."
-"%3$sНацісніце на значок друку.%4$s"
+"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны "
+"маршрут.%3$sНацісніце на значок друку.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21134,6 +21108,8 @@ msgstr "Сёння"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Пераключыце, каб паспрабаваць прыватны AI-чат, або %1$sвыключыце яго ў меню "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21309,8 +21285,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя DuckDuckGo."
-"Спіс будзе абнаўляцца па меры вашага выкарыстання."
+"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя "
+"DuckDuckGo.Спіс будзе абнаўляцца па меры вашага выкарыстання."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21552,7 +21528,7 @@ msgstr "Паспрабуйце"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Паспрабаваць іншую мадэль"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21563,7 +21539,7 @@ msgstr "Паспрабуйце пошук!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Паспрабуйце прапанову"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21606,16 +21582,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
+msgstr "Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
+msgstr "Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21635,7 +21609,7 @@ msgstr "Паспрабаваць бясплатна"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Паспрабаваць бясплатна"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21657,7 +21631,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Паспрабуйце бясплатна на працягу 7 дзён"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21684,14 +21658,13 @@ msgstr "Паспрабуйце наш браўзер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
+msgstr "Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Паспрабаваць разважанне"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21760,15 +21733,13 @@ msgstr "Паспрабуйце новы прыватны галасавы чат
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
+msgstr "Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
+msgstr "Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -21945,7 +21916,7 @@ msgstr "Уключыце Duck Player, каб глядзець YouTube без м�
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Уключыць пераключальнік Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22183,8 +22154,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі сістэмамі..."
-"%4$s"
+"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі "
+"сістэмамі...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22308,15 +22279,13 @@ msgstr ""
 msgctxt ""
 "Text that shows users they can unlock advanced AI models with a subscription."
 msgid "Unlock advanced AI models with a %s"
-msgstr ""
-"Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
+msgstr "Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
 
 # smartling.placeholder_format=C
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
+msgstr "Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -22328,14 +22297,13 @@ msgstr "Атрымайце доступ да перадавога штучнаг
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Разблакіраваць перадавыя мадэлі"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
+msgstr "Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -22558,8 +22526,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
+msgstr "Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22669,8 +22636,7 @@ msgstr "Выкарыстаць прыватны пошук DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
+msgstr "Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22698,7 +22664,7 @@ msgstr "Скарыстаць у Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Каб выдаліць чат з гісторыі., выкарыстоўвайце Fire Button."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22723,8 +22689,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
+msgstr "Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22927,8 +22892,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады Duck."
-"ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
+"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады "
+"Duck.ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
 "%7$sСінхранізаваць з іншай прыладай%8$s."
 
 # smartling.placeholder_format=C
@@ -23244,8 +23209,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
+msgstr "Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23447,8 +23411,8 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду вэб-"
-"старонак."
+"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду "
+"вэб-старонак."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23482,8 +23446,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
+msgstr "Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23743,8 +23706,7 @@ msgstr "Якія фактары варта ўлічваць пры куплі м
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
+msgstr "Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23752,8 +23714,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
+msgstr "Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23892,7 +23853,7 @@ msgstr "Што прывяло вас сёння?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Што вы ўмееце?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24323,6 +24284,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"З Duck.ai вашы чаты ананімізаваны і ніколі не выкарыстоўваюцца для навучання "
+"штучнага інтэлекту. Уключы або адключы гэта ў любы час у меню '%1$s'."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24755,7 +24718,7 @@ msgstr "Вы можаце далучыць да размовы абмежава�
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Вы можаце далучыць за раз абмежаваную колькасць укладак (%1$s)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24905,7 +24868,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Усё гатова!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24959,7 +24922,7 @@ msgstr "Вы заблакіравалі 1 сайт"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Вы засвоілі асновы Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24987,16 +24950,14 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
+msgstr "Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
+msgstr "Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25226,8 +25187,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у Duck."
-"ai."
+"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25373,6 +25334,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Вашы налады захаваны, але выдаленне файлаў cookie прывядзе да іх скіду. "
+"Уключыце пашырэнне %1$sDuckDuckGo No AI%2$s, каб яно працавала ўвесь час."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25970,4 +25933,4 @@ msgstr "г."
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "Преди %1$s дни"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Разпознат %1$s"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +361,12 @@ msgid "%s used"
 msgstr "%1$s използвани"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s гледане"
@@ -468,7 +480,8 @@ msgstr "%1$sНаучи повече%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
+msgstr ""
+"%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -608,6 +621,12 @@ msgstr "1 опит блокиран от DuckDuckGo през последнит�
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Преди 1 ден"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -959,8 +978,8 @@ msgstr ""
 "AI Chat ви позволява да провеждате анонимни разговори с модели за чат с "
 "изкуствен интелект на трети страни. Изключването на това ще скрие функцията "
 "AI Chat в DuckDuckGo Search. Все още можете да получите достъп до AI Chat, "
-"когато тази настройка е изключена, като посетите "
-"%1$sduckduckgo.com/aichat%2$s."
+"когато тази настройка е изключена, като посетите %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1522,6 +1541,14 @@ msgctxt ""
 "app variant)"
 msgid "Advanced Models"
 msgstr "Усъвършенствани модели"
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2150,7 +2177,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
+msgstr ""
+"Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2316,6 +2344,12 @@ msgid "Ask privately"
 msgstr "Задавайте въпроси поверително"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2464,7 +2498,8 @@ msgstr "След приключване на чата аудиото не се �
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
+msgstr ""
+"След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3668,7 +3703,8 @@ msgstr "Променя фоновия цвят, когато курсорът б
 #. Description of a setting managing the color of search result snippet text.
 msgctxt "settings"
 msgid "Changes the color of descriptive content shown for results"
-msgstr "Променя цвета на описателното съдържание, което се показва с резултатите"
+msgstr ""
+"Променя цвета на описателното съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -3871,6 +3907,12 @@ msgid "Chat privately with AI"
 msgstr "Поверителен чат с AI"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4025,7 +4067,8 @@ msgstr "Проверете правописа"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
+msgstr ""
+"Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4424,7 +4467,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
+msgstr ""
+"Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4491,7 +4535,8 @@ msgstr "Щракнете върху %1$sБраузър%2$s в странично
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
+msgstr ""
+"Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4509,7 +4554,8 @@ msgstr "Щракнете върху %1$sТърсачки%2$s под Видове
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
+msgstr ""
+"Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4584,7 +4630,8 @@ msgstr "Щракнете върху %1$sиконата за разрешения
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
+msgstr ""
+"Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4666,6 +4713,12 @@ msgid "Close"
 msgstr "Затваряне"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4708,6 +4761,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Затваряне на търсенето"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5081,6 +5140,12 @@ msgid "Continue Blocking Ads"
 msgstr "Продължи да блокираш рекламите"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5146,6 +5211,12 @@ msgid "Cookie data:"
 msgstr "Данни за бисквитка:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5184,13 +5255,20 @@ msgstr "Копиране"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
+msgstr ""
+"Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Копиране на кода"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5260,7 +5338,8 @@ msgstr "Коста Рика"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
+msgstr ""
+"Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5306,6 +5385,12 @@ msgid "Create Image"
 msgstr "Създаване на изображение"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5347,6 +5432,14 @@ msgstr "Създадено от"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Създаден от %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5500,6 +5593,12 @@ msgstr "Персонализиране на отговорите"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Персонализиране на отговорите"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5788,10 +5887,22 @@ msgid "Delete Server Data?"
 msgstr "Изтриване на данните от сървъра?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Изтриване на преписа"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5824,6 +5935,12 @@ msgstr "Изтриване на изображението"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Изтриване на изображението?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6052,7 +6169,8 @@ msgstr "Деактивиране и изключване"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
+msgstr ""
+"Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6134,6 +6252,12 @@ msgstr "Отхвърли завинаги"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Пропусни промоцията"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6240,7 +6364,8 @@ msgstr "Не виждате DuckDuckGo в списъка?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
+msgstr ""
+"Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6344,6 +6469,12 @@ msgstr "Изтеглянето е завършено"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Изтегляне на DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6558,7 +6689,14 @@ msgstr "Условия за ползване на Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
+msgstr ""
+"Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
+
+# smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6598,7 +6736,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
+msgstr ""
+"Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6648,7 +6787,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
+msgstr ""
+"Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6679,8 +6819,8 @@ msgstr ""
 "интелект на трети страни, включително модели от OpenAI, Anthropic и други. "
 "Ако изключите тази настройка, бутоните и връзките на Duck.ai в DuckDuckGo "
 "Search ще се скрият. Въпреки това можете да получите достъп до Duck.ai, "
-"когато тази настройка е изключена, като посетите директно "
-"%1$shttps://duck.ai%2$s ."
+"когато тази настройка е изключена, като посетите директно %1$shttps://duck."
+"ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6712,6 +6852,12 @@ msgid ""
 msgstr ""
 "Отговорите на Duck.ai не се основават на конкретни източници и не се "
 "проверяват за точност."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6914,8 +7060,8 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
 msgstr ""
-"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново "
-"по-късно."
+"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7363,6 +7509,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Активиране на най-често посещавани сайтове"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7530,13 +7682,15 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
+msgstr ""
+"Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
+msgstr ""
+"Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7566,13 +7720,15 @@ msgstr "Уверете се, че достъпът до местоположен
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
+msgstr ""
+"Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
+msgstr ""
+"Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7665,6 +7821,12 @@ msgid "Entertainment guide"
 msgstr "Екскурзовод за развлечения"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Екваториална Гвинея"
 
@@ -7672,7 +7834,8 @@ msgstr "Екваториална Гвинея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
+msgstr ""
+"Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7765,7 +7928,8 @@ msgstr "Обясни приетия отговор с прости думи."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
+msgstr ""
+"Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7828,10 +7992,23 @@ msgid "Explicit lyrics"
 msgstr "Нецензуриран текст на песен"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
+msgstr ""
+"Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7927,6 +8104,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Безплатно"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8130,7 +8313,8 @@ msgstr "Финансов консултант"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
+msgstr ""
+"Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8350,6 +8534,12 @@ msgid "Free Up Storage"
 msgstr "Освобождаване на място за съхранение"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8359,7 +8549,8 @@ msgstr "Безплатни и поверителни чатове, аноним�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
+msgstr ""
+"Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8605,13 +8796,15 @@ msgstr "Общо предназначение"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
+msgstr ""
+"Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
+msgstr ""
+"Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -8868,6 +9061,12 @@ msgid "Get computer help"
 msgstr "Потърсете помощ от компютър"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8905,6 +9104,18 @@ msgid "Get the Latest Version"
 msgstr "Инсталирайте най-новата версия"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8925,6 +9136,12 @@ msgstr "Вземете тази песен в:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Убедете приятелите си да превключат и ни помогнете да се развием!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8998,7 +9215,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
+msgstr ""
+"Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9612,6 +9830,12 @@ msgid "Hide Tips"
 msgstr "Съвети за скриване"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9658,7 +9882,8 @@ msgstr "Скриване на Вашия имейл адрес"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
+msgstr ""
+"Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9920,7 +10145,8 @@ msgstr "Колко често искате да виждате отговори�
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
+msgstr ""
+"Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10058,8 +10284,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри "
-"книги/поредици има, които приличат най-много на нея, и защо?"
+"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри книги/"
+"поредици има, които приличат най-много на нея, и защо?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10685,7 +10911,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
+msgstr ""
+"Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10735,7 +10962,8 @@ msgstr "Той е бърз, безплатен и осигурява още по
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
+msgstr ""
+"Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11236,6 +11464,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Осигурява възможност за анонимно търсене с DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Либерия"
 
@@ -11291,7 +11526,8 @@ msgstr "Ограничено съхранение на данни за този 
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr "Ограничава количеството описателно съдържание, което се показва с резултатите"
+msgstr ""
+"Ограничава количеството описателно съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11304,6 +11540,12 @@ msgstr "Изображение с линии"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Спечелени тъчове"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11432,7 +11674,8 @@ msgstr "Зареждане на още резултати с изображен�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "При превъртане зарежда повече резултати в изображения, видео и пазаруване"
+msgstr ""
+"При превъртане зарежда повече резултати в изображения, видео и пазаруване"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11461,7 +11704,8 @@ msgstr "Местоположение"
 #. Message informing users that location-based search is private.
 msgctxt "precise_user_location"
 msgid "Location information is stored only on your device."
-msgstr "Информацията за местоположението се съхранява само на вашето устройство."
+msgstr ""
+"Информацията за местоположението се съхранява само на вашето устройство."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -12404,6 +12648,12 @@ msgid "More than 20 minutes"
 msgstr "Повече от 20 минути"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12890,6 +13140,12 @@ msgstr "Не, благодаря"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Не, благодаря"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13554,6 +13810,12 @@ msgid "On but no numbers"
 msgstr "Включено, но без номерация"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13770,6 +14032,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Отваряне на предложения за създаване и редактиране на изображения"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13832,7 +14100,8 @@ msgstr "Отваряне на панела Как работи Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
+msgstr ""
+"Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14424,9 +14693,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"Ако формулирате своето търсене като въпрос и в пълно изречение, е "
-"по-вероятно DuckAssist да се появи и често допринася за по-добри отговори. "
-"За да настроите как да работи тази функция или да я изключите, отидете на "
+"Ако формулирате своето търсене като въпрос и в пълно изречение, е по-"
+"вероятно DuckAssist да се появи и често допринася за по-добри отговори. За "
+"да настроите как да работи тази функция или да я изключите, отидете на "
 "%1$sНастройки на DuckAssist%2$s."
 
 # smartling.placeholder_format=C
@@ -14517,10 +14786,22 @@ msgid "Pin"
 msgstr "Добавяне като отметка"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Закачете чатове от %1$s %2$s тук"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14538,6 +14819,12 @@ msgstr "Розово"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Закачени"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14857,6 +15144,12 @@ msgid "Poor formatting"
 msgstr "Лошо форматиране"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15063,6 +15356,12 @@ msgstr "Предишно изображение"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Предишни раздели"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15605,6 +15904,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "AI за разсъждения със средно ниво на вградена модерация"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15638,6 +15949,12 @@ msgstr "Последни раздели"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Съхраняването на последните чатове може да се коригира в %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15793,6 +16110,12 @@ msgstr "Повторно търсене без този сайт"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Намаляване на употребата"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15953,7 +16276,8 @@ msgstr "Запомни моя избор"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
+msgstr ""
+"Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16172,6 +16496,12 @@ msgid "Reset All Settings"
 msgstr "Нулиране на всички настройки"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16182,6 +16512,12 @@ msgstr "Нулира се след %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Резолюция"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16809,13 +17145,15 @@ msgstr "Шотландия"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
+msgstr ""
+"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
+msgstr ""
+"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16885,6 +17223,12 @@ msgstr "Търсене"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Искате да потърсите %1$s, за да намерите резултати по-близо до вас?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17248,7 +17592,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
+msgstr ""
+"Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17259,6 +17604,12 @@ msgid ""
 msgstr ""
 "Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край. "
 "Никой освен Вас не може да види Вашите данни, дори ние."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17369,7 +17720,8 @@ msgstr "Вижте някои от най-новите ни актуализац
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
+msgstr ""
+"За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17409,7 +17761,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
+msgstr ""
+"Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17430,7 +17783,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
+msgstr ""
+"Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17776,6 +18130,12 @@ msgid "Set as Homepage"
 msgstr "Задай като Начална страница"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17843,6 +18203,18 @@ msgid "Seychelles"
 msgstr "Сейшели"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17880,9 +18252,16 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Споделете местоположение на ниво град с AI моделите, за да получавате "
-"по-подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
+"Споделете местоположение на ниво град с AI моделите, за да получавате по-"
+"подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
 "нито на нас, нито на AI моделите."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17941,6 +18320,12 @@ msgstr "Споделяне на URL адрес на страницата"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Споделяне на положителен отзив"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18076,6 +18461,12 @@ msgstr "Показвай Отметката и Данните за настро�
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Показване на подробности"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18227,6 +18618,12 @@ msgid "Show more"
 msgstr "Покажи повече"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18260,6 +18657,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Показване на страничната лента"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18357,7 +18760,8 @@ msgstr "Показва периодично напомняне за добавя
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
+msgstr ""
+"Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18375,7 +18779,8 @@ msgstr "Показва номерата на страниците в края н
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
+msgstr ""
+"Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18398,12 +18803,14 @@ msgstr "Показва фона на бутона за търсене"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Показва приветствие в горната част на страницата с резултати от търсенето"
+msgstr ""
+"Показва приветствие в горната част на страницата с резултати от търсенето"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
+msgstr ""
+"Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18475,12 +18882,14 @@ msgstr "Имена на сайтове"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
+msgstr ""
+"Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
+msgstr ""
+"Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18625,13 +19034,20 @@ msgstr "Нещо се обърка при запазването на сървъ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
+msgstr ""
+"Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Възникна някаква грешка, опитайте отново по-късно."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18649,7 +19065,8 @@ msgstr "Понякога"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
+msgstr ""
+"Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18724,8 +19141,8 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново "
-"по-късно."
+"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18930,6 +19347,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Започнете да използвате седмичен лимит"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Започни търсене!"
@@ -19035,7 +19458,8 @@ msgstr "Спрете скритите тракери, които се спота
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
+msgstr ""
+"Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19510,6 +19934,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Преминете към търсачка, която не ви проследява. Никога."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19668,6 +20100,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Функцията за синхронизиране и архивиране временно не е достъпна"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19755,6 +20193,22 @@ msgid "Take Back Your Privacy!"
 msgstr "Възвърнете си поверителността!"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19776,8 +20230,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим "
-"Duck.ai."
+"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20141,7 +20595,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
+msgstr ""
+"Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20195,7 +20650,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
+msgstr ""
+"Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20211,7 +20667,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
+msgstr ""
+"Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20220,10 +20677,22 @@ msgid "This Month"
 msgstr "Този месец"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Тази седмица"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20354,6 +20823,22 @@ msgid "This information isn’t useful"
 msgstr "Тази информация не е полезна"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20472,7 +20957,8 @@ msgstr "Този превод е грешен"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
+msgstr ""
+"Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20698,6 +21184,12 @@ msgid "Today"
 msgstr "Днес"
 
 # smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Togo"
 msgstr "Того"
 
@@ -20918,8 +21410,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от английски на френски: „Как да стигна до "
-"най-близкото кино?“"
+"Преведи това изречение от английски на френски: „Как да стигна до най-"
+"близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20928,8 +21420,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от български на английски: „Как да стигна до "
-"най-близкото кино?“"
+"Преведи това изречение от български на английски: „Как да стигна до най-"
+"близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21047,7 +21539,8 @@ msgstr "Изпробвайте %1$s — първият ни модел с нул
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
+msgstr ""
+"Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -21109,9 +21602,21 @@ msgid "Try Them Out"
 msgstr "Изпробвайте ги"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Опитайте търсене!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21182,6 +21687,12 @@ msgid "Try for free"
 msgstr "Безплатна проба"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21196,6 +21707,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Пробвайте безплатно! Сигурна VPN услуга, усъвършенстван и поверителен AI и "
 "много други."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21222,7 +21739,14 @@ msgstr "Изпробвайте нашия браузър"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Опитайте нашата начална страница, която никога не показва тези съобщения:"
+msgstr ""
+"Опитайте нашата начална страница, която никога не показва тези съобщения:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21474,6 +21998,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Включете Duck Player, за да гледате YouTube без насочени реклами"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21689,7 +22219,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
+msgstr ""
+"Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21707,7 +22238,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
+msgstr ""
+"В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21843,6 +22375,12 @@ msgstr "Отключете усъвършенствани AI модели с а�
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Отключете усъвършенстван AI заедно с абонамента!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22208,6 +22746,12 @@ msgid "Use in Safari"
 msgstr "Използвайте в Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22230,7 +22774,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Да се използва приблизителното Ви местоположение за по-точни резултати?"
+msgstr ""
+"Да се използва приблизителното Ви местоположение за по-точни резултати?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22708,8 +23253,8 @@ msgstr "Ние анонимизираме"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме "
-"по-точни резултати."
+"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме по-"
+"точни резултати."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22821,7 +23366,8 @@ msgstr "Ние не ви проследяваме. Никога."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
+msgstr ""
+"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22862,7 +23408,8 @@ msgstr "Не ви следим нито във, нито извън режима
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
+msgstr ""
+"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22989,7 +23536,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
+msgstr ""
+"Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23154,7 +23702,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
+msgstr ""
+"Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23245,13 +23794,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
+msgstr ""
+"Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Кои атракции трябва да види един турист, който посещава Париж за първи път?"
+msgstr ""
+"Кои атракции трябва да види един турист, който посещава Париж за първи път?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23370,7 +23921,8 @@ msgstr "Кои са ястията, които задължително тряб
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Какво е работното време, местоположението и данните за контакт на това място?"
+msgstr ""
+"Какво е работното време, местоположението и данните за контакт на това място?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23395,6 +23947,12 @@ msgstr "Какво не харесахте в отговора?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Какво ви върна тук днес?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23817,6 +24375,14 @@ msgid "Wintry Mix"
 msgstr "Киша"
 
 # smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -24206,7 +24772,8 @@ msgstr "Можете да продължите този чат, като изп�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
+msgstr ""
+"Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24245,6 +24812,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Можете да прикачите само %1$s изображения на разговор."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24276,7 +24850,8 @@ msgstr "Можете да възстановите настройките си, 
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr "Можете да споделяте и използвате настройките си с други компютри и браузъри."
+msgstr ""
+"Можете да споделяте и използвате настройките си с други компютри и браузъри."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -24389,6 +24964,12 @@ msgstr ""
 "актуализации на приложението DuckDuckGo."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24436,6 +25017,12 @@ msgid "You've blocked 1 site"
 msgstr "Блокирали сте 1 сайт"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24454,14 +25041,15 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново "
-"по-късно."
+"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Достигнали сте максималната продължителност на гласовия чат за една сесия."
+msgstr ""
+"Достигнали сте максималната продължителност на гласовия чат за една сесия."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -24473,7 +25061,8 @@ msgstr "Достигнали сте лимита за гласов чат за �
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
+msgstr ""
+"Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24482,8 +25071,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в "
-"Duck.ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
+"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в Duck."
+"ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
 "синхронизирането. Закачените чатове няма да бъдат изтрити."
 
 # smartling.placeholder_format=C
@@ -24511,8 +25100,8 @@ msgid ""
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
 "YouTube (притежаван от Google) не позволява да гледате видео анонимно. "
-"Следователно гледането на YouTube видео тук ще бъде следено от "
-"YouTube/Google."
+"Следователно гледането на YouTube видео тук ще бъде следено от YouTube/"
+"Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24635,7 +25224,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Чатовете са поверителни и никога не се използват за обучение на AI модели"
+msgstr ""
+"Чатовете са поверителни и никога не се използват за обучение на AI модели"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24696,7 +25286,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
+msgstr ""
+"Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24833,6 +25424,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Вашите търсения не могат да бъдат свързани с Вас"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24914,7 +25513,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
+msgstr ""
+"Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24997,7 +25597,8 @@ msgstr "от %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
+msgstr ""
+"от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25423,3 +26024,9 @@ msgstr "години"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "год."
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "Разпознат %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s използвани файла"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -364,7 +364,7 @@ msgstr "%1$s използвани"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -480,8 +480,7 @@ msgstr "%1$sНаучи повече%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
+msgstr "%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -626,7 +625,7 @@ msgstr "Преди 1 ден"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 използван файл"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -978,8 +977,8 @@ msgstr ""
 "AI Chat ви позволява да провеждате анонимни разговори с модели за чат с "
 "изкуствен интелект на трети страни. Изключването на това ще скрие функцията "
 "AI Chat в DuckDuckGo Search. Все още можете да получите достъп до AI Chat, "
-"когато тази настройка е изключена, като посетите %1$sduckduckgo.com/"
-"aichat%2$s."
+"когато тази настройка е изключена, като посетите "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1549,6 +1548,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Усъвършенстваните модели могат да изразходват лимитите 2-5 пъти по-бързо от "
+"другите модели. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2177,8 +2178,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
+msgstr "Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2347,7 +2347,7 @@ msgstr "Задавайте въпроси поверително"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Задавайте въпроси поверително"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2498,8 +2498,7 @@ msgstr "След приключване на чата аудиото не се �
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
+msgstr "След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3703,8 +3702,7 @@ msgstr "Променя фоновия цвят, когато курсорът б
 #. Description of a setting managing the color of search result snippet text.
 msgctxt "settings"
 msgid "Changes the color of descriptive content shown for results"
-msgstr ""
-"Променя цвета на описателното съдържание, което се показва с резултатите"
+msgstr "Променя цвета на описателното съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -3910,7 +3908,7 @@ msgstr "Поверителен чат с AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Поверителен чат с популярни AI модели"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4067,8 +4065,7 @@ msgstr "Проверете правописа"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
+msgstr "Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4467,8 +4464,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
+msgstr "Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4535,8 +4531,7 @@ msgstr "Щракнете върху %1$sБраузър%2$s в странично
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
+msgstr "Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4554,8 +4549,7 @@ msgstr "Щракнете върху %1$sТърсачки%2$s под Видове
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
+msgstr "Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4630,8 +4624,7 @@ msgstr "Щракнете върху %1$sиконата за разрешения
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
+msgstr "Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4716,7 +4709,7 @@ msgstr "Затваряне"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Затваряне"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4766,7 +4759,7 @@ msgstr "Затваряне на търсенето"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Затваряне на второто мнение"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5143,7 +5136,7 @@ msgstr "Продължи да блокираш рекламите"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Продължете последните чатове тук. Или ги изтрийте с Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5214,7 +5207,7 @@ msgstr "Данни за бисквитка:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Копирано"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5255,8 +5248,7 @@ msgstr "Копиране"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
+msgstr "Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5268,7 +5260,7 @@ msgstr "Копиране на кода"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Копиране на връзката"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5338,8 +5330,7 @@ msgstr "Коста Рика"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
+msgstr "Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5388,7 +5379,7 @@ msgstr "Създаване на изображение"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Създаване на връзка за споделяне"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5440,6 +5431,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"При създаване на връзка се прави копие на чата, което може да бъде видяно от "
+"всеки, който го отвори."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5598,7 +5591,7 @@ msgstr "Персонализиране на отговорите"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Персонализиране на отговорите"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5890,7 +5883,7 @@ msgstr "Изтриване на данните от сървъра?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Изтриване на споделената връзка"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5902,7 +5895,7 @@ msgstr "Изтриване на преписа"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Изтриване на чат"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5940,7 +5933,7 @@ msgstr "Изтриване на изображението?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Изтрийте ме"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6169,8 +6162,7 @@ msgstr "Деактивиране и изключване"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
+msgstr "Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6257,7 +6249,7 @@ msgstr "Пропусни промоцията"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Пропускане на обиколката"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6364,8 +6356,7 @@ msgstr "Не виждате DuckDuckGo в списъка?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
+msgstr "Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6474,7 +6465,7 @@ msgstr "Изтегляне на DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Изтегляне на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6689,14 +6680,13 @@ msgstr "Условия за ползване на Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
+msgstr "Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai вече може да анализира PDF файлове. Изпробвайте го!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6736,8 +6726,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
+msgstr "Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6787,8 +6776,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
+msgstr "Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6819,8 +6807,8 @@ msgstr ""
 "интелект на трети страни, включително модели от OpenAI, Anthropic и други. "
 "Ако изключите тази настройка, бутоните и връзките на Duck.ai в DuckDuckGo "
 "Search ще се скрият. Въпреки това можете да получите достъп до Duck.ai, "
-"когато тази настройка е изключена, като посетите директно %1$shttps://duck."
-"ai%2$s ."
+"когато тази настройка е изключена, като посетите директно "
+"%1$shttps://duck.ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6857,7 +6845,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai поддържа модели от Anthropic, OpenAI и други."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7060,8 +7048,8 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
 msgstr ""
-"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново по-"
-"късно."
+"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7512,7 +7500,7 @@ msgstr "Активиране на най-често посещавани сай�
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Активирайте сега"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7682,15 +7670,13 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
+msgstr "Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
+msgstr "Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7720,15 +7706,13 @@ msgstr "Уверете се, че достъпът до местоположен
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
+msgstr "Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
+msgstr "Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7824,7 +7808,7 @@ msgstr "Екскурзовод за развлечения"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Целият чат"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7834,8 +7818,7 @@ msgstr "Екваториална Гвинея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
+msgstr "Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7928,8 +7911,7 @@ msgstr "Обясни приетия отговор с прости думи."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
+msgstr "Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7995,20 +7977,19 @@ msgstr "Нецензуриран текст на песен"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Разгледайте Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Разгледайте Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
+msgstr "Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8109,7 +8090,7 @@ msgstr "Безплатно"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "БЕЗПЛАТНО И ПО ЖЕЛАНИЕ"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8313,8 +8294,7 @@ msgstr "Финансов консултант"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
+msgstr "Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8537,7 +8517,7 @@ msgstr "Освобождаване на място за съхранение"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Безплатно и винаги поверително"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8549,8 +8529,7 @@ msgstr "Безплатни и поверителни чатове, аноним�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
+msgstr "Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8796,15 +8775,13 @@ msgstr "Общо предназначение"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
+msgstr "Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
+msgstr "Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9064,7 +9041,7 @@ msgstr "Потърсете помощ от компютър"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Вземете по-високи лимити за използване с абонамент за DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9107,13 +9084,15 @@ msgstr "Инсталирайте най-новата версия"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Вземете приложението"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Вземете безплатния браузър DuckDuckGo, %1$sза да блокирате рекламите в "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9141,7 +9120,7 @@ msgstr "Убедете приятелите си да превключат и н
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Списък с първи стъпки"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9215,8 +9194,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
+msgstr "Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9833,7 +9811,7 @@ msgstr "Съвети за скриване"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Скриване на указанията"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9882,8 +9860,7 @@ msgstr "Скриване на Вашия имейл адрес"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
+msgstr "Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10145,8 +10122,7 @@ msgstr "Колко често искате да виждате отговори�
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
+msgstr "Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10284,8 +10260,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри книги/"
-"поредици има, които приличат най-много на нея, и защо?"
+"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри "
+"книги/поредици има, които приличат най-много на нея, и защо?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10911,8 +10887,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
+msgstr "Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10962,8 +10937,7 @@ msgstr "Той е бърз, безплатен и осигурява още по
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
+msgstr "Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11469,6 +11443,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Можете да превключвате между изпращане на заявки за търсене и подкани към "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11526,8 +11502,7 @@ msgstr "Ограничено съхранение на данни за този 
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr ""
-"Ограничава количеството описателно съдържание, което се показва с резултатите"
+msgstr "Ограничава количеството описателно съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11545,7 +11520,7 @@ msgstr "Спечелени тъчове"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Връзката изтича след 7 дни."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11674,8 +11649,7 @@ msgstr "Зареждане на още резултати с изображен�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"При превъртане зарежда повече резултати в изображения, видео и пазаруване"
+msgstr "При превъртане зарежда повече резултати в изображения, видео и пазаруване"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11704,8 +11678,7 @@ msgstr "Местоположение"
 #. Message informing users that location-based search is private.
 msgctxt "precise_user_location"
 msgid "Location information is stored only on your device."
-msgstr ""
-"Информацията за местоположението се съхранява само на вашето устройство."
+msgstr "Информацията за местоположението се съхранява само на вашето устройство."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -12651,7 +12624,7 @@ msgstr "Повече от 20 минути"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Още съвети"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13145,7 +13118,7 @@ msgstr "Не, благодаря"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Не, благодаря"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13813,7 +13786,7 @@ msgstr "Включено, но без номерация"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Регистрацията е завършена"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -14035,7 +14008,7 @@ msgstr "Отваряне на предложения за създаване и 
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Отваряне на списъка с първи стъпки"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14100,8 +14073,7 @@ msgstr "Отваряне на панела Как работи Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
+msgstr "Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14693,9 +14665,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"Ако формулирате своето търсене като въпрос и в пълно изречение, е по-"
-"вероятно DuckAssist да се появи и често допринася за по-добри отговори. За "
-"да настроите как да работи тази функция или да я изключите, отидете на "
+"Ако формулирате своето търсене като въпрос и в пълно изречение, е "
+"по-вероятно DuckAssist да се появи и често допринася за по-добри отговори. "
+"За да настроите как да работи тази функция или да я изключите, отидете на "
 "%1$sНастройки на DuckAssist%2$s."
 
 # smartling.placeholder_format=C
@@ -14789,7 +14761,7 @@ msgstr "Добавяне като отметка"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Закачане на чат"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14801,7 +14773,7 @@ msgstr "Закачете чатове от %1$s %2$s тук"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Закачете ме"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14824,7 +14796,7 @@ msgstr "Закачени"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15148,6 +15120,8 @@ msgstr "Лошо форматиране"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Налични са популярни AI модели. Не е необходим акаунт. Чатове, анонимизирани "
+"от нас."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15361,7 +15335,7 @@ msgstr "Предишни раздели"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Предишни съвети"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15907,13 +15881,13 @@ msgstr "AI за разсъждения със средно ниво на вгр�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "С обосновка може да получите по-подробни отговори на сложни въпроси."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15954,7 +15928,7 @@ msgstr "Съхраняването на последните чатове мож
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Последни чатове"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16115,7 +16089,7 @@ msgstr "Намаляване на употребата"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Намалете употребата с по-ефективен модел"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16276,8 +16250,7 @@ msgstr "Запомни моя избор"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
+msgstr "Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16499,7 +16472,7 @@ msgstr "Нулиране на всички настройки"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Рестартиране на указанията"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16517,7 +16490,7 @@ msgstr "Резолюция"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Отговор"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -17145,15 +17118,13 @@ msgstr "Шотландия"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
+msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
+msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17228,7 +17199,7 @@ msgstr "Искате да потърсите %1$s, за да намерите р
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Превключване на Търсене и Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17592,8 +17563,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
+msgstr "Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17609,7 +17579,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Съхранява се сигурно на нашия криптиран сървър."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17720,8 +17690,7 @@ msgstr "Вижте някои от най-новите ни актуализац
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
+msgstr "За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17761,8 +17730,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
+msgstr "Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17783,8 +17751,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
+msgstr "Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18133,7 +18100,7 @@ msgstr "Задай като Начална страница"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Задайте тона и стила на отговорите на Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18206,13 +18173,13 @@ msgstr "Сейшели"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Споделяне"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Споделяне"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18252,8 +18219,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Споделете местоположение на ниво град с AI моделите, за да получавате по-"
-"подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
+"Споделете местоположение на ниво град с AI моделите, за да получавате "
+"по-подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
 "нито на нас, нито на AI моделите."
 
 # smartling.placeholder_format=C
@@ -18261,7 +18228,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Споделяне на чат"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18325,7 +18292,7 @@ msgstr "Споделяне на положителен отзив"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Обхват на споделяне"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18466,7 +18433,7 @@ msgstr "Показване на подробности"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Показване на указанията за Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18621,7 +18588,7 @@ msgstr "Покажи повече"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Показване на още модели"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18662,7 +18629,7 @@ msgstr "Показване на страничната лента"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18760,8 +18727,7 @@ msgstr "Показва периодично напомняне за добавя
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
+msgstr "Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18779,8 +18745,7 @@ msgstr "Показва номерата на страниците в края н
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
+msgstr "Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18803,14 +18768,12 @@ msgstr "Показва фона на бутона за търсене"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Показва приветствие в горната част на страницата с резултати от търсенето"
+msgstr "Показва приветствие в горната част на страницата с резултати от търсенето"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
+msgstr "Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18882,14 +18845,12 @@ msgstr "Имена на сайтове"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
+msgstr "Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
+msgstr "Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19034,8 +18995,7 @@ msgstr "Нещо се обърка при запазването на сървъ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
+msgstr "Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19047,7 +19007,7 @@ msgstr "Възникна някаква грешка, опитайте отно�
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Възникна някаква грешка. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19065,8 +19025,7 @@ msgstr "Понякога"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
+msgstr "Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19141,8 +19100,8 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново по-"
-"късно."
+"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19350,7 +19309,7 @@ msgstr "Започнете да използвате седмичен лимит
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Стартиране на нов чат"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19458,8 +19417,7 @@ msgstr "Спрете скритите тракери, които се спота
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
+msgstr "Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19939,7 +19897,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Превключване към това второ мнение"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20103,7 +20061,7 @@ msgstr "Функцията за синхронизиране и архивира
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Синхронизиране на чатовете между устройствата"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20199,6 +20157,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Вземете Duck.ai навсякъде. Вземете го вграден в нашето безплатно приложение, "
+"за да имате по-бърз достъп навсякъде."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20207,6 +20167,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Вземете Duck.ai навсякъде. Вземете го вграден в нашия безплатен браузър, за "
+"да имате по-бърз достъп за сърфиране навсякъде."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20230,8 +20192,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим Duck."
-"ai."
+"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20595,8 +20557,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
+msgstr "Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20650,8 +20611,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
+msgstr "Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20667,8 +20627,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
+msgstr "Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20680,7 +20639,7 @@ msgstr "Този месец"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Този отговор"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20692,7 +20651,7 @@ msgstr "Тази седмица"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Този чат остава в Duck.ai и е поверителен."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20829,6 +20788,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Това е само примерен чат. Отворете менюто (трите точки) и след това изберете "
+"Закачане, за да го запазите най-отгоре в списъка с чатове!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20837,6 +20798,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Това е просто примерен чат. Използвайте Fire Button в страничното меню, за "
+"да го изтриете!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20957,8 +20920,7 @@ msgstr "Този превод е грешен"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
+msgstr "Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21188,6 +21150,8 @@ msgstr "Днес"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Превключете, за да изпробвате поверителен чат с AI, или %1$sго изключете от "
+"менюто %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21410,8 +21374,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от английски на френски: „Как да стигна до най-"
-"близкото кино?“"
+"Преведи това изречение от английски на френски: „Как да стигна до "
+"най-близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21420,8 +21384,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от български на английски: „Как да стигна до най-"
-"близкото кино?“"
+"Преведи това изречение от български на английски: „Как да стигна до "
+"най-близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21539,8 +21503,7 @@ msgstr "Изпробвайте %1$s — първият ни модел с нул
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
+msgstr "Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -21605,7 +21568,7 @@ msgstr "Изпробвайте ги"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Изпробвайте друг модел"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21616,7 +21579,7 @@ msgstr "Опитайте търсене!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Опитайте с предложена подкана"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21690,7 +21653,7 @@ msgstr "Безплатна проба"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Изпробвайте безплатно"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21712,7 +21675,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Изпробвайте безплатно за 7 дни"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21739,14 +21702,13 @@ msgstr "Изпробвайте нашия браузър"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Опитайте нашата начална страница, която никога не показва тези съобщения:"
+msgstr "Опитайте нашата начална страница, която никога не показва тези съобщения:"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Изпробвайте обосновката"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -22001,7 +21963,7 @@ msgstr "Включете Duck Player, за да гледате YouTube без н
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Активиране на превключвател за Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22219,8 +22181,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
+msgstr "Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22238,8 +22199,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
+msgstr "В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22380,7 +22340,7 @@ msgstr "Отключете усъвършенстван AI заедно с аб�
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Отключване на усъвършенствани модели"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22749,7 +22709,7 @@ msgstr "Използвайте в Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Използвайте Fire Button, за да изтриете чат от историята."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22774,8 +22734,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Да се използва приблизителното Ви местоположение за по-точни резултати?"
+msgstr "Да се използва приблизителното Ви местоположение за по-точни резултати?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23253,8 +23212,8 @@ msgstr "Ние анонимизираме"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме по-"
-"точни резултати."
+"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме "
+"по-точни резултати."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23366,8 +23325,7 @@ msgstr "Ние не ви проследяваме. Никога."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
+msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23408,8 +23366,7 @@ msgstr "Не ви следим нито във, нито извън режима
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
+msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23536,8 +23493,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
+msgstr "Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23702,8 +23658,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
+msgstr "Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23794,15 +23749,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
+msgstr "Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Кои атракции трябва да види един турист, който посещава Париж за първи път?"
+msgstr "Кои атракции трябва да види един турист, който посещава Париж за първи път?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23921,8 +23874,7 @@ msgstr "Кои са ястията, които задължително тряб
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Какво е работното време, местоположението и данните за контакт на това място?"
+msgstr "Какво е работното време, местоположението и данните за контакт на това място?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23952,7 +23904,7 @@ msgstr "Какво ви върна тук днес?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Какво можете да правите?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24381,6 +24333,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Чатовете с Duck.ai са анонимизирани и никога не се използват за обучение на "
+"изкуствен интелект. Включете или изключете по всяко време в менюто '%1$s'."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24772,8 +24726,7 @@ msgstr "Можете да продължите този чат, като изп�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
+msgstr "Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24816,7 +24769,7 @@ msgstr "Можете да прикачите само %1$s изображени�
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Можете да прикачите до %1$s раздела едновременно."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24850,8 +24803,7 @@ msgstr "Можете да възстановите настройките си, 
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr ""
-"Можете да споделяте и използвате настройките си с други компютри и браузъри."
+msgstr "Можете да споделяте и използвате настройките си с други компютри и браузъри."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -24967,7 +24919,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Всичко е готово!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -25020,7 +24972,7 @@ msgstr "Блокирали сте 1 сайт"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Запознахте се с основните функции на Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25041,15 +24993,14 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново по-"
-"късно."
+"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Достигнали сте максималната продължителност на гласовия чат за една сесия."
+msgstr "Достигнали сте максималната продължителност на гласовия чат за една сесия."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25061,8 +25012,7 @@ msgstr "Достигнали сте лимита за гласов чат за �
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
+msgstr "Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25071,8 +25021,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в Duck."
-"ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
+"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в "
+"Duck.ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
 "синхронизирането. Закачените чатове няма да бъдат изтрити."
 
 # smartling.placeholder_format=C
@@ -25100,8 +25050,8 @@ msgid ""
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
 "YouTube (притежаван от Google) не позволява да гледате видео анонимно. "
-"Следователно гледането на YouTube видео тук ще бъде следено от YouTube/"
-"Google."
+"Следователно гледането на YouTube видео тук ще бъде следено от "
+"YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25224,8 +25174,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Чатовете са поверителни и никога не се използват за обучение на AI модели"
+msgstr "Чатовете са поверителни и никога не се използват за обучение на AI модели"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25286,8 +25235,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
+msgstr "Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25430,6 +25378,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Настройките са запазени, но ще се нулират, ако изчистите бисквитките. "
+"Активирайте разширението %1$sDuckDuckGo No AI%2$s, за да ги направите "
+"постоянни."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25513,8 +25464,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
+msgstr "Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25597,8 +25547,7 @@ msgstr "от %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
+msgstr "от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26029,4 +25978,4 @@ msgstr "год."
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/bn_BD/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_BD/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3677,6 +3709,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3712,6 +3749,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4019,6 +4061,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4073,6 +4120,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4110,6 +4162,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4206,6 +4263,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4240,6 +4302,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4365,6 +4434,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4601,9 +4675,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4631,6 +4715,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4884,6 +4973,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5050,6 +5144,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5225,6 +5324,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5332,6 +5436,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5832,6 +5941,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6072,6 +6186,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6205,6 +6324,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6286,6 +6415,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6617,6 +6751,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7038,6 +7177,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7067,6 +7211,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7084,6 +7238,11 @@ msgstr "এই গানটি পাবেনঃ"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "আপনার বন্ধুদের জানান আর আমাদেরকে বেড়ে উঠতে সাহায্য করুন!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7634,6 +7793,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8935,6 +9099,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8990,6 +9160,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9887,6 +10062,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10281,6 +10461,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10831,6 +11016,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "নির্ধারন"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11001,6 +11191,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11597,9 +11792,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11614,6 +11819,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11870,6 +12080,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12039,6 +12254,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12481,6 +12701,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12508,6 +12738,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12630,6 +12865,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12932,6 +13172,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "সব সেটিংস রিসেট করো"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12940,6 +13185,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13497,6 +13747,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13777,6 +14032,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14180,6 +14440,11 @@ msgstr "ডিফল্ট সার্চ ইঞ্জিন হিসেবে
 msgid "Set as Homepage"
 msgstr "হোমপেজ হিসেবে ব্যবহার করুন"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14232,6 +14497,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14261,6 +14536,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14309,6 +14590,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14420,6 +14706,11 @@ msgstr "বুকমার্কলেট এবং সেটিংস তথ্
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14544,6 +14835,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14572,6 +14868,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14871,6 +15172,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15103,6 +15409,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15581,6 +15892,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15693,6 +16011,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15762,6 +16085,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16131,9 +16468,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16234,6 +16581,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16491,6 +16852,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16828,9 +17194,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "একটি অনুসন্ধান করুন!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16884,6 +17260,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16894,6 +17275,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16917,6 +17303,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "আমাদের হোমপেজ দেখুন যেটা এসব ম্যাসেজ কখনোই দেখায় না:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17116,6 +17507,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17402,6 +17798,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17698,6 +18099,11 @@ msgstr ""
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Safari-তে ব্যবহার করুন"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18610,6 +19016,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18949,6 +19360,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19295,6 +19713,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19404,6 +19828,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19438,6 +19867,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19737,6 +20171,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20210,6 +20651,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/bn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_IN/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3675,6 +3707,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3710,6 +3747,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4017,6 +4059,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4071,6 +4118,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4108,6 +4160,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4204,6 +4261,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4238,6 +4300,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4363,6 +4432,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4599,9 +4673,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4629,6 +4713,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4882,6 +4971,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5048,6 +5142,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5223,6 +5322,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5330,6 +5434,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5830,6 +5939,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6069,6 +6183,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6202,6 +6321,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6283,6 +6412,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6612,6 +6746,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7033,6 +7172,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7062,6 +7206,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7078,6 +7232,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7629,6 +7788,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8926,6 +9090,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8981,6 +9151,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9877,6 +10052,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10271,6 +10451,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10819,6 +11004,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "চালু কিন্তু কোন সংখ্যা নয়"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10987,6 +11177,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11583,9 +11778,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11600,6 +11805,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11856,6 +12066,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12025,6 +12240,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12467,6 +12687,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12494,6 +12724,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12616,6 +12851,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12918,6 +13158,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12926,6 +13171,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13483,6 +13733,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13765,6 +14020,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14162,6 +14422,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "হোমপেজ হিসেবে নির্বাচন করুন "
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14214,6 +14479,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14243,6 +14518,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14291,6 +14572,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14402,6 +14688,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14526,6 +14817,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14554,6 +14850,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14852,6 +15153,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15084,6 +15390,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15562,6 +15873,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15674,6 +15992,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15743,6 +16066,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16112,9 +16449,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16215,6 +16562,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16471,6 +16832,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16808,8 +17174,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16864,6 +17240,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16874,6 +17255,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16896,6 +17282,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17096,6 +17487,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17380,6 +17776,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17675,6 +18076,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18588,6 +18994,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18927,6 +19338,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19273,6 +19691,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19381,6 +19805,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19415,6 +19844,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19712,6 +20146,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20186,6 +20627,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/bo_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bo_CN/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4013,6 +4055,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4067,6 +4114,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4104,6 +4156,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4200,6 +4257,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4234,6 +4296,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4359,6 +4428,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4595,9 +4669,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4625,6 +4709,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4878,6 +4967,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5044,6 +5138,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5219,6 +5318,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5326,6 +5430,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5814,6 +5923,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6053,6 +6167,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6186,6 +6305,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6267,6 +6396,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6596,6 +6730,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7017,6 +7156,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7046,6 +7190,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7062,6 +7216,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7613,6 +7772,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8908,6 +9072,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8963,6 +9133,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9859,6 +10034,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10253,6 +10433,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10801,6 +10986,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr ""
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10969,6 +11159,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11565,9 +11760,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11582,6 +11787,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11838,6 +12048,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12007,6 +12222,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12449,6 +12669,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12476,6 +12706,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12598,6 +12833,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12900,6 +13140,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12908,6 +13153,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13465,6 +13715,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13745,6 +14000,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14142,6 +14402,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14194,6 +14459,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14223,6 +14498,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14271,6 +14552,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14382,6 +14668,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14506,6 +14797,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14534,6 +14830,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14832,6 +15133,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15064,6 +15370,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15542,6 +15853,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15654,6 +15972,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15723,6 +16046,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16092,9 +16429,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16195,6 +16542,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16451,6 +16812,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16788,8 +17154,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16844,6 +17220,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16854,6 +17235,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16876,6 +17262,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17076,6 +17467,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17360,6 +17756,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17655,6 +18056,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18568,6 +18974,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18907,6 +19318,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19251,6 +19669,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19359,6 +19783,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19393,6 +19822,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19690,6 +20124,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20162,4 +20603,9 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""

--- a/locales/br_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/br_FR/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3683,6 +3715,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3718,6 +3755,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4025,6 +4067,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4079,6 +4126,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4116,6 +4168,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4212,6 +4269,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4246,6 +4308,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4371,6 +4440,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4607,9 +4681,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4637,6 +4721,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4890,6 +4979,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5056,6 +5150,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5231,6 +5330,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5338,6 +5442,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5826,6 +5935,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6066,6 +6180,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6199,6 +6318,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6280,6 +6409,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6612,6 +6746,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7033,6 +7172,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7062,6 +7206,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7078,6 +7232,11 @@ msgstr "Kaout an ton-mañ digant :"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7629,6 +7788,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8928,6 +9092,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8983,6 +9153,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9881,6 +10056,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10275,6 +10455,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10826,6 +11011,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Gweredekaet, niverenn ebet, 'vat"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10996,6 +11186,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11592,9 +11787,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11609,6 +11814,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11865,6 +12075,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12034,6 +12249,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12476,6 +12696,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12503,6 +12733,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12625,6 +12860,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12927,6 +13167,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Adderaouekaat an holl arventennoù"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12935,6 +13180,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13492,6 +13742,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13774,6 +14029,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14176,6 +14436,11 @@ msgstr "Kefluniañ da geflusker klask dre ziouer"
 msgid "Set as Homepage"
 msgstr "Lakaat da bennbajenn"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14228,6 +14493,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14257,6 +14532,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14305,6 +14586,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14416,6 +14702,11 @@ msgstr "Diskouez ar sined ha roadennoù an arventennoù"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14540,6 +14831,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14568,6 +14864,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14868,6 +15169,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15100,6 +15406,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15578,6 +15889,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15690,6 +16008,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15759,6 +16082,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16128,9 +16465,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16231,6 +16578,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16489,6 +16850,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16826,9 +17192,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "kas ur c'hlask"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16882,6 +17258,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16892,6 +17273,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16914,6 +17300,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17114,6 +17505,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17405,6 +17801,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17701,6 +18102,11 @@ msgstr ""
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Arverañ e Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18613,6 +19019,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18954,6 +19365,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19300,6 +19718,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19408,6 +19832,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19442,6 +19871,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19741,6 +20175,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20215,6 +20656,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/bs_BA/LC_MESSAGES/duckduckgo.po
+++ b/locales/bs_BA/LC_MESSAGES/duckduckgo.po
@@ -111,6 +111,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%s prepoznat"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -292,6 +297,11 @@ msgstr "Broj blokiranih pokušaja praćenja: %s"
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -492,6 +502,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "prije 1 dan"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1233,6 +1248,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Reklamiraj se na pretrazi"
@@ -1859,6 +1881,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3114,6 +3141,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3723,6 +3755,11 @@ msgstr "Clipart"
 msgid "Close"
 msgstr "Zatvori"
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3758,6 +3795,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4065,6 +4107,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4119,6 +4166,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr "Sadržaj kolačića:"
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4156,6 +4208,11 @@ msgstr "Kopirajte i zalijepite %sabout:preferences#search%s u adresnu traku"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4252,6 +4309,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4286,6 +4348,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4411,6 +4480,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4647,9 +4721,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4677,6 +4761,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4930,6 +5019,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5096,6 +5190,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5271,6 +5370,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5378,6 +5482,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5880,6 +5989,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Prikaži najposjećenije sajtove"
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6125,6 +6239,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6258,6 +6377,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6339,6 +6468,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6672,6 +6806,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7093,6 +7232,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7124,6 +7268,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7141,6 +7295,11 @@ msgstr "Preuzmi pjesmu na:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Dovedite prijatelje da se prebace i pomozite nam u rastu!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr "Gana"
@@ -7691,6 +7850,11 @@ msgstr "Sakrij korake"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -9017,6 +9181,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Omogućuje anonimno pretraživanje pomoću DuckDuckGoa"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9072,6 +9242,11 @@ msgstr "Crtež linije"
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9969,6 +10144,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Duži od 20 minuta"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10363,6 +10543,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10913,6 +11098,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Uključeno, ali bez brojeva"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11085,6 +11275,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11691,9 +11886,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11708,6 +11913,11 @@ msgstr "Ružičasta"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11964,6 +12174,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12133,6 +12348,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12577,6 +12797,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12604,6 +12834,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12726,6 +12961,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -13033,6 +13273,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Resetiraj sve postavke"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -13041,6 +13286,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13602,6 +13852,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr "Da tražim %s za rezultate bliže Vama?"
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Traži anonimno"
 
@@ -13887,6 +14142,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14291,6 +14551,11 @@ msgstr "Postavite za predodređenog pretraživača"
 msgid "Set as Homepage"
 msgstr "Postavite za početnu stranicu"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14344,6 +14609,16 @@ msgstr "Postavke ažurirane"
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14373,6 +14648,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14422,6 +14703,11 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Podijeli pozitivne povratne informacije"
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
@@ -14533,6 +14819,11 @@ msgstr "Prikaži oznaku i podatke o postavkama"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Prikaži detalje"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14656,6 +14947,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14684,6 +14980,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14989,6 +15290,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15223,6 +15529,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15704,6 +16015,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Prebacite se na pretraživač koji Vas nikad ne prati."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15816,6 +16134,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15886,6 +16209,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Vratite svoju privatnost!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16263,9 +16600,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16367,6 +16714,20 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Informacija nije korisna"
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
@@ -16626,6 +16987,11 @@ msgstr "Danas"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16963,9 +17329,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Isprobajte pretragu!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -17019,6 +17395,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -17029,6 +17410,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -17052,6 +17438,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Isprobajte početnu stranicu koja nikad ne prikazuje ove poruke:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17251,6 +17642,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17543,6 +17939,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17840,6 +18241,11 @@ msgstr "Koristi u Firefoxu"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Koristi u Safariju"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18775,6 +19181,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Šta Vas je dovelo nazad danas?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19119,6 +19530,13 @@ msgstr "Pobjeda"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Razne zimske nepogode"
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
@@ -19465,6 +19883,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19573,6 +19997,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19611,6 +20040,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19919,6 +20353,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20392,6 +20833,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "god"
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
 
 #~ msgctxt "SERP footer content"
 #~ msgid "%s Billion Searches"

--- a/locales/ca_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ca_ES/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%s detectat"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -492,6 +502,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "fa 1 dia"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1233,6 +1248,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1861,6 +1883,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3112,6 +3139,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3724,6 +3756,11 @@ msgstr "Fitxer d'imatges"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3759,6 +3796,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4066,6 +4108,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4120,6 +4167,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr "Dades de les galetes:"
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4157,6 +4209,11 @@ msgstr "Copia i enganxa %sabout:preferences#search%s a la barra d'adreces"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4253,6 +4310,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4287,6 +4349,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4412,6 +4481,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4648,9 +4722,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4678,6 +4762,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4931,6 +5020,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5098,6 +5192,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5273,6 +5372,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5380,6 +5484,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5882,6 +5991,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6133,6 +6247,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6266,6 +6385,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6347,6 +6476,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6678,6 +6812,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7099,6 +7238,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7130,6 +7274,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7147,6 +7301,11 @@ msgstr "Obtingueu aquesta cançó a:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Feu que els teus amics es canviïn i ens ajudin a créixer!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr "Ghana"
@@ -7698,6 +7857,11 @@ msgstr "Amaga els passos"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -9030,6 +9194,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Us permet cercar de manera anònima amb el DuckDuckGo"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9085,6 +9255,11 @@ msgstr "Dibuix lineal"
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9982,6 +10157,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Més de 20 minuts"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10376,6 +10556,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10926,6 +11111,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activat però sense números"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11098,6 +11288,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11704,9 +11899,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11721,6 +11926,11 @@ msgstr "Rosa"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11978,6 +12188,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12147,6 +12362,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12591,6 +12811,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12618,6 +12848,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12740,6 +12975,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -13046,6 +13286,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restableix totes les configuracions"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -13054,6 +13299,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13620,6 +13870,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr "Cerqueu %s per trobar resultats més a prop vostre?"
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Cerca anònima"
 
@@ -13905,6 +14160,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14314,6 +14574,11 @@ msgstr "Estableix com a motor de cerca per defecte"
 msgid "Set as Homepage"
 msgstr "Estableix com a pàgina d'inici"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14368,6 +14633,16 @@ msgstr "S'ha actualitzat la configuració"
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14398,6 +14673,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14446,6 +14727,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14558,6 +14844,11 @@ msgstr "Mostra els preferits i les dades de configuració"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Mostra el detall"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14681,6 +14972,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14709,6 +15005,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -15019,6 +15320,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15251,6 +15557,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15732,6 +16043,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Canvieu al motor de cerca que no us segueix. Mai."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15844,6 +16162,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15914,6 +16237,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Recupereu la vostra privadesa!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16292,9 +16629,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16395,6 +16742,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16655,6 +17016,11 @@ msgstr "Avui"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16992,9 +17358,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Proveu una cerca!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -17049,6 +17425,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -17059,6 +17440,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -17082,6 +17468,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Proveu la nostra pàgina d'inici que mai no mostra aquests missatges:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17281,6 +17672,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17572,6 +17968,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17869,6 +18270,11 @@ msgstr "Utilitza al Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Utilitza al Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18803,6 +19209,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Què us porta per aquí avui?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19144,6 +19555,13 @@ msgstr "Victories"
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19490,6 +19908,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19599,6 +20023,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19638,6 +20067,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19946,6 +20380,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20421,6 +20862,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "any"
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
 
 #~ msgctxt "SERP footer content"
 #~ msgid "%s Billion Searches"

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -98,8 +98,7 @@ msgstr "Počet pokusů: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
+msgstr "Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -128,7 +127,7 @@ msgstr "Rozpoznaný jazyk: %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Použito %1$s souborů"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,7 +364,7 @@ msgstr "Využito %1$s"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s využívá limity až 2–5× rychleji než základní modely %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -494,8 +493,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
+msgstr "%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -507,8 +505,7 @@ msgstr "%1$sPodrž%2$s ikonu aplikace DuckDuckGo na domovské obrazovce"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
+msgstr "%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -620,7 +617,7 @@ msgstr "Před 1 dnem"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "Použit 1 soubor"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -841,8 +838,7 @@ msgstr "Byl vyčerpán 6hodinový limit využití."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -913,8 +909,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
+msgstr "Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1536,7 +1531,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
+msgstr "Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1820,8 +1815,7 @@ msgstr "Povolit anonymní kontrolu souborů pro tento chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
+msgstr "Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2154,8 +2148,7 @@ msgstr "Jsi tam ještě?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
+msgstr "Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2327,7 +2320,7 @@ msgstr "Zeptej se soukromě"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Zeptej se soukromě"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -3267,8 +3260,7 @@ msgstr "Kliknutím na „%1$s“ odsouhlasíš naše %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
+msgstr "Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3347,8 +3339,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
+msgstr "Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3887,7 +3878,7 @@ msgstr "Soukromý chat s AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Chatuj soukromě s oblíbenými AI"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4433,15 +4424,13 @@ msgstr "Klikni %1$ssem%2$s a stáhni si rozšíření DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
+msgstr "Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
+msgstr "V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4688,7 +4677,7 @@ msgstr "Zavřít"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Zavřít"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4738,7 +4727,7 @@ msgstr "Zavřít vyhledávání"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Zavřít jiný názor"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5116,6 +5105,8 @@ msgstr "Pokračovat v blokování reklam"
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
+"Tady můžeš pokračovat v nedávných chatech. Nebo je smaž tlačítkem Fire "
+"Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5186,7 +5177,7 @@ msgstr "Údaje o souborech cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Zkopírováno"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5239,7 +5230,7 @@ msgstr "Kopírovat kód"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopírovat odkaz"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5360,7 +5351,7 @@ msgstr "Vytvoř obrázek"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Vytvořit odkaz ke sdílení"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5412,6 +5403,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Vytvořením odkazu vznikne kopie chatu, kterou si může zobrazit každý, kdo ji "
+"otevře."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5570,7 +5563,7 @@ msgstr "Přizpůsobit odpovědi"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Přizpůsobit odpovědi"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5637,8 +5630,7 @@ msgstr "Byl vyčerpán denní limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5861,7 +5853,7 @@ msgstr "Smazat data ze serveru?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Smazat sdílený odkaz"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5873,7 +5865,7 @@ msgstr "Smazat přepis"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Smazat chat"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5911,7 +5903,7 @@ msgstr "Smazat obrázek?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Smaž mě"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6225,7 +6217,7 @@ msgstr "Zavřít propagační akci"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Odmítnout průvodce"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6332,8 +6324,7 @@ msgstr "Nevidíš v seznamu DuckDuckGo?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
+msgstr "Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6442,7 +6433,7 @@ msgstr "Stáhnout DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Stáhnout DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6663,7 +6654,7 @@ msgstr "Duck.ai od DuckDuckGo. Soukromý AI chat. Zadarmo."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai teď umí analyzovat PDF soubory. Zkus to!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6702,8 +6693,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
+msgstr "Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6791,8 +6781,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
+msgstr "Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6823,7 +6812,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai podporuje modely od Anthropic, OpenAI a dalších."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6841,8 +6830,7 @@ msgstr "Upgrade Duck.ai je hotový!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
+msgstr "Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7019,8 +7007,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
+msgstr "DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7473,7 +7460,7 @@ msgstr "Povolit nejnavštěvovanější weby"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Zapnout teď"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7776,7 +7763,7 @@ msgstr "Průvodce zábavou"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Celý chat"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7786,8 +7773,7 @@ msgstr "Rovníková Guinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
+msgstr "Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7946,13 +7932,13 @@ msgstr "Explicitní texty"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Prozkoumej Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Prozkoumej Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8059,7 +8045,7 @@ msgstr "Zadarmo"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "ZDARMA A VOLITELNÉ"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8136,8 +8122,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
+msgstr "Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8214,8 +8199,7 @@ msgstr "Filtry nefungují"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
+msgstr "Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8384,8 +8368,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
+msgstr "Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8484,7 +8467,7 @@ msgstr "Uvolnit úložiště"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Zdarma a vždycky soukromé"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8496,8 +8479,7 @@ msgstr "Bezplatné a soukromé chaty, které anonymizujeme"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
+msgstr "Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9003,7 +8985,7 @@ msgstr "Nech si poradit s počítačem"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Získej vyšší limity využití s předplatným DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9046,13 +9028,15 @@ msgstr "Stáhnout nejnovější verzi"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Stáhnout aplikaci"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9080,7 +9064,7 @@ msgstr "Řekni o nás přátelům a pomoz nám růst."
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Kontrolní seznam do začátku"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9772,7 +9756,7 @@ msgstr "Skrýt tipy"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Skrýt tutoriál"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10063,8 +10047,7 @@ msgstr "Jak to funguje"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
+msgstr "Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10312,8 +10295,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
+msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10322,8 +10304,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
+msgstr "Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10842,8 +10823,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
+msgstr "Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11398,7 +11378,7 @@ msgstr "Umožní ti anonymně vyhledávat pomocí DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11474,7 +11454,7 @@ msgstr "Vyhrané vhazování"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Platnost odkazu skončí za 7 dní."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11781,8 +11761,7 @@ msgstr "Ujisti se, že jsou všechna slova napsaná správně."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
+msgstr "Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12361,8 +12340,7 @@ msgstr "Byl vyčerpán měsíční limit"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12574,7 +12552,7 @@ msgstr "Více než 20 minut"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Další tipy"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13067,7 +13045,7 @@ msgstr "Ne, děkuji"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Ne, děkuji"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13215,8 +13193,7 @@ msgstr "Nebyly nalezeny žádné výsledky."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
+msgstr "Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13736,7 +13713,7 @@ msgstr "Zapnuto bez čísel"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Průvodce dokončen"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13795,8 +13772,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
+msgstr "Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13871,8 +13847,7 @@ msgstr "Otevřít %1$sNastavení%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
+msgstr "Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13956,7 +13931,7 @@ msgstr "Otevřít návrhy na vytváření a úpravu obrázků"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Otevřít kontrolní seznam pro začátečníky"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14707,7 +14682,7 @@ msgstr "Připnout"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Připnout chat"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14719,7 +14694,7 @@ msgstr "Připni sem chaty z %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Připni mě"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14742,7 +14717,7 @@ msgstr "Připnuté"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Připnuté chaty se zobrazí nahoře v tvých nedávných chatech."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15062,6 +15037,8 @@ msgstr "Špatné formátování"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Jsou dostupné oblíbené AI modely. Není potřeba žádný účet. Chaty "
+"anonymizujeme."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15275,7 +15252,7 @@ msgstr "Předchozí karty"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Předchozí tipy"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15570,8 +15547,7 @@ msgstr "Upozornit"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
+msgstr "Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15613,8 +15589,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
+msgstr "Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15819,13 +15794,13 @@ msgstr "Umělá inteligence s vysokou mírou moderace"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Uvažování může poskytnout lepší odpovědi na složité otázky."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Uvažování je důkladnější, ale limity vyčerpá 2–5× rychleji. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15866,7 +15841,7 @@ msgstr "Uložené nedávné chaty můžeš upravit v %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Nedávné chaty"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16026,7 +16001,7 @@ msgstr "Omez čerpání"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Omez čerpání pomocí efektivnějšího modelu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16411,7 +16386,7 @@ msgstr "Obnovit všechna nastavení"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Resetovat tutoriál"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16429,7 +16404,7 @@ msgstr "Rozlišení"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Odpověď"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16703,8 +16678,7 @@ msgstr "SV"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
+msgstr "Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -16771,8 +16745,7 @@ msgstr "Bezpečné vyhledávání zablokovalo výsledky pro %1$s."
 # smartling.placeholder_format=C
 #. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
 msgid "Safe search blocked some results for %s."
-msgstr ""
-"Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
+msgstr "Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
 
 # smartling.placeholder_format=C
 #. Safe search lets you remove adult content from results on DuckDuckGo. This string is used to invite users to select the desired level of protection (e.g., strict, moderate, off)
@@ -16920,8 +16893,7 @@ msgstr "Ukládej až 30 svých nejnovějších chatů lokálně na své zaříze
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
+msgstr "Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17098,8 +17070,7 @@ msgstr "Přejdi dolů a vyhledej %1$ssvůj prohlížeč%2$s v seznamu."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
+msgstr "Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17133,7 +17104,7 @@ msgstr "Hledat %1$s a najít bližší výsledky?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Přepínač Vyhledávání & Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17510,7 +17481,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Bezpečně uloženo na našem šifrovaném serveru."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17655,14 +17626,13 @@ msgstr "V Safari zvol %1$sNastavení pro tuto webovou stránku...%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej %3$shttps://"
-"duckduckgo.com%4$s"
+"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
+msgstr "Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17804,8 +17774,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
+msgstr "V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18023,7 +17992,7 @@ msgstr "Nastavit jako domovskou stránku"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Nastav tón a styl odpovědí Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18045,8 +18014,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
+msgstr "Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18095,13 +18063,13 @@ msgstr "Seychely"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Sdílet"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Sdílet"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18139,15 +18107,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. Duck."
-"ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
+"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. "
+"Duck.ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Sdílet chat"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18211,7 +18179,7 @@ msgstr "Sdílet pozitivní zpětnou vazbu"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Rozsah sdílení"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18352,7 +18320,7 @@ msgstr "Zobrazit detail"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Zobrazit návod k Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18507,7 +18475,7 @@ msgstr "Zobrazit více"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Zobrazit více modelů"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18548,7 +18516,7 @@ msgstr "Zobrazit postranní panel"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Zobrazit tipy krok za krokem, jak z Duck.ai vytěžit maximum."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18928,7 +18896,7 @@ msgstr "Něco se pokazilo, zkus to znovu později."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Něco se pokazilo. Zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19074,8 +19042,7 @@ msgstr "Vymazaný zdrojový text"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
+msgstr "Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19227,7 +19194,7 @@ msgstr "Začít vyžívat týdenní limit"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Zahaj nový chat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19813,7 +19780,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Přepni na tento jiný názor"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19970,7 +19937,7 @@ msgstr "Funkce Sync & Backup je dočasně nedostupná"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Synchronizuj chaty napříč zařízeními"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20066,6 +20033,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Vezmi si Duck.ai všude s sebou. Integruj si ji do naší bezplatné aplikaci "
+"pro rychlejší přístup, ať jsi kdekoli."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20074,6 +20043,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Vezmi si Duck.ai všude s sebou. Integruj si ji do našeho bezplatného "
+"prohlížeče pro rychlejší přístup, ať brouzdáš kdekoli."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20096,8 +20067,7 @@ msgstr "Měj osobní údaje ve svých rukou!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
+msgstr "Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20296,15 +20266,13 @@ msgstr "Děkujeme za zpětnou vazbu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -20364,8 +20332,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
+msgstr "Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20516,8 +20483,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
+msgstr "Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20545,7 +20511,7 @@ msgstr "Tento měsíc"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Tato odpověď"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20557,7 +20523,7 @@ msgstr "Tento týden"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Tento chat zůstává v Duck.ai a zůstává pro tebe soukromý."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20698,6 +20664,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Toto je jen ukázkový chat. Otevři jeho nabídku (tři tečky) a pak vyber "
+"Připnout, aby zůstal nahoře mezi tvými chaty!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20706,6 +20674,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Toto je jen ukázkový chat. K jeho smazání použij tlačítko Fire Button v "
+"postranní nabídce!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20823,15 +20793,13 @@ msgstr "Tento překlad je špatný"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
+msgstr "Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
+msgstr "Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21047,7 +21015,7 @@ msgstr "Dnes"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
+msgstr "Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21395,8 +21363,7 @@ msgstr "Zkus přejít na %1$s a podobné zprávy už ti nebudeme ukazovat."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
+msgstr "Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21465,7 +21432,7 @@ msgstr "Vyzkoušej je"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Zkus jiný model"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21476,7 +21443,7 @@ msgstr "Vyzkoušej vyhledávání"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Zkus návrh"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21544,7 +21511,7 @@ msgstr "Vyzkoušej zdarma"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Zkus to zdarma"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21564,7 +21531,7 @@ msgstr "Vyzkoušej to zdarma! Bezpečná VPN, špičková soukromá AI a mnohem 
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Vyzkoušej zdarma na 7 dní"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21597,7 +21564,7 @@ msgstr "Zkus naši domovskou stránku, která tyto zprávy nikdy nezobrazuje:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Vyzkoušej uvažování"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21852,7 +21819,7 @@ msgstr "Zapni si Duck Player a dívej se na YouTube bez cílených reklam"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Zapni přepínač Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22070,8 +22037,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: https://duckduckgo."
-"com"
+"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22081,8 +22048,7 @@ msgstr "V nabídce %1$sNastavení vyhledávání%2$s zvol %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
+msgstr "Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22229,7 +22195,7 @@ msgstr "Pořiď si předplatné a získej špičkovou umělou inteligenci!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Odemkni pokročilé modely"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22456,8 +22422,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
+msgstr "Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22567,8 +22532,7 @@ msgstr "Použít vyhledávač Private Search od DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
+msgstr "Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22596,7 +22560,7 @@ msgstr "Použít v Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Tlačítkem Fire Button smažeš chat z historie."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23186,8 +23150,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
+msgstr "Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23208,8 +23171,7 @@ msgstr "Nesledujeme tě. Nikdy."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
+msgstr "My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23250,8 +23212,7 @@ msgstr "Nesledujeme tě. Ani v anonymním režimu ani mimo něj."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
+msgstr "My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23486,8 +23447,7 @@ msgstr "Byl vyčerpán týdenní limit využití"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23786,7 +23746,7 @@ msgstr "Co tě přivedlo zpět?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Co umíš?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24015,8 +23975,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
+msgstr "Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24212,6 +24171,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"S Duck.ai jsou tvoje chaty anonymizované a nikdy se nepoužívají k trénování "
+"AI. Můžeš ji kdykoli zapnout nebo vypnout v nabídce ‚%1$s’."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24644,7 +24605,7 @@ msgstr "Počet obrázků, které můžeš přiložit v jedné konverzaci: %1$s"
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Maximum karet, které jde přiložit najednou: %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24791,7 +24752,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "A je to!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24844,7 +24805,7 @@ msgstr "Máš zablokovaný 1 web"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Ovládl jsi základy Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25105,8 +25066,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
+msgstr "Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25217,8 +25177,7 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr ""
-"Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
+msgstr "Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25250,6 +25209,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Tvá nastavení jsou uložená, ale smazání cookies je vymaže. Aktivuj si "
+"rozšíření %1$sDuckDuckGo No AI%2$s, aby zůstala natrvalo."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25323,8 +25284,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
+msgstr "Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25626,8 +25586,7 @@ msgstr "oficiálních webových stránkách"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
+msgstr "nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25843,4 +25802,4 @@ msgstr "r."
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -98,7 +98,8 @@ msgstr "Počet pokusů: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
+msgstr ""
+"Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -122,6 +123,12 @@ msgstr "Před %1$s d."
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Rozpoznaný jazyk: %1$s"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +362,12 @@ msgid "%s used"
 msgstr "Využito %1$s"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s přehrání"
@@ -481,7 +494,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
+msgstr ""
+"%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -493,7 +507,8 @@ msgstr "%1$sPodrž%2$s ikonu aplikace DuckDuckGo na domovské obrazovce"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
+msgstr ""
+"%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -600,6 +615,12 @@ msgstr "Služba DuckDuckGo za posledních 24 hodin zablokovala 1 pokus"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Před 1 dnem"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -820,7 +841,8 @@ msgstr "Byl vyčerpán 6hodinový limit využití."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -891,7 +913,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
+msgstr ""
+"Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1508,6 +1531,14 @@ msgid "Advanced Models"
 msgstr "Pokročilé modely"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Reklama ve vyhledávání"
@@ -1789,7 +1820,8 @@ msgstr "Povolit anonymní kontrolu souborů pro tento chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
+msgstr ""
+"Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2122,7 +2154,8 @@ msgstr "Jsi tam ještě?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
+msgstr ""
+"Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2289,6 +2322,12 @@ msgstr "Zeptej se soukromě"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask privately"
 msgstr "Zeptej se soukromě"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -3228,7 +3267,8 @@ msgstr "Kliknutím na „%1$s“ odsouhlasíš naše %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
+msgstr ""
+"Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3307,7 +3347,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
+msgstr ""
+"Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3841,6 +3882,12 @@ msgstr "Zahajte soukromý chat s %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Soukromý chat s AI"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4386,13 +4433,15 @@ msgstr "Klikni %1$ssem%2$s a stáhni si rozšíření DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
+msgstr ""
+"Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
+msgstr ""
+"V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4636,6 +4685,12 @@ msgid "Close"
 msgstr "Zavřít"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4678,6 +4733,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Zavřít vyhledávání"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5051,6 +5112,12 @@ msgid "Continue Blocking Ads"
 msgstr "Pokračovat v blokování reklam"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5116,6 +5183,12 @@ msgid "Cookie data:"
 msgstr "Údaje o souborech cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5161,6 +5234,12 @@ msgstr "Do adresního řádku zkopíruj %1$sabout:preferences#search%2$s"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopírovat kód"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5278,6 +5357,12 @@ msgid "Create Image"
 msgstr "Vytvoř obrázek"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5319,6 +5404,14 @@ msgstr "Autor"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Vytvořeno službou %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5474,6 +5567,12 @@ msgid "Customize responses"
 msgstr "Přizpůsobit odpovědi"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "Přizpůsobení této stránky"
@@ -5538,7 +5637,8 @@ msgstr "Byl vyčerpán denní limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5758,10 +5858,22 @@ msgid "Delete Server Data?"
 msgstr "Smazat data ze serveru?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Smazat přepis"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5794,6 +5906,12 @@ msgstr "Smazat obrázek"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Smazat obrázek?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6104,6 +6222,12 @@ msgid "Dismiss promotion"
 msgstr "Zavřít propagační akci"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6208,7 +6332,8 @@ msgstr "Nevidíš v seznamu DuckDuckGo?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
+msgstr ""
+"Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6312,6 +6437,12 @@ msgstr "Stahování dokončeno"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Stáhnout DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6529,6 +6660,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai od DuckDuckGo. Soukromý AI chat. Zadarmo."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6565,7 +6702,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
+msgstr ""
+"Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6653,7 +6791,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
+msgstr ""
+"Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6681,6 +6820,12 @@ msgstr ""
 "nikdo nekontroluje."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6696,7 +6841,8 @@ msgstr "Upgrade Duck.ai je hotový!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
+msgstr ""
+"Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6873,7 +7019,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
+msgstr ""
+"DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7323,6 +7470,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Povolit nejnavštěvovanější weby"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7620,6 +7773,12 @@ msgid "Entertainment guide"
 msgstr "Průvodce zábavou"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Rovníková Guinea"
 
@@ -7627,7 +7786,8 @@ msgstr "Rovníková Guinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
+msgstr ""
+"Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7783,6 +7943,18 @@ msgid "Explicit lyrics"
 msgstr "Explicitní texty"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7884,6 +8056,12 @@ msgid "FREE"
 msgstr "Zadarmo"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7958,7 +8136,8 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
+msgstr ""
+"Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8035,7 +8214,8 @@ msgstr "Filtry nefungují"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
+msgstr ""
+"Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8204,7 +8384,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
+msgstr ""
+"Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8300,6 +8481,12 @@ msgid "Free Up Storage"
 msgstr "Uvolnit úložiště"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8309,7 +8496,8 @@ msgstr "Bezplatné a soukromé chaty, které anonymizujeme"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
+msgstr ""
+"Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8812,6 +9000,12 @@ msgid "Get computer help"
 msgstr "Nech si poradit s počítačem"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8849,6 +9043,18 @@ msgid "Get the Latest Version"
 msgstr "Stáhnout nejnovější verzi"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8869,6 +9075,12 @@ msgstr "Získat tuto píseň na:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Řekni o nás přátelům a pomoz nám růst."
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9557,6 +9769,12 @@ msgid "Hide Tips"
 msgstr "Skrýt tipy"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9845,7 +10063,8 @@ msgstr "Jak to funguje"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
+msgstr ""
+"Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10093,7 +10312,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
+msgstr ""
+"Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10102,7 +10322,8 @@ msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatn�
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
+msgstr ""
+"Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10621,7 +10842,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
+msgstr ""
+"Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11172,6 +11394,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Umožní ti anonymně vyhledávat pomocí DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Libérie"
 
@@ -11240,6 +11469,12 @@ msgstr "Šrafovaná kresba"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Vyhrané vhazování"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11546,7 +11781,8 @@ msgstr "Ujisti se, že jsou všechna slova napsaná správně."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
+msgstr ""
+"Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12125,7 +12361,8 @@ msgstr "Byl vyčerpán měsíční limit"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12332,6 +12569,12 @@ msgstr "Další statistiky najdeš na %1$s"
 msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Více než 20 minut"
+
+# smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12821,6 +13064,12 @@ msgid "No Thanks"
 msgstr "Ne, děkuji"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "Žádné sledování. Nikdy."
@@ -12966,7 +13215,8 @@ msgstr "Nebyly nalezeny žádné výsledky."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
+msgstr ""
+"Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13483,6 +13733,12 @@ msgid "On but no numbers"
 msgstr "Zapnuto bez čísel"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13539,7 +13795,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
+msgstr ""
+"Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13614,7 +13871,8 @@ msgstr "Otevřít %1$sNastavení%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
+msgstr ""
+"Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13693,6 +13951,12 @@ msgstr "Otevřít návrhy chatu"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Otevřít návrhy na vytváření a úpravu obrázků"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14440,10 +14704,22 @@ msgid "Pin"
 msgstr "Připnout"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Připni sem chaty z %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14461,6 +14737,12 @@ msgstr "Růžová"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Připnuté"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14776,6 +15058,12 @@ msgid "Poor formatting"
 msgstr "Špatné formátování"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14982,6 +15270,12 @@ msgstr "Předchozí obrázek"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Předchozí karty"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15276,7 +15570,8 @@ msgstr "Upozornit"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
+msgstr ""
+"Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15318,7 +15613,8 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
+msgstr ""
+"Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15520,6 +15816,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Umělá inteligence s vysokou mírou moderace"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15553,6 +15861,12 @@ msgstr "Nedávné karty"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Uložené nedávné chaty můžeš upravit v %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15707,6 +16021,12 @@ msgstr "Znovu vyhledat bez tohohle webu"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Omez čerpání"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16088,6 +16408,12 @@ msgid "Reset All Settings"
 msgstr "Obnovit všechna nastavení"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16098,6 +16424,12 @@ msgstr "Resetuje se za %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Rozlišení"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16371,7 +16703,8 @@ msgstr "SV"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
+msgstr ""
+"Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -16438,7 +16771,8 @@ msgstr "Bezpečné vyhledávání zablokovalo výsledky pro %1$s."
 # smartling.placeholder_format=C
 #. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
 msgid "Safe search blocked some results for %s."
-msgstr "Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
+msgstr ""
+"Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
 
 # smartling.placeholder_format=C
 #. Safe search lets you remove adult content from results on DuckDuckGo. This string is used to invite users to select the desired level of protection (e.g., strict, moderate, off)
@@ -16586,7 +16920,8 @@ msgstr "Ukládej až 30 svých nejnovějších chatů lokálně na své zaříze
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
+msgstr ""
+"Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16763,7 +17098,8 @@ msgstr "Přejdi dolů a vyhledej %1$ssvůj prohlížeč%2$s v seznamu."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
+msgstr ""
+"Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16792,6 +17128,12 @@ msgstr "Hledat"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Hledat %1$s a najít bližší výsledky?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17165,6 +17507,12 @@ msgstr ""
 "tebe tvoje data neuvidí, dokonce ani my."
 
 # smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "Security issue"
 msgstr "Problém se zabezpečením"
@@ -17307,13 +17655,14 @@ msgstr "V Safari zvol %1$sNastavení pro tuto webovou stránku...%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej "
-"%3$shttps://duckduckgo.com%4$s"
+"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej %3$shttps://"
+"duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
+msgstr ""
+"Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17455,7 +17804,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
+msgstr ""
+"V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17670,6 +18020,12 @@ msgid "Set as Homepage"
 msgstr "Nastavit jako domovskou stránku"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17689,7 +18045,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
+msgstr ""
+"Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17735,6 +18092,18 @@ msgid "Seychelles"
 msgstr "Seychely"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17770,8 +18139,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. "
-"Duck.ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
+"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. Duck."
+"ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17830,6 +18206,12 @@ msgstr "Sdílet adresu URL stránky"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Sdílet pozitivní zpětnou vazbu"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17965,6 +18347,12 @@ msgstr "Zobrazit nastavení JSON"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Zobrazit detail"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18116,6 +18504,12 @@ msgid "Show more"
 msgstr "Zobrazit více"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18149,6 +18543,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Zobrazit postranní panel"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18525,6 +18925,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Něco se pokazilo, zkus to znovu později."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18668,7 +19074,8 @@ msgstr "Vymazaný zdrojový text"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
+msgstr ""
+"Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18815,6 +19222,12 @@ msgstr "Začít vyžívat měsíční limit"
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "Začít vyžívat týdenní limit"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19395,6 +19808,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Přejdi na vyhledávač, který tě nesleduje. Nikdy."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19546,6 +19967,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Funkce Sync & Backup je dočasně nedostupná"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19633,6 +20060,22 @@ msgid "Take Back Your Privacy!"
 msgstr "Získej zpět vlastní soukromí!"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19653,7 +20096,8 @@ msgstr "Měj osobní údaje ve svých rukou!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
+msgstr ""
+"Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19852,13 +20296,15 @@ msgstr "Děkujeme za zpětnou vazbu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr ""
+"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr ""
+"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -19918,7 +20364,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
+msgstr ""
+"Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20069,7 +20516,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
+msgstr ""
+"Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20094,10 +20542,22 @@ msgid "This Month"
 msgstr "Tento měsíc"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Tento týden"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20232,6 +20692,22 @@ msgid "This information isn’t useful"
 msgstr "Tyto informace nejsou užitečné"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20347,13 +20823,15 @@ msgstr "Tento překlad je špatný"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
+msgstr ""
+"Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
+msgstr ""
+"Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20564,6 +21042,12 @@ msgstr "Dnes"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Dnes"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20911,7 +21395,8 @@ msgstr "Zkus přejít na %1$s a podobné zprávy už ti nebudeme ukazovat."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
+msgstr ""
+"Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20977,9 +21462,21 @@ msgid "Try Them Out"
 msgstr "Vyzkoušej je"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Vyzkoušej vyhledávání"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21044,6 +21541,12 @@ msgid "Try for free"
 msgstr "Vyzkoušej zdarma"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21056,6 +21559,12 @@ msgstr "Vyzkoušej zdarma"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "Vyzkoušej to zdarma! Bezpečná VPN, špičková soukromá AI a mnohem víc."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21083,6 +21592,12 @@ msgstr "Vyzkoušej náš prohlížeč"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Zkus naši domovskou stránku, která tyto zprávy nikdy nezobrazuje:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21334,6 +21849,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Zapni si Duck Player a dívej se na YouTube bez cílených reklam"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21549,8 +22070,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: "
-"https://duckduckgo.com"
+"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21560,7 +22081,8 @@ msgstr "V nabídce %1$sNastavení vyhledávání%2$s zvol %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
+msgstr ""
+"Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21702,6 +22224,12 @@ msgstr "Získej pokročilé modely AI s předplatným DuckDuckGo"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Pořiď si předplatné a získej špičkovou umělou inteligenci!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -21928,7 +22456,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
+msgstr ""
+"Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22038,7 +22567,8 @@ msgstr "Použít vyhledávač Private Search od DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
+msgstr ""
+"Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22061,6 +22591,12 @@ msgstr "Použít ve Firefoxu"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Použít v Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22650,7 +23186,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
+msgstr ""
+"Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22671,7 +23208,8 @@ msgstr "Nesledujeme tě. Nikdy."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
+msgstr ""
+"My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22712,7 +23250,8 @@ msgstr "Nesledujeme tě. Ani v anonymním režimu ani mimo něj."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
+msgstr ""
+"My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22947,7 +23486,8 @@ msgstr "Byl vyčerpán týdenní limit využití"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23243,6 +23783,12 @@ msgid "What brought you back today?"
 msgstr "Co tě přivedlo zpět?"
 
 # smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -23469,7 +24015,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
+msgstr ""
+"Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23657,6 +24204,14 @@ msgstr "Výhry"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Mrznoucí déšť se sněhem"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24085,6 +24640,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Počet obrázků, které můžeš přiložit v jedné konverzaci: %1$s"
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24226,6 +24788,12 @@ msgstr ""
 "automaticky."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24271,6 +24839,12 @@ msgstr "Máš zablokovaných %1$s webů"
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "Máš zablokovaný 1 web"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24531,7 +25105,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
+msgstr ""
+"Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24642,7 +25217,8 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr "Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
+msgstr ""
+"Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -24666,6 +25242,14 @@ msgstr "Tvoje role"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Tvoje vyhledávání se s tvojí osobou nespojí"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -24739,7 +25323,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
+msgstr ""
+"Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25041,7 +25626,8 @@ msgstr "oficiálních webových stránkách"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
+msgstr ""
+"nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25252,3 +25838,9 @@ msgstr "lety"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "r."
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/cy_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/cy_GB/LC_MESSAGES/duckduckgo.po
@@ -112,6 +112,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -293,6 +298,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -492,6 +502,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 diwrnod yn ôl"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1231,6 +1246,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1853,6 +1875,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3096,6 +3123,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3695,6 +3727,11 @@ msgstr "Clipart"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3730,6 +3767,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4040,6 +4082,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4094,6 +4141,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4131,6 +4183,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4227,6 +4284,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4261,6 +4323,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4387,6 +4456,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4623,9 +4697,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4653,6 +4737,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4906,6 +4995,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5073,6 +5167,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5248,6 +5347,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5355,6 +5459,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5843,6 +5952,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6082,6 +6196,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6216,6 +6335,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6298,6 +6427,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6633,6 +6767,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7054,6 +7193,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7083,6 +7227,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7100,6 +7254,11 @@ msgstr "Cael y gân hon ar:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Cael eich ffrindiau i newid a helpu ni tyfu!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7652,6 +7811,11 @@ msgstr "Cuddio camau"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8957,6 +9121,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9012,6 +9182,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9914,6 +10089,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Mwy na 20 munudau"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10311,6 +10491,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10861,6 +11046,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Ymlaen ond heb rifau"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11035,6 +11225,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11637,9 +11832,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11654,6 +11859,11 @@ msgstr "Pinc"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11910,6 +12120,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12079,6 +12294,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12524,6 +12744,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12551,6 +12781,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12673,6 +12908,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12976,6 +13216,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Ailosod pob gosodiad"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12984,6 +13229,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13541,6 +13791,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 #, fuzzy
 msgid "Search Anonymously"
 msgstr "Chwilio yn ddienwr"
@@ -13825,6 +14080,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14222,6 +14482,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Gosod fel Hafan"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14276,6 +14541,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14306,6 +14581,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14354,6 +14635,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14466,6 +14752,11 @@ msgstr "Dangos data sgriptnodau a gosodiadau"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Dangos Gwybodaeth"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14589,6 +14880,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14617,6 +14913,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14916,6 +15217,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15149,6 +15455,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15629,6 +15940,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Newid i'r peiriant chwilio sydd byth yn eich tracio."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15741,6 +16059,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15811,6 +16134,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Chymryd Nôl Eich Preifatrwydd!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16179,9 +16516,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16282,6 +16629,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16538,6 +16899,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16875,9 +17241,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Triwch chwilio!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16931,6 +17307,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16941,6 +17322,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16963,6 +17349,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17163,6 +17554,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17451,6 +17847,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17748,6 +18149,11 @@ msgstr "Defnyddio mewn Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Defnyddio mewn Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18673,6 +19079,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Beth wnaeth dod â chi ynôl heddiw?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19013,6 +19424,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19360,6 +19778,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19468,6 +19892,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19504,6 +19933,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19806,6 +20240,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20281,6 +20722,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "%1$s dage siden"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s registreret"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +361,12 @@ msgid "%s used"
 msgstr "%1$s brugt"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s visning"
@@ -416,7 +428,8 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
+msgstr ""
+"%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -471,7 +484,8 @@ msgstr "%1$sSe, hvordan vi holder din placering hemmelig%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
+msgstr ""
+"%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -596,6 +610,12 @@ msgstr "1 forsøg blokeret af DuckDuckGo inden for de sidste 24 timer"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 dag siden"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -816,7 +836,8 @@ msgstr "Grænsen på 6 timers brug er nået."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
+msgstr ""
+"Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -887,14 +908,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
+msgstr ""
+"En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
+msgstr ""
+"En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1504,6 +1527,14 @@ msgid "Advanced Models"
 msgstr "Avancerede modeller"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Annoncér på Search"
@@ -1714,7 +1745,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
+msgstr ""
+"Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2020,8 +2052,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. "
-"f.eks. Fortæl mig altid fakta om ænder"
+"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. f."
+"eks. Fortæl mig altid fakta om ænder"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2120,7 +2152,8 @@ msgstr "Er du der stadig?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
+msgstr ""
+"Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2132,7 +2165,8 @@ msgstr "Er du sikker på, at du vil rydde denne samtale og starte en ny?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
+msgstr ""
+"Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2290,6 +2324,12 @@ msgid "Ask privately"
 msgstr "Spørg privat"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2327,8 +2367,8 @@ msgstr ""
 "skal vises: Aldrig (fjerner Assist UI fra søgeresultaterne), On-demand "
 "(viser kun AI-assisterede svar, hvis du klikker på knappen Assist), Nogle "
 "gange (viser kun AI-assisterede svar, når det er yderst relevant) eller Ofte "
-"(vises oftere på en bredere række af søgninger). Indtil videre er "
-"AI-assisterede svar kun tilgængelige i USA (engelsk)."
+"(vises oftere på en bredere række af søgninger). Indtil videre er AI-"
+"assisterede svar kun tilgængelige i USA (engelsk)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -3601,7 +3641,8 @@ msgstr "Ændrer den måde, URL-resultaterne vises på"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
+msgstr ""
+"Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3837,6 +3878,12 @@ msgid "Chat privately with AI"
 msgstr "Chat privat med AI"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3925,8 +3972,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i "
-"Duck.ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
+"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i Duck."
+"ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4059,7 +4106,8 @@ msgstr "Vælg mellem flere AI-modeller, herunder %1$s og %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
+msgstr ""
+"Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4499,8 +4547,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
 "Klik eller tryk på %1$sSlet mine oplysninger%2$s. Dette fjerner "
-"oplysningerne fra skyen, men de forbliver i din browser, indtil du "
-"klikker/trykker på %3$sNulstil alle indstillinger%4$s."
+"oplysningerne fra skyen, men de forbliver i din browser, indtil du klikker/"
+"trykker på %3$sNulstil alle indstillinger%4$s."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4622,6 +4670,12 @@ msgid "Close"
 msgstr "Luk"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4664,6 +4718,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Luk søgning"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5037,6 +5097,12 @@ msgid "Continue Blocking Ads"
 msgstr "Fortsæt med at blokere annoncer"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5102,6 +5168,12 @@ msgid "Cookie data:"
 msgstr "Cookiedata:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5147,6 +5219,12 @@ msgstr "Kopiér og indsæt %1$sabout:preferences#search%2$s i adressefeltet"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopier kode"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5262,6 +5340,12 @@ msgid "Create Image"
 msgstr "Opret billede"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5303,6 +5387,14 @@ msgstr "Skabt af"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Skabt af %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5456,6 +5548,12 @@ msgstr "Tilpas svar"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Tilpas svar"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5742,10 +5840,22 @@ msgid "Delete Server Data?"
 msgstr "Slet serverdata?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Slet Transskript"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5780,6 +5890,12 @@ msgid "Delete image?"
 msgstr "Slet billede?"
 
 # smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats to free up storage?"
@@ -5789,7 +5905,8 @@ msgstr "Vil du slette de ældste chats for at frigøre lagerplads?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
+msgstr ""
+"Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5903,7 +6020,8 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr ""
+"Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6086,6 +6204,12 @@ msgid "Dismiss promotion"
 msgstr "Afvis kampagne"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6228,8 +6352,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen "
-"AI-funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen AI-"
+"funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6238,8 +6362,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden "
-"AI-funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden AI-"
+"funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6294,6 +6418,12 @@ msgstr "Download fuldført"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Hent DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6511,6 +6641,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai af DuckDuckGo. Privat AI-chat. Gratis."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6626,12 +6762,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai giver dig mulighed for at have anonyme samtaler med "
-"tredjeparts-AI-chatmodeller, herunder modeller fra OpenAI, Anthropic og "
-"andre. Hvis du deaktiverer denne indstilling, vil Duck.ai-knapper og -links "
-"blive skjult på DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, "
-"når denne indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s "
-"direkte."
+"Duck.ai giver dig mulighed for at have anonyme samtaler med tredjeparts-AI-"
+"chatmodeller, herunder modeller fra OpenAI, Anthropic og andre. Hvis du "
+"deaktiverer denne indstilling, vil Duck.ai-knapper og -links blive skjult på "
+"DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, når denne "
+"indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6665,6 +6800,12 @@ msgstr ""
 "nøjagtighed."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6691,8 +6832,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privat AI-chatbot, gratis AI-chat, anonym AI-chat, "
-"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source "
-"AI-modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
+"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source AI-"
+"modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
 "konto"
 
 # smartling.placeholder_format=C
@@ -6855,7 +6996,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
+msgstr ""
+"DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7307,6 +7449,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Aktivér Mest besøgte sider"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7354,7 +7502,8 @@ msgstr "Aktivér diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
+msgstr ""
+"Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7464,7 +7613,8 @@ msgstr "Kan du lide Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
+msgstr ""
+"Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7605,6 +7755,12 @@ msgid "Entertainment guide"
 msgstr "Underholdningsguide"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Ækvatorialguinea"
 
@@ -7703,7 +7859,8 @@ msgstr "Forklar det accepterede svar i simple termer."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
+msgstr ""
+"Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7764,6 +7921,18 @@ msgstr "Stødende indhold"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Stødende sangtekster"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7867,6 +8036,12 @@ msgid "FREE"
 msgstr "Gratis"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7923,8 +8098,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og "
-"-forbedringer."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
+"forbedringer."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7933,8 +8108,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og "
-"-forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
+"forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8026,7 +8201,8 @@ msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
+msgstr ""
+"Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8281,6 +8457,12 @@ msgid "Free Up Storage"
 msgstr "Frigør lagerplads"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8320,7 +8502,8 @@ msgstr "Gratis at dele og bruge kommercielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
+msgstr ""
+"Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8794,6 +8977,12 @@ msgid "Get computer help"
 msgstr "Få hjælp til computeren"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8831,6 +9020,18 @@ msgid "Get the Latest Version"
 msgstr "Hent den nyeste version"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8851,6 +9052,12 @@ msgstr "Få denne sang på:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Få dine venner til at skifte over, og hjælp os med at vokse!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8881,9 +9088,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed › Kopiér tekstkode%4$s"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden enhed "
+"› Kopiér tekstkode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8892,9 +9099,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed%4$s"
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
+"enhed%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8904,9 +9111,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed%4$s, og scan denne kode:"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
+"enhed%4$s, og scan denne kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8916,9 +9123,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
+"enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9537,6 +9744,12 @@ msgid "Hide Tips"
 msgstr "Skjul tips"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9831,7 +10044,8 @@ msgstr "Hvor tit vil du have, at AI-assisterede svar skal dukke op?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
+msgstr ""
+"Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10272,7 +10486,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr "Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
+msgstr ""
+"Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11157,6 +11372,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Lader dig søge anonymt på internettet med DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11225,6 +11447,12 @@ msgstr "Stregtegning"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Lineouts vundet"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11353,7 +11581,8 @@ msgstr "Indlæser flere billedresultater, mens du scroller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
+msgstr ""
+"Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12319,6 +12548,12 @@ msgid "More than 20 minutes"
 msgstr "Over 20 minutter"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12639,11 +12874,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nye prompter og svar krypteres og gemmes midlertidigt på en "
-"DuckDuckGo-server efter afsendelse for at hjælpe med at gendanne en chat, "
-"hvis du mister din internetforbindelse. Deaktivering af chathistorikken "
-"sletter fastgjorte chats og deaktiverer midlertidig lagring af nye prompter "
-"og svar."
+"Nye prompter og svar krypteres og gemmes midlertidigt på en DuckDuckGo-"
+"server efter afsendelse for at hjælpe med at gendanne en chat, hvis du "
+"mister din internetforbindelse. Deaktivering af chathistorikken sletter "
+"fastgjorte chats og deaktiverer midlertidig lagring af nye prompter og svar."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12805,6 +13039,12 @@ msgstr "Nej tak."
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Nej tak"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13469,6 +13709,12 @@ msgid "On but no numbers"
 msgstr "Til, men ingen numre"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13681,6 +13927,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Åbn forslag til at oprette og redigere billeder"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13844,8 +14096,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"Andre søgemaskiner sporer dine søgninger, selv når du er i privat "
-"browsing-tilstand. Vi sporer dig ikke – punktum."
+"Andre søgemaskiner sporer dine søgninger, selv når du er i privat browsing-"
+"tilstand. Vi sporer dig ikke – punktum."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14428,10 +14680,22 @@ msgid "Pin"
 msgstr "Fastgør"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Fastgør chats her fra %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14449,6 +14713,12 @@ msgstr "Lyserød"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Fastgjort"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14768,6 +15038,12 @@ msgid "Poor formatting"
 msgstr "Dårlig formatering"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14974,6 +15250,12 @@ msgstr "Forrige billede"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Forrige faner"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15516,6 +15798,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Ræsonnerende AI med medium indbygget moderation"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15549,6 +15843,12 @@ msgstr "Seneste faner"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Lagring af seneste chats kan justeres i %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15703,6 +16003,12 @@ msgstr "Prøv at søge igen uden dette websted"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Reducer brugen"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16080,6 +16386,12 @@ msgid "Reset All Settings"
 msgstr "Nulstil alle indstillinger"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16090,6 +16402,12 @@ msgstr "Nulstiller om %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Opløsning"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16763,7 +17081,8 @@ msgstr "Rul ned til %1$sDuckDuckGo%2$s, og lad den bruge din placering."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
+msgstr ""
+"Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16786,6 +17105,12 @@ msgstr "Søg"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Vil du søge efter %1$s for at finde resultater tættere på dig?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16987,8 +17312,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge "
-"POST-anmodninger)"
+"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge POST-"
+"anmodninger)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17155,6 +17480,12 @@ msgid ""
 msgstr ""
 "Sikkert gemt på DuckDuckGos server med end-to-end-kryptering. Ingen andre "
 "end dig kan se dine data, ikke engang os."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17447,7 +17778,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
+msgstr ""
+"Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17663,6 +17995,12 @@ msgid "Set as Homepage"
 msgstr "Gør til Startside"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17730,6 +18068,18 @@ msgid "Seychelles"
 msgstr "Seychellerne"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17738,7 +18088,8 @@ msgstr "Del"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
+msgstr ""
+"Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17767,6 +18118,13 @@ msgid ""
 msgstr ""
 "Fortæl AI-modeller hvilken by, du bor i, for at forbedre relevansen. Duck.ai "
 "afslører aldrig din præcise placering for os eller AI-modeller."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17825,6 +18183,12 @@ msgstr "Del webadresse på siden"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Del positiv feedback"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17960,6 +18324,12 @@ msgstr "Vis bookmarklet- og indstillingsdata"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Vis detaljer"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18109,6 +18479,12 @@ msgid "Show more"
 msgstr "Vis mere"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18142,6 +18518,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Vis sidemenu"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18218,7 +18600,8 @@ msgstr "Viser vandrette linjer ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
+msgstr ""
+"Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18239,7 +18622,8 @@ msgstr "Viser lejlighedsvise påmindelser om at føje DuckDuckGo til din browser
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
+msgstr ""
+"Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18257,7 +18641,8 @@ msgstr "Vis sidenumre ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
+msgstr ""
+"Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18355,7 +18740,8 @@ msgstr "Navne på websteder"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
+msgstr ""
+"Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18514,6 +18900,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Noget gik galt. Prøv igen senere"
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18657,7 +19049,8 @@ msgstr "Kildetekst ryddet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
+msgstr ""
+"Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18806,6 +19199,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Begynd at bruge den ugentlige grænse"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Søg nu!"
@@ -18820,7 +19219,8 @@ msgstr "Start med et billede"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
+msgstr ""
+"Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -18856,7 +19256,8 @@ msgstr "Bliv på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
+msgstr ""
+"Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19390,6 +19791,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Skift til søgemaskinen, der ikke sporer dig. Aldrig nogensinde."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19544,6 +19953,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sync & Backup er midlertidigt utilgængelig"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19629,6 +20044,22 @@ msgstr "Tadsjikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Få dit privatliv tilbage!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19890,13 +20321,15 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
+msgstr ""
+"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
+msgstr ""
+"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -19934,7 +20367,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
+msgstr ""
+"Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20086,7 +20520,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
+msgstr ""
+"Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20095,10 +20530,22 @@ msgid "This Month"
 msgstr "Denne måned"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Denne uge"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20214,19 +20661,37 @@ msgstr "Dette billede kunne ikke oprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
+msgstr ""
+"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
+msgstr ""
+"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Disse oplysninger er ikke nyttige"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20274,7 +20739,8 @@ msgstr "Denne side kræver JavaScript for at kunne fungere."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
+msgstr ""
+"Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20341,7 +20807,8 @@ msgstr "Denne oversættelse er forkert"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
+msgstr ""
+"Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20559,6 +21026,12 @@ msgstr "I dag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "I dag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20972,9 +21445,21 @@ msgid "Try Them Out"
 msgstr "Prøv dem nu"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Prøv at søge!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21009,7 +21494,8 @@ msgstr "Prøv andre nøgleord."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
+msgstr ""
+"Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21039,6 +21525,12 @@ msgid "Try for free"
 msgstr "Prøv gratis"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21051,6 +21543,12 @@ msgstr "Prøv gratis"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "Prøv gratis! En sikker VPN, avanceret og privat AI og meget mere."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21078,6 +21576,12 @@ msgstr "Prøv vores browser,"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Prøv vores startside, der aldrig viser disse beskeder:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21327,6 +21831,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Slå Duck Player til for at se YouTube uden målrettede annoncer"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21529,8 +22039,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: "
-"https://duckduckgo.com"
+"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21557,14 +22067,15 @@ msgstr "Under %1$sSøg i adressefeltet med%2$s vælger du %3$sTilføj ny%4$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner "
-"...%4$s"
+"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner ..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
+msgstr ""
+"Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21671,8 +22182,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås op for avancerede AI-modeller og højere grænser med et "
-"DuckDuckGo-abonnement"
+"Lås op for avancerede AI-modeller og højere grænser med et DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21694,6 +22205,12 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "Lås op for avanceret AI med dit abonnement!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -21705,7 +22222,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
+msgstr ""
+"Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21918,7 +22436,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
+msgstr ""
+"Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22028,7 +22547,8 @@ msgstr "Brug DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
+msgstr ""
+"Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22051,6 +22571,12 @@ msgstr "Brug i Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Anvend i Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22314,10 +22840,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn "
-"Duck.ai-indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg "
-"\"Synkroniser med en anden enhed\". Eller scan QR-koden på din "
-"gendannelses-PDF."
+"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn Duck.ai-"
+"indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg \"Synkroniser "
+"med en anden enhed\". Eller scan QR-koden på din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22369,7 +22894,8 @@ msgstr "Stemmesamtale afsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr ""
+"Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22594,7 +23120,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
+msgstr ""
+"Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22790,7 +23317,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
+msgstr ""
+"Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22824,7 +23352,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
+msgstr ""
+"Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22987,7 +23516,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
+msgstr ""
+"Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23078,13 +23608,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
+msgstr ""
+"Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
+msgstr ""
+"Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23115,10 +23647,9 @@ msgid ""
 msgstr ""
 "Hvad er fordelene ved at downloade DuckDuckGo-browseren, hvis du er "
 "interesseret i at bruge Duck.ai? Referer kun officielle DuckDuckGo-kilder. "
-"Opdel svaret i klare sektioner med titler, med fokus på "
-"Duck.ai-integrationer og beskyttelse af privatlivet. Hold det kort, enkelt "
-"og letforståeligt for folk med eller uden betydelig AI- eller teknisk "
-"erfaring."
+"Opdel svaret i klare sektioner med titler, med fokus på Duck.ai-"
+"integrationer og beskyttelse af privatlivet. Hold det kort, enkelt og "
+"letforståeligt for folk med eller uden betydelig AI- eller teknisk erfaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23203,7 +23734,8 @@ msgstr "Hvilke retter bør man prøve her?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
+msgstr ""
+"Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23228,6 +23760,12 @@ msgstr "Hvad generede dig mest?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Hvad bragte dig tilbage i dag?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23339,7 +23877,8 @@ msgstr "Hvilke informationer bliver gemt?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr "Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
+msgstr ""
+"Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23456,7 +23995,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
+msgstr ""
+"Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23648,6 +24188,14 @@ msgstr "Sejre"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Blandet vintervejr"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -23922,7 +24470,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
+msgstr ""
+"Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24076,6 +24625,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Du kan kun vedhæfte %1$s billeder pr. samtale."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24204,7 +24760,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
+msgstr ""
+"Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24215,6 +24772,12 @@ msgid ""
 msgstr ""
 "Du vil modtage automatiske app-opdateringer fra DuckDuckGo, når du har den "
 "nyeste version."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24264,6 +24827,12 @@ msgid "You've blocked 1 site"
 msgstr "Du har blokeret 1 websted"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24287,14 +24856,16 @@ msgstr "Du har nået det maksimale antal beskeder for nu. Prøv igen senere."
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Du har nået den maksimale varighed af stemmechat for en enkelt session."
+msgstr ""
+"Du har nået den maksimale varighed af stemmechat for en enkelt session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
+msgstr ""
+"Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24452,7 +25023,8 @@ msgstr "Dine chats bliver nu gemt."
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr "Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
+msgstr ""
+"Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24466,8 +25038,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
-"AI-modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24475,8 +25047,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
-"AI-modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24594,8 +25166,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure "
-"Hash-algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
+"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure Hash-"
+"algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
 "indstillingsfil forlader din browser. Vi gemmer indstillingsfilen ved at "
 "bruge nøglen som navnet. DuckDuckGo får aldrig dit adgangsudtryk at vide."
 
@@ -24653,6 +25225,14 @@ msgstr "Din rolle"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Dine søgninger kan ikke knyttes tilbage til dig"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25247,3 +25827,9 @@ msgstr "år"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "år"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s registreret"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s filer brugt"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,6 +365,8 @@ msgstr "%1$s brugt"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
+"%1$s bruger grænserne op til 2-5 gange hurtigere end grundlæggende modeller "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -428,8 +430,7 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
+msgstr "%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -484,8 +485,7 @@ msgstr "%1$sSe, hvordan vi holder din placering hemmelig%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
+msgstr "%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -615,7 +615,7 @@ msgstr "1 dag siden"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 fil brugt"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -836,8 +836,7 @@ msgstr "Grænsen på 6 timers brug er nået."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
+msgstr "Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -908,16 +907,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
+msgstr "En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
+msgstr "En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1533,6 +1530,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Avancerede modeller kan bruge grænserne 2-5 gange hurtigere end andre "
+"modeller. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1745,8 +1744,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
+msgstr "Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2052,8 +2050,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. f."
-"eks. Fortæl mig altid fakta om ænder"
+"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. "
+"f.eks. Fortæl mig altid fakta om ænder"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2152,8 +2150,7 @@ msgstr "Er du der stadig?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
+msgstr "Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2165,8 +2162,7 @@ msgstr "Er du sikker på, at du vil rydde denne samtale og starte en ny?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
+msgstr "Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2327,7 +2323,7 @@ msgstr "Spørg privat"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Spørg privat"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2367,8 +2363,8 @@ msgstr ""
 "skal vises: Aldrig (fjerner Assist UI fra søgeresultaterne), On-demand "
 "(viser kun AI-assisterede svar, hvis du klikker på knappen Assist), Nogle "
 "gange (viser kun AI-assisterede svar, når det er yderst relevant) eller Ofte "
-"(vises oftere på en bredere række af søgninger). Indtil videre er AI-"
-"assisterede svar kun tilgængelige i USA (engelsk)."
+"(vises oftere på en bredere række af søgninger). Indtil videre er "
+"AI-assisterede svar kun tilgængelige i USA (engelsk)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -3641,8 +3637,7 @@ msgstr "Ændrer den måde, URL-resultaterne vises på"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
+msgstr "Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3881,7 +3876,7 @@ msgstr "Chat privat med AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Chat privat med populære AI'er"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3972,8 +3967,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i Duck."
-"ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
+"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i "
+"Duck.ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4106,8 +4101,7 @@ msgstr "Vælg mellem flere AI-modeller, herunder %1$s og %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
+msgstr "Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4547,8 +4541,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
 "Klik eller tryk på %1$sSlet mine oplysninger%2$s. Dette fjerner "
-"oplysningerne fra skyen, men de forbliver i din browser, indtil du klikker/"
-"trykker på %3$sNulstil alle indstillinger%4$s."
+"oplysningerne fra skyen, men de forbliver i din browser, indtil du "
+"klikker/trykker på %3$sNulstil alle indstillinger%4$s."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4673,7 +4667,7 @@ msgstr "Luk"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Luk"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4723,7 +4717,7 @@ msgstr "Luk søgning"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Luk anden vurdering"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5100,7 +5094,7 @@ msgstr "Fortsæt med at blokere annoncer"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Fortsæt seneste chats her. Eller slet dem med Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5171,7 +5165,7 @@ msgstr "Cookiedata:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Kopieret"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5224,7 +5218,7 @@ msgstr "Kopier kode"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopiér link"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5343,7 +5337,7 @@ msgstr "Opret billede"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Opret delingslink"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5395,6 +5389,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Oprettelse af et link laver en kopi af chatten, der kan ses af alle, der "
+"åbner det."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5553,7 +5549,7 @@ msgstr "Tilpas svar"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Tilpas svar"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5843,7 +5839,7 @@ msgstr "Slet serverdata?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Slet delt link"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5855,7 +5851,7 @@ msgstr "Slet Transskript"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Slet en chat"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5893,7 +5889,7 @@ msgstr "Slet billede?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Slet mig"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5905,8 +5901,7 @@ msgstr "Vil du slette de ældste chats for at frigøre lagerplads?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
+msgstr "Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6020,8 +6015,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr "Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6207,7 +6201,7 @@ msgstr "Afvis kampagne"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Afvis rundvisning"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6352,8 +6346,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen AI-"
-"funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen "
+"AI-funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6362,8 +6356,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden AI-"
-"funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden "
+"AI-funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6423,7 +6417,7 @@ msgstr "Hent DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Hent DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6644,7 +6638,7 @@ msgstr "Duck.ai af DuckDuckGo. Privat AI-chat. Gratis."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai kan nu analysere PDF-filer. Prøv det!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6762,11 +6756,12 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai giver dig mulighed for at have anonyme samtaler med tredjeparts-AI-"
-"chatmodeller, herunder modeller fra OpenAI, Anthropic og andre. Hvis du "
-"deaktiverer denne indstilling, vil Duck.ai-knapper og -links blive skjult på "
-"DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, når denne "
-"indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s direkte."
+"Duck.ai giver dig mulighed for at have anonyme samtaler med "
+"tredjeparts-AI-chatmodeller, herunder modeller fra OpenAI, Anthropic og "
+"andre. Hvis du deaktiverer denne indstilling, vil Duck.ai-knapper og -links "
+"blive skjult på DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, "
+"når denne indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s "
+"direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6803,7 +6798,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai understøtter modeller fra Anthropic, OpenAI og andre."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6832,8 +6827,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privat AI-chatbot, gratis AI-chat, anonym AI-chat, "
-"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source AI-"
-"modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
+"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source "
+"AI-modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
 "konto"
 
 # smartling.placeholder_format=C
@@ -6996,8 +6991,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
+msgstr "DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7452,7 +7446,7 @@ msgstr "Aktivér Mest besøgte sider"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Aktiver nu"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7502,8 +7496,7 @@ msgstr "Aktivér diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
+msgstr "Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7613,8 +7606,7 @@ msgstr "Kan du lide Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
+msgstr "Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7758,7 +7750,7 @@ msgstr "Underholdningsguide"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Hele chatten"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7859,8 +7851,7 @@ msgstr "Forklar det accepterede svar i simple termer."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
+msgstr "Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7926,13 +7917,13 @@ msgstr "Stødende sangtekster"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Udforsk Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Udforsk Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8039,7 +8030,7 @@ msgstr "Gratis"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRATIS OG VALGFRI"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8098,8 +8089,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
-"forbedringer."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og "
+"-forbedringer."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8108,8 +8099,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
-"forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og "
+"-forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8201,8 +8192,7 @@ msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
+msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8460,7 +8450,7 @@ msgstr "Frigør lagerplads"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Gratis og altid privat"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8502,8 +8492,7 @@ msgstr "Gratis at dele og bruge kommercielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
+msgstr "Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8980,7 +8969,7 @@ msgstr "Få hjælp til computeren"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Få højere forbrugsgrænser med et DuckDuckGo-abonnement."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9023,13 +9012,15 @@ msgstr "Hent den nyeste version"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Hent appen"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9057,7 +9048,7 @@ msgstr "Få dine venner til at skifte over, og hjælp os med at vokse!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Tjekliste til at komme i gang"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9088,9 +9079,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden enhed "
-"› Kopiér tekstkode%4$s"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed › Kopiér tekstkode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9099,9 +9090,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s"
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9111,9 +9102,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s, og scan denne kode:"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s, og scan denne kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9123,9 +9114,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9747,7 +9738,7 @@ msgstr "Skjul tips"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Skjul vejledning"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10044,8 +10035,7 @@ msgstr "Hvor tit vil du have, at AI-assisterede svar skal dukke op?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
+msgstr "Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10486,8 +10476,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr ""
-"Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
+msgstr "Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11376,7 +11365,7 @@ msgstr "Lader dig søge anonymt på internettet med DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11452,7 +11441,7 @@ msgstr "Lineouts vundet"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Linket udløber om 7 dage."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11581,8 +11570,7 @@ msgstr "Indlæser flere billedresultater, mens du scroller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
+msgstr "Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12551,7 +12539,7 @@ msgstr "Over 20 minutter"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Flere tips"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12874,10 +12862,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nye prompter og svar krypteres og gemmes midlertidigt på en DuckDuckGo-"
-"server efter afsendelse for at hjælpe med at gendanne en chat, hvis du "
-"mister din internetforbindelse. Deaktivering af chathistorikken sletter "
-"fastgjorte chats og deaktiverer midlertidig lagring af nye prompter og svar."
+"Nye prompter og svar krypteres og gemmes midlertidigt på en "
+"DuckDuckGo-server efter afsendelse for at hjælpe med at gendanne en chat, "
+"hvis du mister din internetforbindelse. Deaktivering af chathistorikken "
+"sletter fastgjorte chats og deaktiverer midlertidig lagring af nye prompter "
+"og svar."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13044,7 +13033,7 @@ msgstr "Nej tak"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nej tak"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13712,7 +13701,7 @@ msgstr "Til, men ingen numre"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Onboarding fuldført"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13930,7 +13919,7 @@ msgstr "Åbn forslag til at oprette og redigere billeder"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Åbn tjekliste til at komme i gang"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14096,8 +14085,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"Andre søgemaskiner sporer dine søgninger, selv når du er i privat browsing-"
-"tilstand. Vi sporer dig ikke – punktum."
+"Andre søgemaskiner sporer dine søgninger, selv når du er i privat "
+"browsing-tilstand. Vi sporer dig ikke – punktum."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14683,7 +14672,7 @@ msgstr "Fastgør"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Fastgør en chat"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14695,7 +14684,7 @@ msgstr "Fastgør chats her fra %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Fastgør mig"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14718,7 +14707,7 @@ msgstr "Fastgjort"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Fastgjorte chats vises øverst i dine seneste chats."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15042,6 +15031,8 @@ msgstr "Dårlig formatering"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Populære AI-modeller tilgængelige. En konto er ikke nødvendig. Chats "
+"anonymiseret af os."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15255,7 +15246,7 @@ msgstr "Forrige faner"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Forrige tips"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15801,13 +15792,15 @@ msgstr "Ræsonnerende AI med medium indbygget moderation"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Ræsonnement kan give bedre svar på komplekse spørgsmål."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Ræsonnementet er mere grundigt, men opbruger grænserne 2-5 gange hurtigere. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15848,7 +15841,7 @@ msgstr "Lagring af seneste chats kan justeres i %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Seneste chats"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16008,7 +16001,7 @@ msgstr "Reducer brugen"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Reducer brugen med en mere effektiv model"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16389,7 +16382,7 @@ msgstr "Nulstil alle indstillinger"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Nulstil vejledning"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16407,7 +16400,7 @@ msgstr "Opløsning"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Svar"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -17081,8 +17074,7 @@ msgstr "Rul ned til %1$sDuckDuckGo%2$s, og lad den bruge din placering."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
+msgstr "Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17110,7 +17102,7 @@ msgstr "Vil du søge efter %1$s for at finde resultater tættere på dig?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Slå Søg og Duck.ai til/fra"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17312,8 +17304,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge POST-"
-"anmodninger)"
+"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge "
+"POST-anmodninger)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17485,7 +17477,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Sikkert gemt på vores krypterede server."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17778,8 +17770,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
+msgstr "Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17998,7 +17989,7 @@ msgstr "Gør til Startside"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Indstil tonen og stilen for Duck.ai's svar."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18071,13 +18062,13 @@ msgstr "Seychellerne"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Del"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Del"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18088,8 +18079,7 @@ msgstr "Del"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
+msgstr "Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18124,7 +18114,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Del chat"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18188,7 +18178,7 @@ msgstr "Del positiv feedback"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Delingsomfang"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18329,7 +18319,7 @@ msgstr "Vis detaljer"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Vis vejledning til Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18482,7 +18472,7 @@ msgstr "Vis mere"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Vis flere modeller"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18523,7 +18513,7 @@ msgstr "Vis sidemenu"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Vis trin for trin-tips til at få mest muligt ud af Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18600,8 +18590,7 @@ msgstr "Viser vandrette linjer ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
+msgstr "Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18622,8 +18611,7 @@ msgstr "Viser lejlighedsvise påmindelser om at føje DuckDuckGo til din browser
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
+msgstr "Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18641,8 +18629,7 @@ msgstr "Vis sidenumre ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
+msgstr "Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18740,8 +18727,7 @@ msgstr "Navne på websteder"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
+msgstr "Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18903,7 +18889,7 @@ msgstr "Noget gik galt. Prøv igen senere"
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Noget gik galt. Prøv igen."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19049,8 +19035,7 @@ msgstr "Kildetekst ryddet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
+msgstr "Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19202,7 +19187,7 @@ msgstr "Begynd at bruge den ugentlige grænse"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Start en ny chat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19219,8 +19204,7 @@ msgstr "Start med et billede"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
+msgstr "Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19256,8 +19240,7 @@ msgstr "Bliv på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
+msgstr "Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19796,7 +19779,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Skift til denne anden vurdering"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19956,7 +19939,7 @@ msgstr "Sync & Backup er midlertidigt utilgængelig"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Synkroniser chats på tværs af enheder"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20052,6 +20035,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Tag Duck.ai med dig overalt. Få det indbygget i vores gratis app for "
+"hurtigere adgang, uanset hvor du er."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20060,6 +20045,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Tag Duck.ai med dig overalt. Få det indbygget i vores gratis browser for "
+"hurtigere adgang, uanset hvor du browser."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20321,15 +20308,13 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
+msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
+msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20367,8 +20352,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
+msgstr "Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20520,8 +20504,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
+msgstr "Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20533,7 +20516,7 @@ msgstr "Denne måned"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Dette svar"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20545,7 +20528,7 @@ msgstr "Denne uge"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Denne chat bliver i Duck.ai og forbliver privat for dig."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20661,16 +20644,14 @@ msgstr "Dette billede kunne ikke oprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
+msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
+msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20684,6 +20665,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Dette er blot en eksempelchat. Åbn dens menu (de tre prikker), og vælg "
+"derefter Fastgør for at holde den øverst i dine chats!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20692,6 +20675,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Dette er blot en eksempelchat. Brug Fire Button i sidemenuen til at slette "
+"den!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20739,8 +20724,7 @@ msgstr "Denne side kræver JavaScript for at kunne fungere."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
+msgstr "Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20807,8 +20791,7 @@ msgstr "Denne oversættelse er forkert"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
+msgstr "Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21032,6 +21015,8 @@ msgstr "I dag"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Slå til/fra for at prøve privat AI-chat eller %1$sdeaktiver den i menuen "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21448,7 +21433,7 @@ msgstr "Prøv dem nu"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Prøv en anden model"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21459,7 +21444,7 @@ msgstr "Prøv at søge!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Prøv et forslag"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21494,8 +21479,7 @@ msgstr "Prøv andre nøgleord."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
+msgstr "Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21528,7 +21512,7 @@ msgstr "Prøv gratis"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Prøv gratis"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21548,7 +21532,7 @@ msgstr "Prøv gratis! En sikker VPN, avanceret og privat AI og meget mere."
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Prøv gratis i 7 dage"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21581,7 +21565,7 @@ msgstr "Prøv vores startside, der aldrig viser disse beskeder:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Prøv ræsonnement"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21834,7 +21818,7 @@ msgstr "Slå Duck Player til for at se YouTube uden målrettede annoncer"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Slå Duck.ai til"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22039,8 +22023,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: https://"
-"duckduckgo.com"
+"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22067,15 +22051,14 @@ msgstr "Under %1$sSøg i adressefeltet med%2$s vælger du %3$sTilføj ny%4$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner ..."
-"%4$s"
+"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner "
+"...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
+msgstr "Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22182,8 +22165,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås op for avancerede AI-modeller og højere grænser med et DuckDuckGo-"
-"abonnement"
+"Lås op for avancerede AI-modeller og højere grænser med et "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22208,7 +22191,7 @@ msgstr "Lås op for avanceret AI med dit abonnement!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Lås op for avancerede modeller"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22222,8 +22205,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
+msgstr "Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22436,8 +22418,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
+msgstr "Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22547,8 +22528,7 @@ msgstr "Brug DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
+msgstr "Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22576,7 +22556,7 @@ msgstr "Anvend i Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Brug Fire Button til at slette en chat fra historikken."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22840,9 +22820,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn Duck.ai-"
-"indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg \"Synkroniser "
-"med en anden enhed\". Eller scan QR-koden på din gendannelses-PDF."
+"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn "
+"Duck.ai-indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg "
+"\"Synkroniser med en anden enhed\". Eller scan QR-koden på din "
+"gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22894,8 +22875,7 @@ msgstr "Stemmesamtale afsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr "Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23120,8 +23100,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
+msgstr "Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23317,8 +23296,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
+msgstr "Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23352,8 +23330,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
+msgstr "Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23516,8 +23493,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
+msgstr "Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23608,15 +23584,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
+msgstr "Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
+msgstr "Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23647,9 +23621,10 @@ msgid ""
 msgstr ""
 "Hvad er fordelene ved at downloade DuckDuckGo-browseren, hvis du er "
 "interesseret i at bruge Duck.ai? Referer kun officielle DuckDuckGo-kilder. "
-"Opdel svaret i klare sektioner med titler, med fokus på Duck.ai-"
-"integrationer og beskyttelse af privatlivet. Hold det kort, enkelt og "
-"letforståeligt for folk med eller uden betydelig AI- eller teknisk erfaring."
+"Opdel svaret i klare sektioner med titler, med fokus på "
+"Duck.ai-integrationer og beskyttelse af privatlivet. Hold det kort, enkelt "
+"og letforståeligt for folk med eller uden betydelig AI- eller teknisk "
+"erfaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23734,8 +23709,7 @@ msgstr "Hvilke retter bør man prøve her?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
+msgstr "Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23765,7 +23739,7 @@ msgstr "Hvad bragte dig tilbage i dag?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Hvad kan du gøre?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23877,8 +23851,7 @@ msgstr "Hvilke informationer bliver gemt?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
+msgstr "Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23995,8 +23968,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
+msgstr "Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24196,6 +24168,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Med Duck.ai er dine chats anonymiserede og bruges aldrig til at træne AI. "
+"Slå det til eller fra når som helst i menuen '%1$s'."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24470,8 +24444,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
+msgstr "Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24629,7 +24602,7 @@ msgstr "Du kan kun vedhæfte %1$s billeder pr. samtale."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Du kan kun vedhæfte %1$s faner ad gangen."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24760,8 +24733,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
+msgstr "Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24777,7 +24749,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Du er klar!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24830,7 +24802,7 @@ msgstr "Du har blokeret 1 websted"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Du har mestret det grundlæggende i Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24856,16 +24828,14 @@ msgstr "Du har nået det maksimale antal beskeder for nu. Prøv igen senere."
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Du har nået den maksimale varighed af stemmechat for en enkelt session."
+msgstr "Du har nået den maksimale varighed af stemmechat for en enkelt session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
+msgstr "Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25023,8 +24993,7 @@ msgstr "Dine chats bliver nu gemt."
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr ""
-"Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
+msgstr "Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25038,8 +25007,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
-"modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25047,8 +25016,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
-"modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25166,8 +25135,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure Hash-"
-"algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
+"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure "
+"Hash-algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
 "indstillingsfil forlader din browser. Vi gemmer indstillingsfilen ved at "
 "bruge nøglen som navnet. DuckDuckGo får aldrig dit adgangsudtryk at vide."
 
@@ -25233,6 +25202,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Dine indstillinger er gemt, men hvis du sletter cookies vil de blive "
+"nulstillet. Aktivér %1$sDuckDuckGo No AI%2$s-udvidelsen for at gøre det "
+"permanent."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25832,4 +25804,4 @@ msgstr "år"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/de_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_CH/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -487,6 +497,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Vor einem Tag"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1228,6 +1243,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1853,6 +1875,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3096,6 +3123,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3704,6 +3736,11 @@ msgstr "Clipart"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3739,6 +3776,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4046,6 +4088,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4100,6 +4147,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4138,6 +4190,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4234,6 +4291,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4268,6 +4330,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4393,6 +4462,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4629,9 +4703,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4659,6 +4743,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4912,6 +5001,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5078,6 +5172,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5253,6 +5352,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5360,6 +5464,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5848,6 +5957,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6088,6 +6202,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6221,6 +6340,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6302,6 +6431,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6634,6 +6768,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7055,6 +7194,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7086,6 +7230,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7103,6 +7257,11 @@ msgstr "Hole diesen Song:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Bringe Deine Freunde zum Wechseln und hilf uns zu wachsen!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7654,6 +7813,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8961,6 +9125,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Lässt dich anonym mit DuckDuckGo suchen"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9016,6 +9186,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9914,6 +10089,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Mehr als 20 Minuten"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10308,6 +10488,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10858,6 +11043,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "An, aber keine Zahlen"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11028,6 +11218,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11631,9 +11826,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11648,6 +11853,11 @@ msgstr "pink"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11904,6 +12114,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12073,6 +12288,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12515,6 +12735,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12542,6 +12772,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12664,6 +12899,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12966,6 +13206,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Alle Einstellungen zurücksetzten"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12974,6 +13219,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13535,6 +13785,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Suche anonym"
 
@@ -13819,6 +14074,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14223,6 +14483,11 @@ msgstr "Als standardmässige Suchmaschine festlegen"
 msgid "Set as Homepage"
 msgstr "Als Startseite festlegen"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14277,6 +14542,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14308,6 +14583,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14356,6 +14637,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14468,6 +14754,11 @@ msgstr "Lesezeichen und Einstellungen anzeigen"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Details anzeigen"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14591,6 +14882,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14619,6 +14915,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14919,6 +15220,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15151,6 +15457,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15629,6 +15940,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Wechsle zur Suchmaschine, welche Dich nicht verfolgt. Niemals."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15741,6 +16059,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15811,6 +16134,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Hole dir Deine Privatsphäre zurück!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16187,9 +16524,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16290,6 +16637,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16550,6 +16911,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16887,9 +17253,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Beginne eine Suche!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16943,6 +17319,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16953,6 +17334,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16976,6 +17362,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Probiere unsere Homepage aus, welche diese Nachrichten nie anzeigt:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17175,6 +17566,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17468,6 +17864,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17764,6 +18165,11 @@ msgstr "In Firefox verwenden"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "In Safari benutzen"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18690,6 +19096,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Was hat dich heute zurückgebracht?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19029,6 +19440,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19375,6 +19793,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19486,6 +19910,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19524,6 +19953,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19827,6 +20261,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20301,6 +20742,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s erkannt"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s Dateien verwendet"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -364,7 +364,7 @@ msgstr "%1$s verwendet"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s verbraucht Limits bis zu 2–5 x schneller als Basismodelle %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -622,7 +622,7 @@ msgstr "vor 1 Tag"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 Datei verwendet"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1278,8 +1278,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr ""
-"Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
+msgstr "Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1547,6 +1546,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Fortschrittliche Modelle können Limits 2–5 x schneller erreichen als andere "
+"Modelle. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1833,8 +1834,7 @@ msgstr "Anonyme Dateiüberprüfung für diesen Chat erlauben?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
+msgstr "Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2176,8 +2176,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
+msgstr "Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2346,7 +2345,7 @@ msgstr "Privat fragen"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Privat fragen"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2383,13 +2382,13 @@ msgid ""
 msgstr ""
 "Assist kann anonym KI-gestützte Antworten auf einige Suchanfragen "
 "generieren, die auf der Zusammenfassung relevanter Webinhalte basieren. Du "
-"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die Assist-"
-"Benutzeroberfläche wird vollständig aus den Suchergebnissen entfernt), Bei "
-"Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du auf die Assist-"
-"Schaltfläche klickst), Manchmal (KI-gestützte Antworten werden nur bei hoher "
-"Relevanz angezeigt) oder Oft (werden häufiger bei einer größeren Anzahl von "
-"Suchanfragen angezeigt). Derzeit sind KI-gestützte Antworten nur in den USA "
-"(Englisch) verfügbar."
+"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die "
+"Assist-Benutzeroberfläche wird vollständig aus den Suchergebnissen "
+"entfernt), Bei Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du "
+"auf die Assist-Schaltfläche klickst), Manchmal (KI-gestützte Antworten "
+"werden nur bei hoher Relevanz angezeigt) oder Oft (werden häufiger bei einer "
+"größeren Anzahl von Suchanfragen angezeigt). Derzeit sind KI-gestützte "
+"Antworten nur in den USA (Englisch) verfügbar."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2401,8 +2400,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym KI-"
-"gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
+"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym "
+"KI-gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
 "das Internet nach relevanten Inhalten und verwendet dann KI-gestützte "
 "natürliche Sprachtechnologie, um eine kurze Antwort auf der Grundlage der "
 "gefundenen relevanten Informationen zu generieren. Es ist wichtig, zu "
@@ -2560,8 +2559,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
+msgstr "Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2635,8 +2633,7 @@ msgstr "Durchschn. Vol."
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr ""
-"Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
+msgstr "Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2932,8 +2929,7 @@ msgstr "E-Mail-Tracker blockieren und deine Adresse verbergen."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
+msgstr "Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2949,8 +2945,7 @@ msgstr "Diese Seite in allen Ergebnissen blockieren"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
+msgstr "Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3208,9 +3203,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, Tracker-"
-"Blockade, und Website-Verschlüsselung – alles in einem Download, für %1$sdie "
-"wichtigsten Browser%2$s."
+"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, "
+"Tracker-Blockade, und Website-Verschlüsselung – alles in einem Download, für "
+"%1$sdie wichtigsten Browser%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3296,8 +3291,7 @@ msgstr "Indem du auf „%1$s“ klickst, akzeptierst du unsere %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
+msgstr "Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3318,11 +3312,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"Normalerweise werden die Einstellungen in nicht personenbezogenen Browser-"
-"Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save lassen sich "
-"Einstellungen dauerhafter sichern (auf einem Remote-Server in der Cloud). Es "
-"werden dabei keine personenbezogenen Daten in der Cloud gespeichert und die "
-"Passphrase verlässt nie den eigenen Browser."
+"Normalerweise werden die Einstellungen in nicht personenbezogenen "
+"Browser-Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save "
+"lassen sich Einstellungen dauerhafter sichern (auf einem Remote-Server in "
+"der Cloud). Es werden dabei keine personenbezogenen Daten in der Cloud "
+"gespeichert und die Passphrase verlässt nie den eigenen Browser."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3378,8 +3372,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
+msgstr "Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3707,8 +3700,7 @@ msgstr ""
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
+msgstr "Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3839,8 +3831,8 @@ msgstr ""
 "KI-Chatmodellen von Drittanbietern zu führen, etwa OpenAI oder Anthropic. "
 "Wenn du diese Einstellung deaktivierst, werden Chat-Schaltflächen und -Links "
 "in DuckDuckGo Search ausgeblendet. Du kannst jedoch auch dann auf den Chat "
-"zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://duck."
-"ai%2$s direkt besuchst."
+"zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
+"%1$shttps://duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3924,7 +3916,7 @@ msgstr "Privat mit KI chatten"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Privat mit beliebten KIs chatten"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3975,9 +3967,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf DuckDuckGo-"
-"Servern oder Remote-Servern. Wenn du den Chatverlauf deaktivierst, werden "
-"angeheftete Chats gelöscht."
+"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf "
+"DuckDuckGo-Servern oder Remote-Servern. Wenn du den Chatverlauf "
+"deaktivierst, werden angeheftete Chats gelöscht."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3990,11 +3982,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "Chats werden lokal auf deinem Gerät gespeichert. Neue Prompts und Antworten "
-"werden verschlüsselt und nach dem Senden vorübergehend auf einem DuckDuckGo-"
-"Server gespeichert, damit du einen Chat wiederherstellen kannst, falls deine "
-"Internetverbindung unterbrochen wird. Wenn du den Chatverlauf deaktivierst, "
-"werden angeheftete Chats gelöscht und die vorübergehende Speicherung neuer "
-"Aufforderungen und Antworten deaktiviert."
+"werden verschlüsselt und nach dem Senden vorübergehend auf einem "
+"DuckDuckGo-Server gespeichert, damit du einen Chat wiederherstellen kannst, "
+"falls deine Internetverbindung unterbrochen wird. Wenn du den Chatverlauf "
+"deaktivierst, werden angeheftete Chats gelöscht und die vorübergehende "
+"Speicherung neuer Aufforderungen und Antworten deaktiviert."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4017,8 +4009,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in Duck."
-"ai hochgeladenen Dateien werden anonym von einem Anbieter für "
+"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in "
+"Duck.ai hochgeladenen Dateien werden anonym von einem Anbieter für "
 "Inhaltsmoderation auf %2$s überprüft."
 
 # smartling.placeholder_format=C
@@ -4152,8 +4144,7 @@ msgstr "Auswahl von KI-Modellen, darunter %1$s und %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
+msgstr "Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4725,7 +4716,7 @@ msgstr "Schließen"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Schließen"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4775,7 +4766,7 @@ msgstr "Suche schließen"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Zweite Meinung schließen"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5152,7 +5143,7 @@ msgstr "Weiterhin Werbung blocken"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Setze aktuelle Chats hier fort. Oder lösche sie mit dem Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5223,7 +5214,7 @@ msgstr "Cookie-Daten"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Kopiert"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5278,7 +5269,7 @@ msgstr "Code kopieren"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Link kopieren"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5399,7 +5390,7 @@ msgstr "Bild erstellen"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "„Link teilen“ erstellen"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5451,6 +5442,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Wenn du einen Link erstellst, wird eine Kopie des Chats erstellt, die von "
+"jedem angesehen werden kann, der sie öffnet."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5609,7 +5602,7 @@ msgstr "Antworten anpassen"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Antworten anpassen"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5676,8 +5669,7 @@ msgstr "Tageslimit erreicht"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
+msgstr "Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5900,7 +5892,7 @@ msgstr "Serverdaten löschen?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Geteilten Link löschen"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5912,7 +5904,7 @@ msgstr "Transkript löschen"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Einen Chat löschen"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5950,7 +5942,7 @@ msgstr "Bild löschen?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Lösch mich"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5986,8 +5978,7 @@ msgstr "Gelöschte Chats"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
+msgstr "Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6009,8 +6000,7 @@ msgstr "Beschreibe die Änderungen basierend auf dem Bild"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
+msgstr "Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6079,8 +6069,8 @@ msgstr "Diktierfunktion in Duck.ai"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von KI-"
-"Modellen verwendet."
+"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von "
+"KI-Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6266,7 +6256,7 @@ msgstr "Werbung verwerfen"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Tour verwerfen"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6423,8 +6413,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne KI-"
-"Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
+"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne "
+"KI-Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
 "erfahren%4$s"
 
 # smartling.placeholder_format=C
@@ -6485,7 +6475,7 @@ msgstr "DuckDuckGo herunterladen"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "DuckDuckGo herunterladen"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6706,7 +6696,7 @@ msgstr "Duck.ai von DuckDuckGo. Privater KI-Chat. Kostenlos."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai kann jetzt PDFs analysieren. Probiere es aus!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6832,10 +6822,10 @@ msgid ""
 msgstr ""
 "Mit Duck.ai kannst du anonyme Unterhaltungen mit KI-Chatmodellen von "
 "Drittanbietern führen, darunter Modelle von OpenAI, Anthropic und anderen. "
-"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und -"
-"Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf Duck."
-"ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://"
-"duck.ai%2$s direkt besuchst."
+"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und "
+"-Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf "
+"Duck.ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
+"%1$shttps://duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6872,7 +6862,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai unterstützt Modelle von Anthropic, OpenAI und anderen."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7029,8 +7019,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die Chat-"
-"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die "
+"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7039,8 +7029,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die Chat-"
-"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die "
+"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7529,7 +7519,7 @@ msgstr "Meistbesuchte Seiten aktivieren"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Jetzt aktivieren"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7729,8 +7719,7 @@ msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist"
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure location access is %sallowed%s."
-msgstr ""
-"Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
+msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7846,7 +7835,7 @@ msgstr "Unterhaltungsanleitung"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Gesamter Chat"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7856,8 +7845,7 @@ msgstr "Äquatorialguinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
+msgstr "Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7950,8 +7938,7 @@ msgstr "Erkläre die akzeptierte Antwort in einfachen Worten."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
+msgstr "Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8017,13 +8004,13 @@ msgstr "Explizite Liedtexte"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai erkunden"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai erkunden"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8130,7 +8117,7 @@ msgstr "Kostenlos"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "KOSTENLOS UND OPTIONAL"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8459,8 +8446,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
+msgstr "Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8559,7 +8545,7 @@ msgstr "Speicherplatz freigeben"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Kostenlos und immer privat"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8571,8 +8557,7 @@ msgstr "Kostenlose und private Chats, von uns anonymisiert"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
+msgstr "Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8685,9 +8670,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Wähle in der Menüleiste der Anwendung auf dem Mac <strong>DuckDuckGo</"
-"strong> &gt; <strong>Nach Updates suchen ...</strong> und dann "
-"<strong>Update installieren</strong>."
+"Wähle in der Menüleiste der Anwendung auf dem Mac "
+"<strong>DuckDuckGo</strong> &gt; <strong>Nach Updates suchen ...</strong> "
+"und dann <strong>Update installieren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9031,8 +9016,7 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections. Try it for free!"
-msgstr ""
-"Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
+msgstr "Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9042,8 +9026,8 @@ msgid ""
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
 "Erhalte Zugang zu den fortschrittlichen KI-Modellen in Duck.ai, indem du "
-"DuckDuckGo abonnierst, was auch unser VPN und andere Premium-"
-"Datenschutzmaßnahmen beinhaltet."
+"DuckDuckGo abonnierst, was auch unser VPN und andere "
+"Premium-Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9054,9 +9038,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen KI-"
-"Modellen in Duck.ai, das auch unser VPN und andere Premium-"
-"Datenschutzmaßnahmen beinhaltet."
+"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen "
+"KI-Modellen in Duck.ai, das auch unser VPN und andere "
+"Premium-Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9085,7 +9069,7 @@ msgstr "Hol dir Computerhilfe"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Erhalte höhere Nutzungslimits mit einem DuckDuckGo-Abo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9128,13 +9112,15 @@ msgstr "Hol dir die neueste Version"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Hol dir die App"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Hol dir den kostenlosen DuckDuckGo Browser, %1$sum Werbung auf YouTube zu "
+"blockieren.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9162,7 +9148,7 @@ msgstr "Bringe deine Freunde dazu zu wechseln und hilf uns dabei, zu wachsen!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Checkliste für die ersten Schritte"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9228,9 +9214,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu %1$sDuck.ai-"
-"Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit einem anderen "
-"Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
+"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu "
+"%1$sDuck.ai-Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit "
+"einem anderen Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
 "Wiederherstellungs-PDF."
 
 # smartling.placeholder_format=C
@@ -9761,15 +9747,13 @@ msgstr "Hilf uns zu verstehen, was wir falsch gemacht haben"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
+msgstr "Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
+msgstr "Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9781,8 +9765,7 @@ msgstr "Hilfreich"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr ""
-"Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
+msgstr "Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -9858,7 +9841,7 @@ msgstr "Tipps ausblenden"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Tutorial ausblenden"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9988,8 +9971,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"Achtung! Wenn du die Einstellung zurücksetzt, wird die DuckDuckGo-"
-"Erweiterung deaktiviert und du verlierst unseren Datenschutz."
+"Achtung! Wenn du die Einstellung zurücksetzt, wird die "
+"DuckDuckGo-Erweiterung deaktiviert und du verlierst unseren Datenschutz."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10309,8 +10292,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Ich mag das Buch „Der Name des Windes“. Welche anderen guten Bücher/"
-"Buchreihen ähneln diesem am meisten und warum?"
+"Ich mag das Buch „Der Name des Windes“. Welche anderen guten "
+"Bücher/Buchreihen ähneln diesem am meisten und warum?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10385,9 +10368,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten Chat-"
-"Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an %1$s "
-"und %2$s wenden."
+"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten "
+"Chat-Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an "
+"%1$s und %2$s wenden."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10425,8 +10408,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue "
-"Tabs« (öffnen mit) aus."
+"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue Tabs« "
+"(öffnen mit) aus."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10955,8 +10938,7 @@ msgstr "Lohnt es sich, das anzuschauen?"
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
-"Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
+msgstr "Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11494,6 +11476,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Lässt dich zwischen dem Absenden von Suchanfragen und Prompts an Duck.ai "
+"wechseln"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11571,7 +11555,7 @@ msgstr "Gewonnene Lineouts"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Link läuft in 7 Tagen ab."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12675,7 +12659,7 @@ msgstr "Länger als 20 Minuten"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Weitere Tipps"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12912,8 +12896,7 @@ msgstr "Niederlande"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a network error occurs during dictation upload.
 msgid "Network error. Please check your connection and try again."
-msgstr ""
-"Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
+msgstr "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
 
 # smartling.placeholder_format=C
 #. The title of the 'Never' option in the assist settings modal.
@@ -13171,7 +13154,7 @@ msgstr "Nein, danke"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nein, danke"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13319,8 +13302,7 @@ msgstr "Keine Ergebnisse gefunden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
+msgstr "Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13840,7 +13822,7 @@ msgstr "An, aber keine Zahlen"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Onboarding abgeschlossen"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13976,8 +13958,7 @@ msgstr "%1$sEinstellungen%2$s öffnen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
+msgstr "Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14061,7 +14042,7 @@ msgstr "Vorschläge zum Erstellen und Bearbeiten von Bildern öffnen"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Checkliste für die ersten Schritte öffnen"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14126,8 +14107,7 @@ msgstr "Öffne das Bedienfeld „So funktioniert Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
+msgstr "Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14709,8 +14689,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als vollständigen Fragesatz formulierst, ist es "
 "wahrscheinlicher, dass KI-gestützte Antworten automatisch erscheinen, und du "
-"erhältst oft bessere Antworten. Um sie auszuschalten und die Assist-"
-"Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
+"erhältst oft bessere Antworten. Um sie auszuschalten und die "
+"Assist-Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14734,8 +14714,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als Frage und in einem vollständigen Satz formulierst, "
 "ist es wahrscheinlicher, dass DuckAssist automatisch erscheint, und du "
-"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die Assist-"
-"Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
+"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die "
+"Assist-Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14815,7 +14795,7 @@ msgstr "Anpinnen"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Einen Chat anheften"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14827,7 +14807,7 @@ msgstr "Chats aus dem %1$s %2$s hier anpinnen"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Anpinnen"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14850,7 +14830,7 @@ msgstr "Angepinnt"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Angeheftete Chats werden oben in deinen aktuellen Chats angezeigt."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15182,6 +15162,8 @@ msgstr "Schlechte Formatierung"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Beliebte KI-Modelle verfügbar. Kein Konto erforderlich. Chats von uns "
+"anonymisiert."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15395,7 +15377,7 @@ msgstr "Vorherige Tabs"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Vorherige Tipps"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15941,13 +15923,15 @@ msgstr "Argumentierende KI mit mittlerer eingebauter Moderation"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Begründung kann bessere Antworten auf komplexe Fragen liefern."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Die Begründung ist ausführlicher, verbraucht die Limits aber 2–5 x so "
+"schnell. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15988,7 +15972,7 @@ msgstr "Der Speicher für aktuelle Chats kann in den %1$s angepasst werden."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Aktuelle Chats"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16149,7 +16133,7 @@ msgstr "Nutzung reduzieren"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Reduziere die Nutzung mit einem effizienteren Modell"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16310,8 +16294,7 @@ msgstr "Meine Auswahl merken"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
+msgstr "Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16533,7 +16516,7 @@ msgstr "Alle Einstellungen zurücksetzen"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Tutorial zurücksetzen"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16551,7 +16534,7 @@ msgstr "Auflösung"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Antwort"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -17048,8 +17031,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit Ende-zu-Ende-"
-"Verschlüsselung."
+"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit "
+"Ende-zu-Ende-Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17189,8 +17172,7 @@ msgstr "Scrolle herunter und wähle %1$sErweiterte Einstellungen%2$s aus"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
+msgstr "Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17265,7 +17247,7 @@ msgstr "Nach %1$s suchen, um Ergebnisse in deiner Nähe zu finden?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Umschalter für Suche & Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17467,8 +17449,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die POST-"
-"Methode verwendet)"
+"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die "
+"POST-Methode verwendet)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17578,8 +17560,7 @@ msgstr "Zweite Meinung"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
+msgstr "Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17588,8 +17569,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17598,8 +17579,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17608,9 +17589,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen synchronisierten Geräten "
-"darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen synchronisierten "
+"Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17619,16 +17600,16 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Speichere deine Chats sicher auf unserem Server mit Ende-zu-Ende-"
-"Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere deine Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
-"Verschlüsselung."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit "
+"End-to-End-Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17637,14 +17618,15 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
-"Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht einmal wir."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit "
+"End-to-End-Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht "
+"einmal wir."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Sicher gespeichert auf unserem verschlüsselten Server."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17755,8 +17737,7 @@ msgstr "Entdecke einige unserer neuesten Updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
+msgstr "Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17783,8 +17764,7 @@ msgstr "%1$s%2$s%3$s auswählen, dann %4$sSuchmaschine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
+msgstr "Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17810,15 +17790,13 @@ msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
+msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
+msgstr "Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18168,7 +18146,7 @@ msgstr "Als Startseite festlegen"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Leg den Ton und Stil der Antworten von Duck.ai fest."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18241,13 +18219,13 @@ msgstr "Seychellen"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Teilen"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Teilen"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18258,8 +18236,7 @@ msgstr "Teilen"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
+msgstr "Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18287,15 +18264,15 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Teile den Standort in Form der Stadt mit KI-Modellen, um die Relevanz zu "
-"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder KI-"
-"Modelle weiter."
+"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder "
+"KI-Modelle weiter."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Chat teilen"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18359,7 +18336,7 @@ msgstr "Positives Feedback teilen"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Freigabeumfang"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18500,7 +18477,7 @@ msgstr "Details anzeigen"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Duck.ai-Tutorial anzeigen"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18511,8 +18488,7 @@ msgstr "DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
+msgstr "DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18656,7 +18632,7 @@ msgstr "Mehr anzeigen"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Mehr Modelle anzeigen"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18697,7 +18673,7 @@ msgstr "Seitenleiste anzeigen"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18845,8 +18821,7 @@ msgstr "Begrüßung oben auf der Suchergebnisseite anzeigen"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
+msgstr "Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18925,8 +18900,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
+msgstr "Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19087,7 +19061,7 @@ msgstr "Etwas ist schiefgelaufen, bitte versuche es später noch einmal."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Etwas ist schiefgelaufen. Bitte versuche es noch einmal."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19132,8 +19106,7 @@ msgstr "Entschuldigung, ein unerwarteter Fehler ist aufgetreten."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
+msgstr "Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -19392,7 +19365,7 @@ msgstr "Beginne mit der Nutzung des Wochenlimits"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Starte einen neuen Chat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19409,8 +19382,7 @@ msgstr "Beginne mit einem Bild"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
+msgstr "Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19447,8 +19419,8 @@ msgstr "Bleib auf DuckDuckGo"
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
 msgstr ""
-"Bleibe gut geschützt und gut informiert – mit unseren Privatsphäre-"
-"Newslettern."
+"Bleibe gut geschützt und gut informiert – mit unseren "
+"Privatsphäre-Newslettern."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19503,8 +19475,7 @@ msgstr "Versteckte Tracker stoppen, die auf anderen Websites lauern."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
+msgstr "Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19726,8 +19697,7 @@ msgstr "Q&As zusammenfassen"
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
-"Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
+msgstr "Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
@@ -19985,7 +19955,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Zu dieser zweiten Meinung wechseln"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20149,7 +20119,7 @@ msgstr "Sync und Backup sind vorübergehend nicht verfügbar"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Chats geräteübergreifend synchronisieren"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20245,6 +20215,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Nimm Duck.ai überallhin mit. Hol es dir direkt in unserer kostenlosen App "
+"für schnelleren Zugriff, wo immer du bist."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20253,6 +20225,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Nimm Duck.ai überallhin mit. Hol es dir integriert in unseren kostenlosen "
+"Browser für schnelleren Zugriff, egal, wo du das Internet nutzt."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20521,8 +20495,7 @@ msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s 
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
+msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20554,8 +20527,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
+msgstr "Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20722,8 +20694,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
+msgstr "Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20735,7 +20706,7 @@ msgstr "Dieser Monat"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Diese Antwort"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20747,7 +20718,7 @@ msgstr "Diese Woche"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Dieser Chat bleibt in Duck.ai und für dich privat."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20756,8 +20727,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des %3$s-"
-"Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
+"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des "
+"%3$s-Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
 "anstößige Informationen an (weitere Informationen siehe %4$s)."
 
 # smartling.placeholder_format=C
@@ -20889,6 +20860,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Das ist nur ein Beispiel-Chat. Öffne das Menü (die drei Punkte) und wähle "
+"Anheften, um ihn ganz oben in deinen Chats zu behalten!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20897,6 +20870,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Das ist nur ein Beispiel-Chat. Verwende den Fire Button im Seitenmenü, um "
+"ihn zu löschen!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20977,8 +20952,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
-"gestützte Antworten."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
+"KI-gestützte Antworten."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20989,9 +20964,9 @@ msgid ""
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
-"gestützte Antworten. Allerdings haben wir auch eine Startseite unter %1$s, "
-"auf der niemals KI-gestützte Antworten angezeigt werden."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
+"KI-gestützte Antworten. Allerdings haben wir auch eine Startseite unter "
+"%1$s, auf der niemals KI-gestützte Antworten angezeigt werden."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -21022,8 +20997,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
+msgstr "Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21141,8 +21115,7 @@ msgstr "Tipps"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
+msgstr "Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21249,6 +21222,8 @@ msgstr "Heute"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Schalte um, um den privaten KI-Chat auszuprobieren, oder %1$sdeaktiviere ihn "
+"im Menü %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21596,8 +21571,7 @@ msgstr "Versuche, %1$s, um solche Nachrichten nicht mehr zu sehen."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
+msgstr "Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21666,7 +21640,7 @@ msgstr "Probiere sie aus."
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Versuche ein anderes Modell"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21677,7 +21651,7 @@ msgstr "Probiere eine Suche!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Probiere einen Vorschlag aus"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21749,7 +21723,7 @@ msgstr "Gratis testen"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Gratis testen"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21763,14 +21737,13 @@ msgstr "Gratis testen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
+msgstr "Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "7 Tage lang kostenlos testen"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21803,7 +21776,7 @@ msgstr "Benutze unsere Homepage, die nie solche Nachrichten anzeigt:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Begründung ausprobieren"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21826,8 +21799,7 @@ msgstr "Versuche deinen Standort manuell einzustellen."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
+msgstr "Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -21873,8 +21845,7 @@ msgstr "Probiere den neuen privaten Echtzeit-Sprachchat aus!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
+msgstr "Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -21898,8 +21869,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr ""
-"Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
+msgstr "Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -21936,9 +21906,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No AI%2$s-"
-"Sucherweiterung, damit deine Einstellungen gespeichert bleiben. %3$sMehr "
-"erfahren%4$s"
+"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No "
+"AI%2$s-Sucherweiterung, damit deine Einstellungen gespeichert bleiben. "
+"%3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22052,8 +22022,7 @@ msgstr "Abschalten:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
+msgstr "Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22064,7 +22033,7 @@ msgstr "Schalte den Duck Player ein, um YouTube ohne gezielte Werbung zu sehen"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Umschalter von Duck.ai einschalten"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22076,8 +22045,7 @@ msgstr "Aktiviere „Präziser Standort“, um genauere Ergebnisse zu erhalten."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
+msgstr "Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22274,8 +22242,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s https://"
-"duckduckgo.com eingeben"
+"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s "
+"https://duckduckgo.com eingeben"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22307,8 +22275,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
+msgstr "Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22425,8 +22392,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem DuckDuckGo-"
-"Abo frei"
+"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem "
+"DuckDuckGo-Abo frei"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22451,7 +22418,7 @@ msgstr "Erhalte mit einem Abonnement Zugriff auf erweiterte KI!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Fortschrittliche Modelle freischalten"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22465,8 +22432,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
+msgstr "Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22823,7 +22789,7 @@ msgstr "In Safari verwenden"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Verwende den Fire Button, um einen Chat aus dem Verlauf zu löschen."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22848,8 +22814,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
+msgstr "Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23150,8 +23115,8 @@ msgstr "Sprachchat beendet"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von KI-"
-"Modellen verwendet."
+"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von "
+"KI-Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23296,8 +23261,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Benutze den Duck Player, um personalisierte Werbung auf YouTube zu "
-"blockieren und zu verhindern, dass deine Aktivitäten die YouTube-"
-"Empfehlungen beeinflussen."
+"blockieren und zu verhindern, dass deine Aktivitäten die "
+"YouTube-Empfehlungen beeinflussen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23444,8 +23409,7 @@ msgstr "Wir tracken dich nicht. Niemals."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
+msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23486,8 +23450,7 @@ msgstr "Wir tracken dich nicht, ob im privaten oder normalen Modus."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
+msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23517,8 +23480,7 @@ msgstr "Wir halten deinen Suchverlauf privat"
 #. Displayed when the voice chat connection is lost and the session ends.
 msgctxt "voice chat error"
 msgid "We lost the connection, please try again later."
-msgstr ""
-"Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
+msgstr "Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
 
 # smartling.placeholder_format=C
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
@@ -23559,8 +23521,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
+msgstr "Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23915,11 +23876,11 @@ msgid ""
 "experience."
 msgstr ""
 "Welche Vorteile bietet das Herunterladen des DuckDuckGo-Browsers für "
-"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle DuckDuckGo-"
-"Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit Titeln auf, "
-"wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem Datenschutz "
-"liegt. Halte es sehr kurz, einfach und leicht verständlich für Menschen mit "
-"oder ohne viel KI- oder technische Erfahrung."
+"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle "
+"DuckDuckGo-Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit "
+"Titeln auf, wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem "
+"Datenschutz liegt. Halte es sehr kurz, einfach und leicht verständlich für "
+"Menschen mit oder ohne viel KI- oder technische Erfahrung."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24004,8 +23965,7 @@ msgstr "Was muss man hier unbedingt probieren?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
+msgstr "Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24035,7 +23995,7 @@ msgstr "Was hat dich wieder hergeführt?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Was kannst du tun?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24468,6 +24428,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Bei Duck.ai werden Chats anonymisiert und niemals zum Trainieren von KI "
+"verwendet. Kann jederzeit im Menü „%1$s“ ein- oder ausgeschaltet werden."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24820,8 +24782,7 @@ msgstr "Du kannst dies jederzeit in den %1$sSucheinstellungen%2$s ändern"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
+msgstr "Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24905,7 +24866,7 @@ msgstr "Du kannst nur %1$s Bilder pro Gespräch anhängen."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Du kannst jeweils nur %1$s Tabs gleichzeitig anhängen."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -25060,7 +25021,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Du bist startklar!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -25113,7 +25074,7 @@ msgstr "Du hast 1 Seite blockiert"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Du hast die Grundlagen von Duck.ai gemeistert"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25125,8 +25086,7 @@ msgstr "Du hast das Limit für die Erstellung von Bildern erreicht."
 #. Title shown when a user has reached their image generation edit limit.
 msgctxt "Title for image generation edit limit reached message"
 msgid "You've reached the maximum number of edits for this image"
-msgstr ""
-"Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
+msgstr "Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum number of messages for a given moment, and should try again later when they might be able to send more messages again.
@@ -25433,8 +25393,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
+msgstr "Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25531,6 +25490,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
+"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No "
+"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25540,15 +25502,14 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No AI%2$s-"
-"Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
+"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No "
+"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
+msgstr "Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26131,4 +26092,4 @@ msgstr "J"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "vor %1$s Tagen"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s erkannt"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -353,6 +359,12 @@ msgstr "%1$s Tracking-Versuche blockiert"
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
 msgstr "%1$s verwendet"
+
+# smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -605,6 +617,12 @@ msgstr "1 Versuch von DuckDuckGo in den letzten 24 Stunden blockiert"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "vor 1 Tag"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1260,7 +1278,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr "Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
+msgstr ""
+"Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1520,6 +1539,14 @@ msgctxt ""
 "app variant)"
 msgid "Advanced Models"
 msgstr "Fortschrittliche Modelle"
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1806,7 +1833,8 @@ msgstr "Anonyme Dateiüberprüfung für diesen Chat erlauben?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
+msgstr ""
+"Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2148,7 +2176,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
+msgstr ""
+"Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2314,6 +2343,12 @@ msgid "Ask privately"
 msgstr "Privat fragen"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2348,13 +2383,13 @@ msgid ""
 msgstr ""
 "Assist kann anonym KI-gestützte Antworten auf einige Suchanfragen "
 "generieren, die auf der Zusammenfassung relevanter Webinhalte basieren. Du "
-"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die "
-"Assist-Benutzeroberfläche wird vollständig aus den Suchergebnissen "
-"entfernt), Bei Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du "
-"auf die Assist-Schaltfläche klickst), Manchmal (KI-gestützte Antworten "
-"werden nur bei hoher Relevanz angezeigt) oder Oft (werden häufiger bei einer "
-"größeren Anzahl von Suchanfragen angezeigt). Derzeit sind KI-gestützte "
-"Antworten nur in den USA (Englisch) verfügbar."
+"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die Assist-"
+"Benutzeroberfläche wird vollständig aus den Suchergebnissen entfernt), Bei "
+"Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du auf die Assist-"
+"Schaltfläche klickst), Manchmal (KI-gestützte Antworten werden nur bei hoher "
+"Relevanz angezeigt) oder Oft (werden häufiger bei einer größeren Anzahl von "
+"Suchanfragen angezeigt). Derzeit sind KI-gestützte Antworten nur in den USA "
+"(Englisch) verfügbar."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2366,8 +2401,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym "
-"KI-gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
+"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym KI-"
+"gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
 "das Internet nach relevanten Inhalten und verwendet dann KI-gestützte "
 "natürliche Sprachtechnologie, um eine kurze Antwort auf der Grundlage der "
 "gefundenen relevanten Informationen zu generieren. Es ist wichtig, zu "
@@ -2525,7 +2560,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
+msgstr ""
+"Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2599,7 +2635,8 @@ msgstr "Durchschn. Vol."
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr "Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
+msgstr ""
+"Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2895,7 +2932,8 @@ msgstr "E-Mail-Tracker blockieren und deine Adresse verbergen."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
+msgstr ""
+"Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2911,7 +2949,8 @@ msgstr "Diese Seite in allen Ergebnissen blockieren"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
+msgstr ""
+"Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3169,9 +3208,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, "
-"Tracker-Blockade, und Website-Verschlüsselung – alles in einem Download, für "
-"%1$sdie wichtigsten Browser%2$s."
+"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, Tracker-"
+"Blockade, und Website-Verschlüsselung – alles in einem Download, für %1$sdie "
+"wichtigsten Browser%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3257,7 +3296,8 @@ msgstr "Indem du auf „%1$s“ klickst, akzeptierst du unsere %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
+msgstr ""
+"Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3278,11 +3318,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"Normalerweise werden die Einstellungen in nicht personenbezogenen "
-"Browser-Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save "
-"lassen sich Einstellungen dauerhafter sichern (auf einem Remote-Server in "
-"der Cloud). Es werden dabei keine personenbezogenen Daten in der Cloud "
-"gespeichert und die Passphrase verlässt nie den eigenen Browser."
+"Normalerweise werden die Einstellungen in nicht personenbezogenen Browser-"
+"Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save lassen sich "
+"Einstellungen dauerhafter sichern (auf einem Remote-Server in der Cloud). Es "
+"werden dabei keine personenbezogenen Daten in der Cloud gespeichert und die "
+"Passphrase verlässt nie den eigenen Browser."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3338,7 +3378,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
+msgstr ""
+"Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3666,7 +3707,8 @@ msgstr ""
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
+msgstr ""
+"Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3797,8 +3839,8 @@ msgstr ""
 "KI-Chatmodellen von Drittanbietern zu führen, etwa OpenAI oder Anthropic. "
 "Wenn du diese Einstellung deaktivierst, werden Chat-Schaltflächen und -Links "
 "in DuckDuckGo Search ausgeblendet. Du kannst jedoch auch dann auf den Chat "
-"zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
-"%1$shttps://duck.ai%2$s direkt besuchst."
+"zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://duck."
+"ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3879,6 +3921,12 @@ msgid "Chat privately with AI"
 msgstr "Privat mit KI chatten"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3927,9 +3975,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf "
-"DuckDuckGo-Servern oder Remote-Servern. Wenn du den Chatverlauf "
-"deaktivierst, werden angeheftete Chats gelöscht."
+"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf DuckDuckGo-"
+"Servern oder Remote-Servern. Wenn du den Chatverlauf deaktivierst, werden "
+"angeheftete Chats gelöscht."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3942,11 +3990,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "Chats werden lokal auf deinem Gerät gespeichert. Neue Prompts und Antworten "
-"werden verschlüsselt und nach dem Senden vorübergehend auf einem "
-"DuckDuckGo-Server gespeichert, damit du einen Chat wiederherstellen kannst, "
-"falls deine Internetverbindung unterbrochen wird. Wenn du den Chatverlauf "
-"deaktivierst, werden angeheftete Chats gelöscht und die vorübergehende "
-"Speicherung neuer Aufforderungen und Antworten deaktiviert."
+"werden verschlüsselt und nach dem Senden vorübergehend auf einem DuckDuckGo-"
+"Server gespeichert, damit du einen Chat wiederherstellen kannst, falls deine "
+"Internetverbindung unterbrochen wird. Wenn du den Chatverlauf deaktivierst, "
+"werden angeheftete Chats gelöscht und die vorübergehende Speicherung neuer "
+"Aufforderungen und Antworten deaktiviert."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3969,8 +4017,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in "
-"Duck.ai hochgeladenen Dateien werden anonym von einem Anbieter für "
+"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in Duck."
+"ai hochgeladenen Dateien werden anonym von einem Anbieter für "
 "Inhaltsmoderation auf %2$s überprüft."
 
 # smartling.placeholder_format=C
@@ -4104,7 +4152,8 @@ msgstr "Auswahl von KI-Modellen, darunter %1$s und %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
+msgstr ""
+"Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4673,6 +4722,12 @@ msgid "Close"
 msgstr "Schließen"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4715,6 +4770,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Suche schließen"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5088,6 +5149,12 @@ msgid "Continue Blocking Ads"
 msgstr "Weiterhin Werbung blocken"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5153,6 +5220,12 @@ msgid "Cookie data:"
 msgstr "Cookie-Daten"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5200,6 +5273,12 @@ msgstr ""
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Code kopieren"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5317,6 +5396,12 @@ msgid "Create Image"
 msgstr "Bild erstellen"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5358,6 +5443,14 @@ msgstr "Erstellt von"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Erstellt von %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5513,6 +5606,12 @@ msgid "Customize responses"
 msgstr "Antworten anpassen"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "Diese Seite anpassen"
@@ -5577,7 +5676,8 @@ msgstr "Tageslimit erreicht"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
+msgstr ""
+"Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5797,10 +5897,22 @@ msgid "Delete Server Data?"
 msgstr "Serverdaten löschen?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Transkript löschen"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5833,6 +5945,12 @@ msgstr "Bild löschen"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Bild löschen?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5868,7 +5986,8 @@ msgstr "Gelöschte Chats"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
+msgstr ""
+"Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -5890,7 +6009,8 @@ msgstr "Beschreibe die Änderungen basierend auf dem Bild"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
+msgstr ""
+"Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -5959,8 +6079,8 @@ msgstr "Diktierfunktion in Duck.ai"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von "
-"KI-Modellen verwendet."
+"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von KI-"
+"Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6143,6 +6263,12 @@ msgid "Dismiss promotion"
 msgstr "Werbung verwerfen"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6297,8 +6423,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne "
-"KI-Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
+"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne KI-"
+"Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
 "erfahren%4$s"
 
 # smartling.placeholder_format=C
@@ -6354,6 +6480,12 @@ msgstr "Download abgeschlossen"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "DuckDuckGo herunterladen"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6571,6 +6703,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai von DuckDuckGo. Privater KI-Chat. Kostenlos."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6694,10 +6832,10 @@ msgid ""
 msgstr ""
 "Mit Duck.ai kannst du anonyme Unterhaltungen mit KI-Chatmodellen von "
 "Drittanbietern führen, darunter Modelle von OpenAI, Anthropic und anderen. "
-"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und "
-"-Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf "
-"Duck.ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
-"%1$shttps://duck.ai%2$s direkt besuchst."
+"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und -"
+"Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf Duck."
+"ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://"
+"duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6729,6 +6867,12 @@ msgid ""
 msgstr ""
 "Die Antworten von Duck.ai basieren nicht auf spezifischen Quellen und wurden "
 "nicht auf ihre Richtigkeit überprüft."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6885,8 +7029,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die "
-"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die Chat-"
+"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6895,8 +7039,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die "
-"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die Chat-"
+"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7382,6 +7526,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Meistbesuchte Seiten aktivieren"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7579,7 +7729,8 @@ msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist"
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure location access is %sallowed%s."
-msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
+msgstr ""
+"Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7692,6 +7843,12 @@ msgid "Entertainment guide"
 msgstr "Unterhaltungsanleitung"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Äquatorialguinea"
 
@@ -7699,7 +7856,8 @@ msgstr "Äquatorialguinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
+msgstr ""
+"Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7792,7 +7950,8 @@ msgstr "Erkläre die akzeptierte Antwort in einfachen Worten."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
+msgstr ""
+"Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7853,6 +8012,18 @@ msgstr "Expliziter Inhalt"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Explizite Liedtexte"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7954,6 +8125,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Kostenlos"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8282,7 +8459,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
+msgstr ""
+"Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8378,6 +8556,12 @@ msgid "Free Up Storage"
 msgstr "Speicherplatz freigeben"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8387,7 +8571,8 @@ msgstr "Kostenlose und private Chats, von uns anonymisiert"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
+msgstr ""
+"Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8500,9 +8685,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Wähle in der Menüleiste der Anwendung auf dem Mac "
-"<strong>DuckDuckGo</strong> &gt; <strong>Nach Updates suchen ...</strong> "
-"und dann <strong>Update installieren</strong>."
+"Wähle in der Menüleiste der Anwendung auf dem Mac <strong>DuckDuckGo</"
+"strong> &gt; <strong>Nach Updates suchen ...</strong> und dann "
+"<strong>Update installieren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8846,7 +9031,8 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections. Try it for free!"
-msgstr "Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
+msgstr ""
+"Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -8856,8 +9042,8 @@ msgid ""
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
 "Erhalte Zugang zu den fortschrittlichen KI-Modellen in Duck.ai, indem du "
-"DuckDuckGo abonnierst, was auch unser VPN und andere "
-"Premium-Datenschutzmaßnahmen beinhaltet."
+"DuckDuckGo abonnierst, was auch unser VPN und andere Premium-"
+"Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8868,9 +9054,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen "
-"KI-Modellen in Duck.ai, das auch unser VPN und andere "
-"Premium-Datenschutzmaßnahmen beinhaltet."
+"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen KI-"
+"Modellen in Duck.ai, das auch unser VPN und andere Premium-"
+"Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8894,6 +9080,12 @@ msgstr "Erhalte Antworten in der DuckDuckGo-Hilfe."
 msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr "Hol dir Computerhilfe"
+
+# smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8933,6 +9125,18 @@ msgid "Get the Latest Version"
 msgstr "Hol dir die neueste Version"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8953,6 +9157,12 @@ msgstr "Titel erhältlich auf:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Bringe deine Freunde dazu zu wechseln und hilf uns dabei, zu wachsen!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9018,9 +9228,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu "
-"%1$sDuck.ai-Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit "
-"einem anderen Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
+"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu %1$sDuck.ai-"
+"Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit einem anderen "
+"Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
 "Wiederherstellungs-PDF."
 
 # smartling.placeholder_format=C
@@ -9551,13 +9761,15 @@ msgstr "Hilf uns zu verstehen, was wir falsch gemacht haben"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
+msgstr ""
+"Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
+msgstr ""
+"Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9569,7 +9781,8 @@ msgstr "Hilfreich"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr "Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
+msgstr ""
+"Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -9640,6 +9853,12 @@ msgstr "Teilschritte ausblenden"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Tipps ausblenden"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9769,8 +9988,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"Achtung! Wenn du die Einstellung zurücksetzt, wird die "
-"DuckDuckGo-Erweiterung deaktiviert und du verlierst unseren Datenschutz."
+"Achtung! Wenn du die Einstellung zurücksetzt, wird die DuckDuckGo-"
+"Erweiterung deaktiviert und du verlierst unseren Datenschutz."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10090,8 +10309,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Ich mag das Buch „Der Name des Windes“. Welche anderen guten "
-"Bücher/Buchreihen ähneln diesem am meisten und warum?"
+"Ich mag das Buch „Der Name des Windes“. Welche anderen guten Bücher/"
+"Buchreihen ähneln diesem am meisten und warum?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10166,9 +10385,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten "
-"Chat-Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an "
-"%1$s und %2$s wenden."
+"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten Chat-"
+"Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an %1$s "
+"und %2$s wenden."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10206,8 +10425,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue Tabs« "
-"(öffnen mit) aus."
+"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue "
+"Tabs« (öffnen mit) aus."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10736,7 +10955,8 @@ msgstr "Lohnt es sich, das anzuschauen?"
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr "Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
+msgstr ""
+"Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -11269,6 +11489,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Mit DuckDuckGo kannst du anonym suchen"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11339,6 +11566,12 @@ msgstr "Strichzeichnung"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Gewonnene Lineouts"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12439,6 +12672,12 @@ msgid "More than 20 minutes"
 msgstr "Länger als 20 Minuten"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12673,7 +12912,8 @@ msgstr "Niederlande"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a network error occurs during dictation upload.
 msgid "Network error. Please check your connection and try again."
-msgstr "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
+msgstr ""
+"Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
 
 # smartling.placeholder_format=C
 #. The title of the 'Never' option in the assist settings modal.
@@ -12928,6 +13168,12 @@ msgid "No Thanks"
 msgstr "Nein, danke"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "Kein Tracking. Niemals."
@@ -13073,7 +13319,8 @@ msgstr "Keine Ergebnisse gefunden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
+msgstr ""
+"Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13590,6 +13837,12 @@ msgid "On but no numbers"
 msgstr "An, aber keine Zahlen"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13723,7 +13976,8 @@ msgstr "%1$sEinstellungen%2$s öffnen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
+msgstr ""
+"Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13804,6 +14058,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Vorschläge zum Erstellen und Bearbeiten von Bildern öffnen"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13866,7 +14126,8 @@ msgstr "Öffne das Bedienfeld „So funktioniert Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
+msgstr ""
+"Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14448,8 +14709,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als vollständigen Fragesatz formulierst, ist es "
 "wahrscheinlicher, dass KI-gestützte Antworten automatisch erscheinen, und du "
-"erhältst oft bessere Antworten. Um sie auszuschalten und die "
-"Assist-Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
+"erhältst oft bessere Antworten. Um sie auszuschalten und die Assist-"
+"Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14473,8 +14734,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als Frage und in einem vollständigen Satz formulierst, "
 "ist es wahrscheinlicher, dass DuckAssist automatisch erscheint, und du "
-"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die "
-"Assist-Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
+"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die Assist-"
+"Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14551,10 +14812,22 @@ msgid "Pin"
 msgstr "Anpinnen"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Chats aus dem %1$s %2$s hier anpinnen"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14572,6 +14845,12 @@ msgstr "Pink"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Angepinnt"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14899,6 +15178,12 @@ msgid "Poor formatting"
 msgstr "Schlechte Formatierung"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15105,6 +15390,12 @@ msgstr "Vorheriges Bild"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Vorherige Tabs"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15647,6 +15938,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Argumentierende KI mit mittlerer eingebauter Moderation"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15680,6 +15983,12 @@ msgstr "Zuletzt verwendete Tabs"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Der Speicher für aktuelle Chats kann in den %1$s angepasst werden."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15835,6 +16144,12 @@ msgstr "Suche ohne diese Website wiederholen"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Nutzung reduzieren"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15995,7 +16310,8 @@ msgstr "Meine Auswahl merken"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
+msgstr ""
+"Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16214,6 +16530,12 @@ msgid "Reset All Settings"
 msgstr "Alle Einstellungen zurücksetzen"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16224,6 +16546,12 @@ msgstr "Wird in %1$s zurückgesetzt"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Auflösung"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16720,8 +17048,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit "
-"Ende-zu-Ende-Verschlüsselung."
+"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit Ende-zu-Ende-"
+"Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16861,7 +17189,8 @@ msgstr "Scrolle herunter und wähle %1$sErweiterte Einstellungen%2$s aus"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
+msgstr ""
+"Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16931,6 +17260,12 @@ msgstr "Suche"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Nach %1$s suchen, um Ergebnisse in deiner Nähe zu finden?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17132,8 +17467,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die "
-"POST-Methode verwendet)"
+"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die POST-"
+"Methode verwendet)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17243,7 +17578,8 @@ msgstr "Zweite Meinung"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
+msgstr ""
+"Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17252,8 +17588,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17262,8 +17598,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17272,9 +17608,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen synchronisierten "
-"Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen synchronisierten Geräten "
+"darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17283,16 +17619,16 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Speichere deine Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere deine Chats sicher auf unserem Server mit Ende-zu-Ende-"
+"Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit "
-"End-to-End-Verschlüsselung."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
+"Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17301,9 +17637,14 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit "
-"End-to-End-Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht "
-"einmal wir."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
+"Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht einmal wir."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17414,7 +17755,8 @@ msgstr "Entdecke einige unserer neuesten Updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
+msgstr ""
+"Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17441,7 +17783,8 @@ msgstr "%1$s%2$s%3$s auswählen, dann %4$sSuchmaschine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
+msgstr ""
+"Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17467,13 +17810,15 @@ msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
+msgstr ""
+"Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
+msgstr ""
+"Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17820,6 +18165,12 @@ msgid "Set as Homepage"
 msgstr "Als Startseite festlegen"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17887,6 +18238,18 @@ msgid "Seychelles"
 msgstr "Seychellen"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17895,7 +18258,8 @@ msgstr "Teilen"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
+msgstr ""
+"Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17923,8 +18287,15 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Teile den Standort in Form der Stadt mit KI-Modellen, um die Relevanz zu "
-"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder "
-"KI-Modelle weiter."
+"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder KI-"
+"Modelle weiter."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17983,6 +18354,12 @@ msgstr "Seiten-URL teilen"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Positives Feedback teilen"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18120,6 +18497,12 @@ msgid "Show Detail"
 msgstr "Details anzeigen"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "DuckAssist <sup>BETA</sup>"
@@ -18128,7 +18511,8 @@ msgstr "DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
+msgstr ""
+"DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18269,6 +18653,12 @@ msgid "Show more"
 msgstr "Mehr anzeigen"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18302,6 +18692,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Seitenleiste anzeigen"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18449,7 +18845,8 @@ msgstr "Begrüßung oben auf der Suchergebnisseite anzeigen"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
+msgstr ""
+"Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18528,7 +18925,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
+msgstr ""
+"Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18686,6 +19084,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Etwas ist schiefgelaufen, bitte versuche es später noch einmal."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18728,7 +19132,8 @@ msgstr "Entschuldigung, ein unerwarteter Fehler ist aufgetreten."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
+msgstr ""
+"Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -18984,6 +19389,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Beginne mit der Nutzung des Wochenlimits"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Suche starten!"
@@ -18998,7 +19409,8 @@ msgstr "Beginne mit einem Bild"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
+msgstr ""
+"Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19035,8 +19447,8 @@ msgstr "Bleib auf DuckDuckGo"
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
 msgstr ""
-"Bleibe gut geschützt und gut informiert – mit unseren "
-"Privatsphäre-Newslettern."
+"Bleibe gut geschützt und gut informiert – mit unseren Privatsphäre-"
+"Newslettern."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19091,7 +19503,8 @@ msgstr "Versteckte Tracker stoppen, die auf anderen Websites lauern."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
+msgstr ""
+"Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19313,7 +19726,8 @@ msgstr "Q&As zusammenfassen"
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr "Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
+msgstr ""
+"Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
@@ -19566,6 +19980,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Wechsle zur Suchmaschine, die dich nicht trackt. Niemals."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19724,6 +20146,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sync und Backup sind vorübergehend nicht verfügbar"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19809,6 +20237,22 @@ msgstr "Tadschikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Hol' dir deine Privatsphäre zurück!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20077,7 +20521,8 @@ msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s 
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
+msgstr ""
+"Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20109,7 +20554,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
+msgstr ""
+"Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20276,7 +20722,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
+msgstr ""
+"Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20285,10 +20732,22 @@ msgid "This Month"
 msgstr "Dieser Monat"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Diese Woche"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20297,8 +20756,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des "
-"%3$s-Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
+"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des %3$s-"
+"Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
 "anstößige Informationen an (weitere Informationen siehe %4$s)."
 
 # smartling.placeholder_format=C
@@ -20424,6 +20883,22 @@ msgid "This information isn’t useful"
 msgstr "Diese Informationen sind nicht hilfreich"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20502,8 +20977,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
-"KI-gestützte Antworten."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
+"gestützte Antworten."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20514,9 +20989,9 @@ msgid ""
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
-"KI-gestützte Antworten. Allerdings haben wir auch eine Startseite unter "
-"%1$s, auf der niemals KI-gestützte Antworten angezeigt werden."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
+"gestützte Antworten. Allerdings haben wir auch eine Startseite unter %1$s, "
+"auf der niemals KI-gestützte Antworten angezeigt werden."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20547,7 +21022,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
+msgstr ""
+"Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20665,7 +21141,8 @@ msgstr "Tipps"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
+msgstr ""
+"Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20766,6 +21243,12 @@ msgstr "Heute"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Heute"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21113,7 +21596,8 @@ msgstr "Versuche, %1$s, um solche Nachrichten nicht mehr zu sehen."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
+msgstr ""
+"Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21179,9 +21663,21 @@ msgid "Try Them Out"
 msgstr "Probiere sie aus."
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Probiere eine Suche!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21250,6 +21746,12 @@ msgid "Try for free"
 msgstr "Gratis testen"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21261,7 +21763,14 @@ msgstr "Gratis testen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
+msgstr ""
+"Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21291,6 +21800,12 @@ msgid "Try our homepage that never shows these messages:"
 msgstr "Benutze unsere Homepage, die nie solche Nachrichten anzeigt:"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
 msgid "Try related keywords"
@@ -21311,7 +21826,8 @@ msgstr "Versuche deinen Standort manuell einzustellen."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
+msgstr ""
+"Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -21357,7 +21873,8 @@ msgstr "Probiere den neuen privaten Echtzeit-Sprachchat aus!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
+msgstr ""
+"Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -21381,7 +21898,8 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr "Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
+msgstr ""
+"Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -21418,9 +21936,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No "
-"AI%2$s-Sucherweiterung, damit deine Einstellungen gespeichert bleiben. "
-"%3$sMehr erfahren%4$s"
+"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No AI%2$s-"
+"Sucherweiterung, damit deine Einstellungen gespeichert bleiben. %3$sMehr "
+"erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21534,12 +22052,19 @@ msgstr "Abschalten:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
+msgstr ""
+"Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Schalte den Duck Player ein, um YouTube ohne gezielte Werbung zu sehen"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21551,7 +22076,8 @@ msgstr "Aktiviere „Präziser Standort“, um genauere Ergebnisse zu erhalten."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
+msgstr ""
+"Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21748,8 +22274,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s "
-"https://duckduckgo.com eingeben"
+"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s https://"
+"duckduckgo.com eingeben"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21781,7 +22307,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
+msgstr ""
+"Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21898,8 +22425,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem "
-"DuckDuckGo-Abo frei"
+"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem DuckDuckGo-"
+"Abo frei"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21921,6 +22448,12 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "Erhalte mit einem Abonnement Zugriff auf erweiterte KI!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -21932,7 +22465,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
+msgstr ""
+"Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22286,6 +22820,12 @@ msgid "Use in Safari"
 msgstr "In Safari verwenden"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22308,7 +22848,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
+msgstr ""
+"Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22609,8 +23150,8 @@ msgstr "Sprachchat beendet"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von "
-"KI-Modellen verwendet."
+"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von KI-"
+"Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22755,8 +23296,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Benutze den Duck Player, um personalisierte Werbung auf YouTube zu "
-"blockieren und zu verhindern, dass deine Aktivitäten die "
-"YouTube-Empfehlungen beeinflussen."
+"blockieren und zu verhindern, dass deine Aktivitäten die YouTube-"
+"Empfehlungen beeinflussen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22903,7 +23444,8 @@ msgstr "Wir tracken dich nicht. Niemals."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
+msgstr ""
+"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22944,7 +23486,8 @@ msgstr "Wir tracken dich nicht, ob im privaten oder normalen Modus."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
+msgstr ""
+"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22974,7 +23517,8 @@ msgstr "Wir halten deinen Suchverlauf privat"
 #. Displayed when the voice chat connection is lost and the session ends.
 msgctxt "voice chat error"
 msgid "We lost the connection, please try again later."
-msgstr "Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
+msgstr ""
+"Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
 
 # smartling.placeholder_format=C
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
@@ -23015,7 +23559,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
+msgstr ""
+"Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23370,11 +23915,11 @@ msgid ""
 "experience."
 msgstr ""
 "Welche Vorteile bietet das Herunterladen des DuckDuckGo-Browsers für "
-"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle "
-"DuckDuckGo-Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit "
-"Titeln auf, wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem "
-"Datenschutz liegt. Halte es sehr kurz, einfach und leicht verständlich für "
-"Menschen mit oder ohne viel KI- oder technische Erfahrung."
+"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle DuckDuckGo-"
+"Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit Titeln auf, "
+"wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem Datenschutz "
+"liegt. Halte es sehr kurz, einfach und leicht verständlich für Menschen mit "
+"oder ohne viel KI- oder technische Erfahrung."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23459,7 +24004,8 @@ msgstr "Was muss man hier unbedingt probieren?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
+msgstr ""
+"Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23484,6 +24030,12 @@ msgstr "Was hat dich am meisten gestört?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Was hat dich wieder hergeführt?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23910,6 +24462,14 @@ msgid "Wintry Mix"
 msgstr "Winterliche Mischung"
 
 # smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -24260,7 +24820,8 @@ msgstr "Du kannst dies jederzeit in den %1$sSucheinstellungen%2$s ändern"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
+msgstr ""
+"Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24338,6 +24899,13 @@ msgstr "Du kannst nur %1$s Bilder pro Gespräch anhängen"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Du kannst nur %1$s Bilder pro Gespräch anhängen."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24489,6 +25057,12 @@ msgstr ""
 "Version hast."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24536,6 +25110,12 @@ msgid "You've blocked 1 site"
 msgstr "Du hast 1 Seite blockiert"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24545,7 +25125,8 @@ msgstr "Du hast das Limit für die Erstellung von Bildern erreicht."
 #. Title shown when a user has reached their image generation edit limit.
 msgctxt "Title for image generation edit limit reached message"
 msgid "You've reached the maximum number of edits for this image"
-msgstr "Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
+msgstr ""
+"Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum number of messages for a given moment, and should try again later when they might be able to send more messages again.
@@ -24852,7 +25433,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
+msgstr ""
+"Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24943,6 +25525,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Deine Suchanfragen können nicht auf dich zurückgeführt werden"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24950,14 +25540,15 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No "
-"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
+"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No AI%2$s-"
+"Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
+msgstr ""
+"Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25535,3 +26126,9 @@ msgstr "Jahren"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "J"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -102,7 +102,8 @@ msgstr "%1$s απόπειρες"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr ""
+"Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -126,6 +127,12 @@ msgstr "Πριν από %1$s ημέρες"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Εντοπίστηκαν %1$s"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -360,6 +367,12 @@ msgid "%s used"
 msgstr "%1$s χρησιμοποιήθηκε"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s προβολή"
@@ -505,7 +518,8 @@ msgstr ""
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
+msgstr ""
+"%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -605,13 +619,20 @@ msgstr "1 προσπάθεια"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when only one exists.
 msgid "1 attempt blocked by DuckDuckGo in the last 24 hours"
-msgstr "Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr ""
+"Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Πριν από 1 ημέρα"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -999,7 +1020,8 @@ msgstr ""
 #. Disclaimer text displayed at the bottom of the voice chat dialog informing the user that the AI (Artificial Intelligence) may provide inaccurate or offensive information.
 msgctxt "voice chat"
 msgid "AI may provide inaccurate or offensive information."
-msgstr "Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr ""
+"Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'AI nickname (is): Fred'
@@ -1536,6 +1558,14 @@ msgid "Advanced Models"
 msgstr "Προηγμένα μοντέλα"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Διαφημιστείτε στην Αναζήτηση"
@@ -1698,7 +1728,8 @@ msgstr "Όλες οι συνομιλίες είναι %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr "Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
+msgstr ""
+"Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -2165,7 +2196,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
+msgstr ""
+"Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2330,6 +2362,12 @@ msgstr "Ρωτήστε ιδιωτικά"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask privately"
 msgstr "Ρωτήστε ιδιωτικά"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2739,7 +2777,8 @@ msgstr "Γραμμοκώδικας"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr "Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
+msgstr ""
+"Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2911,12 +2950,14 @@ msgstr "Αποκλεισμός ενοχλητικών αναδυόμενων π�
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
+msgstr ""
+"Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
+msgstr ""
+"Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2999,7 +3040,8 @@ msgstr "Αποκλεισμένα:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr "Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
+msgstr ""
+"Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3283,7 +3325,8 @@ msgstr "Κάνοντας κλικ στο «%1$s» συμφωνείτε με το
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
+msgstr ""
+"Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3669,7 +3712,8 @@ msgstr "Αλλάζει την εμφάνιση των διευθύνσεων URL
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
+msgstr ""
+"Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3908,6 +3952,12 @@ msgstr "Συνομιλήστε ιδιωτικά με το %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Συνομιλήστε ιδιωτικά με την τεχνητή νοημοσύνη"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4379,8 +4429,8 @@ msgid ""
 msgstr ""
 "Η εκκαθάριση των δεδομένων του προγράμματος περιήγησης διαγράφει τις "
 "πρόσφατες συνομιλίες. Οι πρόσφατες συνομιλίες μπορεί να αποθηκευτούν επ' "
-"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του "
-"Duck.ai., ανάλογα με το πρόγραμμα περιήγησής σας."
+"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του Duck."
+"ai., ανάλογα με το πρόγραμμα περιήγησής σας."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4500,7 +4550,8 @@ msgstr "Κάνε κλικ στις %1$sΡυθμίσεις%2$s στο αναπτ�
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
+msgstr ""
+"Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4538,7 +4589,8 @@ msgstr "Κάνε κλικ στο %1$sΠρόγραμμα περιήγησης%2$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
+msgstr ""
+"Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4618,13 +4670,15 @@ msgstr "Κάνε κλικ στην καρτέλα %1$sΓενικά%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr "Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
+msgstr ""
+"Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr "Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
+msgstr ""
+"Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4721,6 +4775,12 @@ msgid "Close"
 msgstr "Κλείσιμο"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4763,6 +4823,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Κλείσιμο αναζήτησης"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5138,6 +5204,12 @@ msgid "Continue Blocking Ads"
 msgstr "Συνεχίστε να μπλοκάρετε διαφημίσεις"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5203,6 +5275,12 @@ msgid "Cookie data:"
 msgstr "Δεδομένα cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5250,6 +5328,12 @@ msgstr ""
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Αντιγραφή κωδικού"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5367,6 +5451,12 @@ msgid "Create Image"
 msgstr "Δημιουργία εικόνας"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5408,6 +5498,14 @@ msgstr "Δημιουργήθηκε από"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Δημιουργήθηκε από %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5561,6 +5659,12 @@ msgstr "Προσαρμογή απαντήσεων"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Προσαρμογή απαντήσεων"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5849,10 +5953,22 @@ msgid "Delete Server Data?"
 msgstr "Διαγραφή δεδομένων διακομιστή;"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Διαγραφή μεταγραφής"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5885,6 +6001,12 @@ msgstr "Διαγραφή εικόνας"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Διαγραφή εικόνας;"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5944,7 +6066,8 @@ msgstr "Περιγράψτε τις αλλαγές με βάση την εικό
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
+msgstr ""
+"Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6114,7 +6237,8 @@ msgstr "Απενεργοποίηση και αποσύνδεση"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
+msgstr ""
+"Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6198,6 +6322,12 @@ msgid "Dismiss promotion"
 msgstr "Κλείσιμο προσφοράς"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6219,7 +6349,8 @@ msgstr "Γλώσσα οθόνης"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
+msgstr ""
+"Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6302,7 +6433,8 @@ msgstr "Δεν βλέπεις το DuckDuckGo στη λίστα;"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
+msgstr ""
+"Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6351,10 +6483,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το "
-"%1$snoai.duckduckgo.com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής "
-"νοημοσύνης και με φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε "
-"περισσότερα%4$s"
+"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το %1$snoai.duckduckgo."
+"com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής νοημοσύνης και με "
+"φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6409,6 +6540,12 @@ msgstr "Η λήψη ολοκληρώθηκε"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Κάντε λήψη του DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6625,7 +6762,14 @@ msgstr "Όρους χρήσης υπηρεσίας του Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
+msgstr ""
+"Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
+
+# smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6697,8 +6841,8 @@ msgid ""
 "remember home on the web: https://duck.ai"
 msgstr ""
 "Το Duck.ai εξακολουθεί να αποτελεί προϊόν της DuckDuckGo, ωστόσο πλέον θα "
-"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: "
-"https://duck.ai"
+"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: https://duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6739,8 +6883,8 @@ msgid ""
 msgstr ""
 "Το Duck.ai σάς επιτρέπει να συνομιλείτε ιδιωτικά με δημοφιλή μοντέλα "
 "τεχνητής νοημοσύνης. Η απενεργοποίησή του αποκρύπτει τα κουμπιά και τους "
-"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το "
-"%1$sduck.ai%2$s απευθείας."
+"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το %1$sduck."
+"ai%2$s απευθείας."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6763,7 +6907,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr ""
+"Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6779,7 +6924,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
+msgstr ""
+"Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6789,6 +6935,12 @@ msgid ""
 msgstr ""
 "Οι απαντήσεις του Duck.ai δεν βασίζονται σε συγκεκριμένες πηγές και δεν "
 "ελέγχονται ως προς την ακρίβειά τους."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6806,7 +6958,8 @@ msgstr "Το Duck.ai αναβαθμίστηκε!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
+msgstr ""
+"Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7000,7 +7153,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
+msgstr ""
+"Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7225,7 +7379,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
+msgstr ""
+"Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7403,7 +7558,8 @@ msgstr "Δώστε έμφαση σε σημαντικές πληροφορίες
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr "Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
+msgstr ""
+"Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7415,7 +7571,8 @@ msgstr "Ενεργοποίηση λειτουργιών τεχνητής νοη�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
+msgstr ""
+"Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7449,6 +7606,12 @@ msgstr "Ενεργοποίηση ιστότοπων με τις περισσότ
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Ενεργοποίηση ιστότοπων που επισκέπτεσαι περισσότερο"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7616,19 +7779,22 @@ msgstr "Βεβαιώσου ότι έχεις επιλέξει %1$sΑποδοχή
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
+msgstr ""
+"Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
+msgstr ""
+"Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
+msgstr ""
+"Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7751,13 +7917,20 @@ msgstr "Καταχώρισε τη διεύθυνση email σου."
 #. A prompt asking users to enter their passphrase.
 msgctxt "cloudsave"
 msgid "Enter your passphrase to load your settings."
-msgstr "Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
+msgstr ""
+"Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an entertainment guide in its responses.
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "Οδηγός ψυχαγωγίας"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7829,7 +8002,8 @@ msgstr "Ανάπτυξη χάρτη"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
+msgstr ""
+"Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7923,6 +8097,18 @@ msgstr "Ακατάλληλο περιεχόμενο"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Στίχοι ακατάλληλοι για ανηλίκους"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8026,6 +8212,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Δωρεάν"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8229,7 +8421,8 @@ msgstr "Οικονομικός σύμβουλος"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
+msgstr ""
+"Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8450,6 +8643,12 @@ msgstr "Δωρεάν πρόγραμμα"
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
 msgstr "Ελευθερώστε αποθηκευτικό χώρο"
+
+# smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8970,6 +9169,12 @@ msgid "Get computer help"
 msgstr "Λήψη βοήθειας για υπολογιστή"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -9009,6 +9214,18 @@ msgid "Get the Latest Version"
 msgstr "Λάβετε την πιο πρόσφατη έκδοση"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -9031,6 +9248,12 @@ msgid "Get your friends to switch and help us grow!"
 msgstr ""
 "Βοήθησε μας να επεκταθούμε, προτείνοντας σε φίλους να αλλάξουν μηχανή "
 "αναζήτησης!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9104,7 +9327,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
+msgstr ""
+"Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9563,7 +9787,8 @@ msgstr "Βοηθήστε με να προετοιμαστώ για τη συνέ
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr "Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
+msgstr ""
+"Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9575,7 +9800,8 @@ msgstr "Βοηθήστε μας να βελτιώσουμε το DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
+msgstr ""
+"Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9627,7 +9853,8 @@ msgstr "Βοηθήστε μας να καταλάβουμε πώς δεν πετ
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
+msgstr ""
+"Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -9718,6 +9945,12 @@ msgstr "Απόκρυψη βημάτων"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Απόκρυψη συμβουλών"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9926,7 +10159,8 @@ msgstr "Οι ώρες λείπουν"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
+msgstr ""
+"Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10033,7 +10267,8 @@ msgstr "Πόσο συχνά θέλετε να βλέπετε τις απαντή
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
+msgstr ""
+"Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10268,7 +10503,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
+msgstr ""
+"Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10853,7 +11089,8 @@ msgstr ""
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
+msgstr ""
+"Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11359,6 +11596,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Σου επιτρέπει να πραγματοποιείς ανώνυμα αναζήτηση με το DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Λιβερία"
 
@@ -11429,6 +11673,12 @@ msgstr "Σχέδιο με γραμμές"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Κερδισμένα λαϊνάουτ"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12531,6 +12781,12 @@ msgid "More than 20 minutes"
 msgstr "Παραπάνω από 20 λεπτά"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -13020,6 +13276,12 @@ msgid "No Thanks"
 msgstr "Όχι, ευχαριστώ"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "Δεν σε παρακολουθούμε, ποτέ μα ποτέ."
@@ -13165,7 +13427,8 @@ msgstr "Δεν βρέθηκαν αποτελέσματα."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
+msgstr ""
+"Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13189,13 +13452,15 @@ msgstr "Δεν αποκλείστηκαν εφαρμογές παρακολού�
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
+msgstr ""
+"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
+msgstr ""
+"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13682,6 +13947,12 @@ msgid "On but no numbers"
 msgstr "Ενεργό αλλά χωρίς αριθμούς"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13898,6 +14169,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Άνοιγμα προτάσεων δημιουργίας και επεξεργασίας εικόνων"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13961,8 +14238,8 @@ msgstr "Άνοιγμα του πίνακα «Πώς λειτουργεί το Du
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
 msgstr ""
-"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το "
-"DuckDuckGo...%2$s"
+"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το DuckDuckGo..."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14651,10 +14928,22 @@ msgid "Pin"
 msgstr "Καρφίτσα"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Καρφιτσώστε συνομιλίες εδώ από το %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14672,6 +14961,12 @@ msgstr "Ροζ"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Καρφιτσωμένες"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14997,6 +15292,12 @@ msgid "Poor formatting"
 msgstr "Κακή μορφοποίηση"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15203,6 +15504,12 @@ msgstr "Προηγούμενη εικόνα"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Προηγούμενες καρτέλες"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15511,7 +15818,8 @@ msgstr "Προστατέψτε τα εισερχόμενά σας"
 #. DuckDuckGo's browser app has features to protect your data by keeping it private
 msgctxt "SERP footer content"
 msgid "Protect your data as you search and browse."
-msgstr "Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
+msgstr ""
+"Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
 
 # smartling.placeholder_format=C
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
@@ -15747,6 +16055,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Συλλογιστική τεχνητή νοημοσύνη με μέτρια ενσωματωμένη εποπτεία"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15780,6 +16100,12 @@ msgstr "Πρόσφατες καρτέλες"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Η πρόσφατη αποθήκευση συνομιλιών μπορεί να ρυθμιστεί από τις %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15935,6 +16261,12 @@ msgstr "Επαναλάβετε την αναζήτηση χωρίς αυτόν �
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Μείωση Χρήσης"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16102,7 +16434,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr "Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
+msgstr ""
+"Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -16318,6 +16651,12 @@ msgid "Reset All Settings"
 msgstr "Επαναφορά όλων των ρυθμίσεων"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16328,6 +16667,12 @@ msgstr "Επαναφορά σε %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Ανάλυση"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16529,7 +16874,8 @@ msgstr "Κριτικές"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
+msgstr ""
+"Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16606,7 +16952,8 @@ msgstr "ΝΑ"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
+msgstr ""
+"Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -16962,13 +17309,15 @@ msgstr "Σκωτία"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr ""
+"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr ""
+"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17045,6 +17394,12 @@ msgid "Search %s to find results closer to you?"
 msgstr ""
 "Θέλεις να κάνεις αναζήτηση για τον όρο %1$s ώστε να βρεις αποτελέσματα πιο "
 "κοντά σου;"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17174,7 +17529,8 @@ msgstr "Ορατότητα αναζήτησης"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
+msgstr ""
+"Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17432,6 +17788,12 @@ msgstr ""
 "δεδομένα σας, ούτε καν εμείς."
 
 # smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "Security issue"
 msgstr "Θέμα ασφάλειας"
@@ -17576,8 +17938,8 @@ msgstr "Επιλέξτε %1$sΡύθμιση για αυτόν τον ιστότ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε "
-"%3$shttps://duckduckgo.com%4$s στο πεδίο εισαγωγής"
+"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε %3$shttps://duckduckgo."
+"com%4$s στο πεδίο εισαγωγής"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17589,13 +17951,15 @@ msgstr ""
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
+msgstr ""
+"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
+msgstr ""
+"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17636,7 +18000,8 @@ msgstr "Διάλεξε %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
+msgstr ""
+"Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17710,7 +18075,8 @@ msgstr "Διάλεξε %1$sΡυθμίσεις%2$s και έπειτα %3$sΣύν
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
+msgstr ""
+"Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17771,7 +18137,8 @@ msgstr "Διάλεξε όλα τα τετράγωνα που περιέχουν 
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr "Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
+msgstr ""
+"Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -17952,6 +18319,12 @@ msgid "Set as Homepage"
 msgstr "Ορισμός του DuckDuckGo ως αρχικής σελίδας"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -18019,6 +18392,18 @@ msgid "Seychelles"
 msgstr "Σεϋχέλλες"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -18059,6 +18444,13 @@ msgstr ""
 "Μοιραστείτε μια τοποθεσία σε επίπεδο πόλης με μοντέλα τεχνητής νοημοσύνης "
 "για να βελτιώσετε τη συνάφεια. Το Duck.ai δεν αποκαλύπτει ποτέ την ακριβή "
 "τοποθεσία σας σε εμάς ή σε μοντέλα τεχνητής νοημοσύνης."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18119,6 +18511,12 @@ msgid "Share positive feedback"
 msgstr "Κοινοποίηση θετικών σχολίων"
 
 # smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -18130,7 +18528,8 @@ msgstr "Κοινοποίησε αυτή τη συνομιλία στο DuckDuckG
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr "Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
+msgstr ""
+"Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -18252,6 +18651,12 @@ msgstr "Εμφάνιση δεδομένων εφαρμογών σελιδοδε�
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Εμφάνιση λεπτομερειών"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18405,6 +18810,12 @@ msgid "Show more"
 msgstr "Εμφάνιση περισσοτέρων"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18438,6 +18849,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Εμφάνιση πλαϊνής γραμμής"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18821,13 +19238,20 @@ msgstr "Κάτι πήγε στραβά κατά την αποθήκευση στ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
+msgstr ""
+"Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Κάτι πήγε λάθος. Προσπαθήστε πάλι αργότερα."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19128,6 +19552,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Έναρξη χρήσης εβδομαδιαίου ορίου"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Ξεκίνα την αναζήτηση!"
@@ -19142,7 +19572,8 @@ msgstr "Αρχίστε με μια εικόνα"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
+msgstr ""
+"Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19416,7 +19847,8 @@ msgstr "Πρότεινε έναν τίτλο για μια ανάρτηση σε
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
+msgstr ""
+"Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19716,6 +20148,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Διάλεξε τη μηχανή αναζήτησης που δεν σε παρακολουθεί ποτέ."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19876,6 +20316,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Το Sync & Backup είναι προσωρινά μη διαθέσιμο"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19961,6 +20407,22 @@ msgstr "Τατζικιστάν"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Πάρε ξανά τον έλεγχο της ιδιωτικότητάς σου!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20184,13 +20646,15 @@ msgstr "Ευχαριστούμε για τα σχόλιά σας!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
+msgstr ""
+"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
+msgstr ""
+"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -20355,7 +20819,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
+msgstr ""
+"Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20429,7 +20894,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
+msgstr ""
+"Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20438,10 +20904,22 @@ msgid "This Month"
 msgstr "Αυτόν τον μήνα"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Αυτή την εβδομάδα"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20496,13 +20974,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
+msgstr ""
+"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
+msgstr ""
+"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20561,19 +21041,37 @@ msgstr "Δεν ήταν δυνατή η δημιουργία αυτής της �
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
+msgstr ""
+"Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
+msgstr ""
+"Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Αυτές οι πληροφορίες δεν είναι χρήσιμες"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20623,7 +21121,8 @@ msgstr "Αυτή η σελίδα απαιτεί Javascript για να λειτ�
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
+msgstr ""
+"Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20702,7 +21201,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
+msgstr ""
+"Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20731,7 +21231,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
+msgstr ""
+"Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20819,7 +21320,8 @@ msgstr "Συμβουλές"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
+msgstr ""
+"Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20852,8 +21354,8 @@ msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
 msgstr ""
-"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του "
-"Duck.ai"
+"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20922,6 +21424,12 @@ msgstr "Σήμερα"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Σήμερα"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21086,7 +21594,8 @@ msgstr "Εφαρμογές παρακολούθησης που αποκλείσ�
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
+msgstr ""
+"Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21272,7 +21781,8 @@ msgstr "Δοκιμάστε το %1$s για να σταματήσετε να β�
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
+msgstr ""
+"Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21340,9 +21850,21 @@ msgid "Try Them Out"
 msgstr "Δοκιμάστε τα"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Δοκίμασε μια αναζήτηση!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21368,7 +21890,8 @@ msgstr ""
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
 msgctxt "noresults"
 msgid "Try clearing your filters and searching again."
-msgstr "Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
+msgstr ""
+"Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words.
@@ -21387,7 +21910,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
+msgstr ""
+"Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21413,6 +21937,12 @@ msgid "Try for free"
 msgstr "Δωρεάν δοκιμή"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21429,9 +21959,16 @@ msgstr ""
 "και πολλά άλλα."
 
 # smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
 msgid "Try generating an AI-assisted answer"
-msgstr "Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
+msgstr ""
+"Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
@@ -21453,7 +21990,14 @@ msgstr "Δοκιμάστε το πρόγραμμα περιήγησής μας"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
+msgstr ""
+"Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21713,6 +22257,12 @@ msgstr ""
 "διαφημίσεις"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21722,7 +22272,8 @@ msgstr "Ενεργοποιήστε την «Ακριβή τοποθεσία» γ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
+msgstr ""
+"Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21874,7 +22425,8 @@ msgstr "Δεν είναι δυνατή η αποστολή σχολίων"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
+msgstr ""
+"Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -21928,7 +22480,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
+msgstr ""
+"Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21947,8 +22500,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών "
-"αναζήτησης…%4$s"
+"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών αναζήτησης…"
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22049,7 +22602,8 @@ msgstr ""
 #. Title for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Unlock VPN + Advanced AI"
-msgstr "Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
+msgstr ""
+"Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Text for the button that allows the user to unlock an AI model with a DuckDuckGo subscription when clicked.
@@ -22079,13 +22633,20 @@ msgstr "Ξεκλειδώστε προηγμένα μοντέλα τεχνητή�
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
+msgstr ""
+"Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Ξεκλειδώστε προηγμένη τεχνητή νοημοσύνη με τη συνδρομή σας!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22430,7 +22991,8 @@ msgstr "Χρήση της ιδιωτικής αναζήτησης του DuckDuc
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
+msgstr ""
+"Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22453,6 +23015,12 @@ msgstr "Χρήση στον Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Χρήση στο Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22616,7 +23184,8 @@ msgstr "Δείτε τιμές για τη διαμονή σας"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
+msgstr ""
+"Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23076,7 +23645,8 @@ msgstr "Δεν σε παρακολουθούμε, ποτέ μα ποτέ."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
+msgstr ""
+"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23119,7 +23689,8 @@ msgstr ""
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
+msgstr ""
+"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23426,7 +23997,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
+msgstr ""
+"Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23488,14 +24060,15 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του "
-"Duck.ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
+"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του Duck."
+"ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What AI model would you like us to add? (optional)"
-msgstr "Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
+msgstr ""
+"Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for providing arguments, counter-arguments, and rebuttals to the concept of a plant-based diet.
@@ -23667,6 +24240,12 @@ msgstr "Τι σε ενόχλησε περισσότερο;"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Τι σε έκανε να επιστρέψεις σήμερα;"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24093,6 +24672,14 @@ msgid "Wintry Mix"
 msgstr "Διάφορα χειμερινά καιρικά φαινόμενα"
 
 # smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -24383,7 +24970,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
+msgstr ""
+"Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -24445,7 +25033,8 @@ msgstr ""
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
+msgstr ""
+"Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24482,7 +25071,8 @@ msgstr ""
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can keep chatting by using your monthly limit."
-msgstr "Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
+msgstr ""
+"Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
 
 # smartling.placeholder_format=C
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
@@ -24527,6 +25117,13 @@ msgstr "Μπορείτε να επισυνάψετε μόνο %1$s εικόνε�
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Μπορείτε να επισυνάψετε μόνο %1$s εικόνες ανά συνομιλία."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24586,7 +25183,8 @@ msgstr "Μπορείς να ξεκινήσεις από την αρχή σε α�
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
+msgstr ""
+"Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -24677,6 +25275,12 @@ msgstr ""
 "την τελευταία έκδοση."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24725,6 +25329,12 @@ msgid "You've blocked 1 site"
 msgstr "Έχετε αποκλείσει 1 ιστότοπο"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24750,14 +25360,16 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
+msgstr ""
+"Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
+msgstr ""
+"Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24783,9 +25395,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες "
-"Duck.ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να "
-"συνεχίσετε τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
+"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες Duck."
+"ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να συνεχίσετε "
+"τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25132,6 +25744,14 @@ msgstr "Ο ρόλος σας"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Οι αναζητήσεις σας δεν μπορούν να συνδεθούν με εσάς"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25729,3 +26349,9 @@ msgstr "έτη"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "έ."
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -102,8 +102,7 @@ msgstr "%1$s απόπειρες"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr "Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -132,7 +131,7 @@ msgstr "Εντοπίστηκαν %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Χρησιμοποιήθηκαν %1$s αρχεία"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -370,7 +369,7 @@ msgstr "%1$s χρησιμοποιήθηκε"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -518,8 +517,7 @@ msgstr ""
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
+msgstr "%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -619,8 +617,7 @@ msgstr "1 προσπάθεια"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when only one exists.
 msgid "1 attempt blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr "Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -632,7 +629,7 @@ msgstr "Πριν από 1 ημέρα"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "Χρησιμοποιήθηκε 1 αρχείο"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1020,8 +1017,7 @@ msgstr ""
 #. Disclaimer text displayed at the bottom of the voice chat dialog informing the user that the AI (Artificial Intelligence) may provide inaccurate or offensive information.
 msgctxt "voice chat"
 msgid "AI may provide inaccurate or offensive information."
-msgstr ""
-"Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr "Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'AI nickname (is): Fred'
@@ -1564,6 +1560,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Τα προηγμένα μοντέλα μπορούν να χρησιμοποιούν τα όρια 2-5x ταχύτερα από άλλα "
+"μοντέλα. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1728,8 +1726,7 @@ msgstr "Όλες οι συνομιλίες είναι %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr ""
-"Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
+msgstr "Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -2196,8 +2193,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
+msgstr "Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2367,7 +2363,7 @@ msgstr "Ρωτήστε ιδιωτικά"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Ρώτα ιδιωτικά"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2777,8 +2773,7 @@ msgstr "Γραμμοκώδικας"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
+msgstr "Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2950,14 +2945,12 @@ msgstr "Αποκλεισμός ενοχλητικών αναδυόμενων π�
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
-"Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
+msgstr "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
+msgstr "Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3040,8 +3033,7 @@ msgstr "Αποκλεισμένα:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr ""
-"Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
+msgstr "Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3325,8 +3317,7 @@ msgstr "Κάνοντας κλικ στο «%1$s» συμφωνείτε με το
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
+msgstr "Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3712,8 +3703,7 @@ msgstr "Αλλάζει την εμφάνιση των διευθύνσεων URL
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
+msgstr "Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3957,7 +3947,7 @@ msgstr "Συνομιλήστε ιδιωτικά με την τεχνητή νο�
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Ιδιωτική συνομιλία με δημοφιλή μοντέλα τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4429,8 +4419,8 @@ msgid ""
 msgstr ""
 "Η εκκαθάριση των δεδομένων του προγράμματος περιήγησης διαγράφει τις "
 "πρόσφατες συνομιλίες. Οι πρόσφατες συνομιλίες μπορεί να αποθηκευτούν επ' "
-"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του Duck."
-"ai., ανάλογα με το πρόγραμμα περιήγησής σας."
+"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του "
+"Duck.ai., ανάλογα με το πρόγραμμα περιήγησής σας."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4550,8 +4540,7 @@ msgstr "Κάνε κλικ στις %1$sΡυθμίσεις%2$s στο αναπτ�
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
+msgstr "Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4589,8 +4578,7 @@ msgstr "Κάνε κλικ στο %1$sΠρόγραμμα περιήγησης%2$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
+msgstr "Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4670,15 +4658,13 @@ msgstr "Κάνε κλικ στην καρτέλα %1$sΓενικά%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr ""
-"Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
+msgstr "Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr ""
-"Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
+msgstr "Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4778,7 +4764,7 @@ msgstr "Κλείσιμο"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Κλείσιμο"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4828,7 +4814,7 @@ msgstr "Κλείσιμο αναζήτησης"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Κλείσιμο δεύτερης γνώμης"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5207,7 +5193,7 @@ msgstr "Συνεχίστε να μπλοκάρετε διαφημίσεις"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5278,7 +5264,7 @@ msgstr "Δεδομένα cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Αντιγράφηκε"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5333,7 +5319,7 @@ msgstr "Αντιγραφή κωδικού"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Αντιγραφή συνδέσμου"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5454,7 +5440,7 @@ msgstr "Δημιουργία εικόνας"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Δημιουργία κοινόχρηστου συνδέσμου"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5506,6 +5492,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Η δημιουργία συνδέσμου φτιάχνει ένα αντίγραφο της συνομιλίας, το οποίο "
+"μπορεί να προβληθεί από οποιονδήποτε τον ανοίξει."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5664,7 +5652,7 @@ msgstr "Προσαρμογή απαντήσεων"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Προσαρμογή απαντήσεων"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5956,7 +5944,7 @@ msgstr "Διαγραφή δεδομένων διακομιστή;"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Διαγραφή κοινόχρηστου συνδέσμου"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5968,7 +5956,7 @@ msgstr "Διαγραφή μεταγραφής"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Διαγραφή μιας συνομιλίας"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -6006,7 +5994,7 @@ msgstr "Διαγραφή εικόνας;"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Διάγραψέ με"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6066,8 +6054,7 @@ msgstr "Περιγράψτε τις αλλαγές με βάση την εικό
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
+msgstr "Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6237,8 +6224,7 @@ msgstr "Απενεργοποίηση και αποσύνδεση"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
+msgstr "Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6325,7 +6311,7 @@ msgstr "Κλείσιμο προσφοράς"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Κλείσιμο περιήγησης"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6349,8 +6335,7 @@ msgstr "Γλώσσα οθόνης"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
+msgstr "Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6433,8 +6418,7 @@ msgstr "Δεν βλέπεις το DuckDuckGo στη λίστα;"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
+msgstr "Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6483,9 +6467,10 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το %1$snoai.duckduckgo."
-"com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής νοημοσύνης και με "
-"φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε περισσότερα%4$s"
+"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το "
+"%1$snoai.duckduckgo.com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής "
+"νοημοσύνης και με φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε "
+"περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6545,7 +6530,7 @@ msgstr "Κάντε λήψη του DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Λήψη του DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6762,14 +6747,13 @@ msgstr "Όρους χρήσης υπηρεσίας του Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
+msgstr "Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Το Duck.ai μπορεί πλέον να αναλύει αρχεία PDF. Δοκίμασέ το!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6841,8 +6825,8 @@ msgid ""
 "remember home on the web: https://duck.ai"
 msgstr ""
 "Το Duck.ai εξακολουθεί να αποτελεί προϊόν της DuckDuckGo, ωστόσο πλέον θα "
-"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: https://duck."
-"ai"
+"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: "
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6883,8 +6867,8 @@ msgid ""
 msgstr ""
 "Το Duck.ai σάς επιτρέπει να συνομιλείτε ιδιωτικά με δημοφιλή μοντέλα "
 "τεχνητής νοημοσύνης. Η απενεργοποίησή του αποκρύπτει τα κουμπιά και τους "
-"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το %1$sduck."
-"ai%2$s απευθείας."
+"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το "
+"%1$sduck.ai%2$s απευθείας."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6907,8 +6891,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr "Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6924,8 +6907,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
+msgstr "Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6940,7 +6922,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Το Duck.ai υποστηρίζει μοντέλα από Anthropic, OpenAI και άλλους."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6958,8 +6940,7 @@ msgstr "Το Duck.ai αναβαθμίστηκε!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
+msgstr "Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7153,8 +7134,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
+msgstr "Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7379,8 +7359,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
+msgstr "Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7558,8 +7537,7 @@ msgstr "Δώστε έμφαση σε σημαντικές πληροφορίες
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr ""
-"Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
+msgstr "Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7571,8 +7549,7 @@ msgstr "Ενεργοποίηση λειτουργιών τεχνητής νοη�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
+msgstr "Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7611,7 +7588,7 @@ msgstr "Ενεργοποίηση ιστότοπων που επισκέπτεσ�
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Ενεργοποίηση τώρα"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7779,22 +7756,19 @@ msgstr "Βεβαιώσου ότι έχεις επιλέξει %1$sΑποδοχή
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
+msgstr "Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
+msgstr "Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
+msgstr "Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7917,8 +7891,7 @@ msgstr "Καταχώρισε τη διεύθυνση email σου."
 #. A prompt asking users to enter their passphrase.
 msgctxt "cloudsave"
 msgid "Enter your passphrase to load your settings."
-msgstr ""
-"Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
+msgstr "Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an entertainment guide in its responses.
@@ -7930,7 +7903,7 @@ msgstr "Οδηγός ψυχαγωγίας"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Ολόκληρη συνομιλία"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -8002,8 +7975,7 @@ msgstr "Ανάπτυξη χάρτη"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
+msgstr "Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -8102,13 +8074,13 @@ msgstr "Στίχοι ακατάλληλοι για ανηλίκους"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Εξερεύνησε το Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Εξερεύνησε το Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8217,7 +8189,7 @@ msgstr "Δωρεάν"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "ΔΩΡΕΑΝ & ΠΡΟΑΙΡΕΤΙΚΑ"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8421,8 +8393,7 @@ msgstr "Οικονομικός σύμβουλος"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
+msgstr "Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8648,7 +8619,7 @@ msgstr "Ελευθερώστε αποθηκευτικό χώρο"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Δωρεάν και πάντα ιδιωτικό"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -9172,7 +9143,7 @@ msgstr "Λήψη βοήθειας για υπολογιστή"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Απόκτησε υψηλότερα όρια χρήσης με μια συνδρομή DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9217,13 +9188,15 @@ msgstr "Λάβετε την πιο πρόσφατη έκδοση"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Απόκτησε την εφαρμογή"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Απόκτησε το δωρεάν πρόγραμμα περιήγησης DuckDuckGo %1$sγια να αποκλείεις τις "
+"διαφημίσεις στο YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9253,7 +9226,7 @@ msgstr ""
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Λίστα ελέγχου πρώτων βημάτων"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9327,8 +9300,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
+msgstr "Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9787,8 +9759,7 @@ msgstr "Βοηθήστε με να προετοιμαστώ για τη συνέ
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
-"Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
+msgstr "Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -9800,8 +9771,7 @@ msgstr "Βοηθήστε μας να βελτιώσουμε το DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
+msgstr "Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9853,8 +9823,7 @@ msgstr "Βοηθήστε μας να καταλάβουμε πώς δεν πετ
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
+msgstr "Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -9950,7 +9919,7 @@ msgstr "Απόκρυψη συμβουλών"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Απόκρυψη προγράμματος εκμάθησης"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10159,8 +10128,7 @@ msgstr "Οι ώρες λείπουν"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
+msgstr "Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10267,8 +10235,7 @@ msgstr "Πόσο συχνά θέλετε να βλέπετε τις απαντή
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
+msgstr "Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10503,8 +10470,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
+msgstr "Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11089,8 +11055,7 @@ msgstr ""
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
+msgstr "Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11601,6 +11566,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Σου επιτρέπει την εναλλαγή μεταξύ της υποβολής ερωτημάτων αναζήτησης και "
+"προτροπών στο Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11678,7 +11645,7 @@ msgstr "Κερδισμένα λαϊνάουτ"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Ο σύνδεσμος λήγει σε 7 ημέρες."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12784,7 +12751,7 @@ msgstr "Παραπάνω από 20 λεπτά"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Περισσότερες συμβουλές"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13279,7 +13246,7 @@ msgstr "Όχι, ευχαριστώ"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Όχι, ευχαριστώ"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13427,8 +13394,7 @@ msgstr "Δεν βρέθηκαν αποτελέσματα."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
+msgstr "Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13452,15 +13418,13 @@ msgstr "Δεν αποκλείστηκαν εφαρμογές παρακολού�
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr ""
-"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
+msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
+msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13950,7 +13914,7 @@ msgstr "Ενεργό αλλά χωρίς αριθμούς"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Η προσθήκη ολοκληρώθηκε"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -14172,7 +14136,7 @@ msgstr "Άνοιγμα προτάσεων δημιουργίας και επεξ
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Άνοιξε τη λίστα ελέγχου πρώτων βημάτων"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14238,8 +14202,8 @@ msgstr "Άνοιγμα του πίνακα «Πώς λειτουργεί το Du
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
 msgstr ""
-"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το DuckDuckGo..."
-"%2$s"
+"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το "
+"DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14931,7 +14895,7 @@ msgstr "Καρφίτσα"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Καρφίτσωμα μιας συνομιλίας"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14943,7 +14907,7 @@ msgstr "Καρφιτσώστε συνομιλίες εδώ από το %1$s %2$s
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Καρφίτσωσέ με"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14967,6 +14931,8 @@ msgstr "Καρφιτσωμένες"
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
+"Οι καρφιτσωμένες συνομιλίες θα εμφανίζονται στην κορυφή των πρόσφατων "
+"συνομιλιών σου."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15296,6 +15262,8 @@ msgstr "Κακή μορφοποίηση"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Διαθέσιμα δημοφιλή μοντέλα τεχνητής νοημοσύνης. Δεν απαιτείται λογαριασμός. "
+"Συνομιλίες ανωνυμοποιημένες από εμάς."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15509,7 +15477,7 @@ msgstr "Προηγούμενες καρτέλες"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Προηγούμενες συμβουλές"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15818,8 +15786,7 @@ msgstr "Προστατέψτε τα εισερχόμενά σας"
 #. DuckDuckGo's browser app has features to protect your data by keeping it private
 msgctxt "SERP footer content"
 msgid "Protect your data as you search and browse."
-msgstr ""
-"Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
+msgstr "Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
 
 # smartling.placeholder_format=C
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
@@ -16058,13 +16025,15 @@ msgstr "Συλλογιστική τεχνητή νοημοσύνη με μέτρ
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Η συλλογιστική είναι πιο διεξοδική, αλλά χρησιμοποιεί τα όρια 2-5x ταχύτερα. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16105,7 +16074,7 @@ msgstr "Η πρόσφατη αποθήκευση συνομιλιών μπορε
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Πρόσφατες συνομιλίες"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16266,7 +16235,7 @@ msgstr "Μείωση Χρήσης"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Μείωσε τη χρήση με ένα πιο αποδοτικό μοντέλο"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16434,8 +16403,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr ""
-"Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
+msgstr "Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -16654,7 +16622,7 @@ msgstr "Επαναφορά όλων των ρυθμίσεων"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Επαναφορά προγράμματος εκμάθησης"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16672,7 +16640,7 @@ msgstr "Ανάλυση"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Απάντηση"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16874,8 +16842,7 @@ msgstr "Κριτικές"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
+msgstr "Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16952,8 +16919,7 @@ msgstr "ΝΑ"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
+msgstr "Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17309,15 +17275,13 @@ msgstr "Σκωτία"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17399,7 +17363,7 @@ msgstr ""
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Διακόπτης «Αναζήτηση και Duck.ai»"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17529,8 +17493,7 @@ msgstr "Ορατότητα αναζήτησης"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
+msgstr "Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17791,7 +17754,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Γίνεται ασφαλή αποθήκευση στον κρυπτογραφημένο διακομιστή μας."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17938,8 +17901,8 @@ msgstr "Επιλέξτε %1$sΡύθμιση για αυτόν τον ιστότ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε %3$shttps://duckduckgo."
-"com%4$s στο πεδίο εισαγωγής"
+"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε "
+"%3$shttps://duckduckgo.com%4$s στο πεδίο εισαγωγής"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17951,15 +17914,13 @@ msgstr ""
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
+msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
+msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18000,8 +17961,7 @@ msgstr "Διάλεξε %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
+msgstr "Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18075,8 +18035,7 @@ msgstr "Διάλεξε %1$sΡυθμίσεις%2$s και έπειτα %3$sΣύν
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
+msgstr "Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18137,8 +18096,7 @@ msgstr "Διάλεξε όλα τα τετράγωνα που περιέχουν 
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr ""
-"Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
+msgstr "Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -18322,7 +18280,7 @@ msgstr "Ορισμός του DuckDuckGo ως αρχικής σελίδας"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Όρισε τον τόνο και το στυλ των απαντήσεων του Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18395,13 +18353,13 @@ msgstr "Σεϋχέλλες"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Κοινοποίηση"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Κοινοποίηση"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18450,7 +18408,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Κοινοποίηση συνομιλίας"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18514,7 +18472,7 @@ msgstr "Κοινοποίηση θετικών σχολίων"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Εύρος κοινοποίησης"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18528,8 +18486,7 @@ msgstr "Κοινοποίησε αυτή τη συνομιλία στο DuckDuckG
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr ""
-"Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
+msgstr "Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -18656,7 +18613,7 @@ msgstr "Εμφάνιση λεπτομερειών"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Εμφάνιση προγράμματος εκμάθησης του Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18813,7 +18770,7 @@ msgstr "Εμφάνιση περισσοτέρων"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Εμφάνιση περισσοτέρων μοντέλων"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18854,7 +18811,7 @@ msgstr "Εμφάνιση πλαϊνής γραμμής"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19238,8 +19195,7 @@ msgstr "Κάτι πήγε στραβά κατά την αποθήκευση στ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
+msgstr "Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19251,7 +19207,7 @@ msgstr "Κάτι πήγε λάθος. Προσπαθήστε πάλι αργότ
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Κάτι πήγε λάθος. Δοκίμασε ξανά."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19555,7 +19511,7 @@ msgstr "Έναρξη χρήσης εβδομαδιαίου ορίου"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Έναρξη νέας συνομιλίας"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19572,8 +19528,7 @@ msgstr "Αρχίστε με μια εικόνα"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
+msgstr "Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -19847,8 +19802,7 @@ msgstr "Πρότεινε έναν τίτλο για μια ανάρτηση σε
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
+msgstr "Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20153,7 +20107,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Αλλαγή σε αυτήν τη δεύτερη γνώμη"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20319,7 +20273,7 @@ msgstr "Το Sync & Backup είναι προσωρινά μη διαθέσιμο
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Συγχρόνισε συνομιλίες σε όλες τις συσκευές"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20415,6 +20369,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Πάρε το Duck.ai μαζί σου παντού. Απόκτησέ το ενσωματωμένο στη δωρεάν "
+"εφαρμογή μας για ταχύτερη πρόσβαση, όπου κι αν βρίσκεσαι."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20423,6 +20379,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Πάρε το Duck.ai μαζί σου παντού. Απόκτησέ το ενσωματωμένο στο δωρεάν "
+"πρόγραμμα περιήγησής μας για ταχύτερη πρόσβαση, όπου κι αν περιηγείσαι."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20646,15 +20604,13 @@ msgstr "Ευχαριστούμε για τα σχόλιά σας!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
+msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
+msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -20819,8 +20775,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
+msgstr "Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20894,8 +20849,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
+msgstr "Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20907,7 +20861,7 @@ msgstr "Αυτόν τον μήνα"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Αυτή την απάντηση"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20919,7 +20873,7 @@ msgstr "Αυτή την εβδομάδα"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20974,15 +20928,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
+msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
+msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21041,16 +20993,14 @@ msgstr "Δεν ήταν δυνατή η δημιουργία αυτής της �
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
+msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
+msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21064,6 +21014,9 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Αυτή είναι απλώς μια δοκιμαστική συνομιλία. Άνοιξε το μενού της (τις τρεις "
+"κουκκίδες) και μετά επίλεξε Καρφίτσωμα για να τη διατηρήσεις στην κορυφή των "
+"συνομιλιών σου!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21072,6 +21025,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Αυτή είναι απλώς μια δοκιμαστική συνομιλία. Χρησιμοποίησε το Fire Button στο "
+"πλευρικό μενού για να τη διαγράψεις!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21121,8 +21076,7 @@ msgstr "Αυτή η σελίδα απαιτεί Javascript για να λειτ�
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
+msgstr "Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21201,8 +21155,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
+msgstr "Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21231,8 +21184,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
+msgstr "Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21320,8 +21272,7 @@ msgstr "Συμβουλές"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
+msgstr "Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21354,8 +21305,8 @@ msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
 msgstr ""
-"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του Duck."
-"ai"
+"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21430,6 +21381,8 @@ msgstr "Σήμερα"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Χρησιμοποίησε τον διακόπτη για να δοκιμάσεις την ιδιωτική συνομιλία με "
+"τεχνητή νοημοσύνη ή %1$sαπενεργοποίησέ την στο μενού %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21594,8 +21547,7 @@ msgstr "Εφαρμογές παρακολούθησης που αποκλείσ�
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
+msgstr "Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21781,8 +21733,7 @@ msgstr "Δοκιμάστε το %1$s για να σταματήσετε να β�
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
+msgstr "Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21853,7 +21804,7 @@ msgstr "Δοκιμάστε τα"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Δοκίμασε ένα διαφορετικό μοντέλο"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21864,7 +21815,7 @@ msgstr "Δοκίμασε μια αναζήτηση!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Δοκίμασε μια πρόταση"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21890,8 +21841,7 @@ msgstr ""
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
 msgctxt "noresults"
 msgid "Try clearing your filters and searching again."
-msgstr ""
-"Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
+msgstr "Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words.
@@ -21910,8 +21860,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
+msgstr "Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21940,7 +21889,7 @@ msgstr "Δωρεάν δοκιμή"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Δωρεάν δοκιμή"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21962,13 +21911,12 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Δοκίμασε δωρεάν για 7 ημέρες"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
 msgid "Try generating an AI-assisted answer"
-msgstr ""
-"Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
+msgstr "Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
@@ -21990,14 +21938,13 @@ msgstr "Δοκιμάστε το πρόγραμμα περιήγησής μας"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
+msgstr "Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Δοκίμασε τη συλλογιστική"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -22260,7 +22207,7 @@ msgstr ""
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Ενεργοποίηση διακόπτη Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22272,8 +22219,7 @@ msgstr "Ενεργοποιήστε την «Ακριβή τοποθεσία» γ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
+msgstr "Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22425,8 +22371,7 @@ msgstr "Δεν είναι δυνατή η αποστολή σχολίων"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
+msgstr "Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22480,8 +22425,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
+msgstr "Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22500,8 +22444,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών αναζήτησης…"
-"%4$s"
+"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών "
+"αναζήτησης…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22602,8 +22546,7 @@ msgstr ""
 #. Title for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Unlock VPN + Advanced AI"
-msgstr ""
-"Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
+msgstr "Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Text for the button that allows the user to unlock an AI model with a DuckDuckGo subscription when clicked.
@@ -22633,8 +22576,7 @@ msgstr "Ξεκλειδώστε προηγμένα μοντέλα τεχνητή�
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
+msgstr "Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -22646,7 +22588,7 @@ msgstr "Ξεκλειδώστε προηγμένη τεχνητή νοημοσύ�
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Ξεκλείδωσε προηγμένα μοντέλα"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22991,8 +22933,7 @@ msgstr "Χρήση της ιδιωτικής αναζήτησης του DuckDuc
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
+msgstr "Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23020,7 +22961,7 @@ msgstr "Χρήση στο Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23184,8 +23125,7 @@ msgstr "Δείτε τιμές για τη διαμονή σας"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
+msgstr "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23645,8 +23585,7 @@ msgstr "Δεν σε παρακολουθούμε, ποτέ μα ποτέ."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
+msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23689,8 +23628,7 @@ msgstr ""
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
+msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23997,8 +23935,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
+msgstr "Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24060,15 +23997,14 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του Duck."
-"ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
+"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του "
+"Duck.ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What AI model would you like us to add? (optional)"
-msgstr ""
-"Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
+msgstr "Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for providing arguments, counter-arguments, and rebuttals to the concept of a plant-based diet.
@@ -24245,7 +24181,7 @@ msgstr "Τι σε έκανε να επιστρέψεις σήμερα;"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Τι μπορείς να κάνεις;"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24678,6 +24614,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Με το Duck.ai, οι συνομιλίες σου είναι ανωνυμοποιημένες και δεν "
+"χρησιμοποιούνται ποτέ για την εκπαίδευση τεχνητής νοημοσύνης. Ενεργοποίησέ "
+"το ή απενεργοποίησέ το οποιαδήποτε στιγμή στο μενού '%1$s'."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24970,8 +24909,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
+msgstr "Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25033,8 +24971,7 @@ msgstr ""
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
+msgstr "Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25071,8 +25008,7 @@ msgstr ""
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can keep chatting by using your monthly limit."
-msgstr ""
-"Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
+msgstr "Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
 
 # smartling.placeholder_format=C
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
@@ -25123,7 +25059,7 @@ msgstr "Μπορείτε να επισυνάψετε μόνο %1$s εικόνε�
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Μπορείς να επισυνάπτεις μόνο %1$s καρτέλες κάθε φορά."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -25183,8 +25119,7 @@ msgstr "Μπορείς να ξεκινήσεις από την αρχή σε α�
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
+msgstr "Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25278,7 +25213,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Είσαι πανέτοιμος!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -25332,7 +25267,7 @@ msgstr "Έχετε αποκλείσει 1 ιστότοπο"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Έχεις κατακτήσει τα βασικά του Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25360,16 +25295,14 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
+msgstr "Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
+msgstr "Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25395,9 +25328,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες Duck."
-"ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να συνεχίσετε "
-"τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
+"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες "
+"Duck.ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να "
+"συνεχίσετε τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25752,6 +25685,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Οι ρυθμίσεις σου έχουν αποθηκευτεί, αλλά η διαγραφή των cookies θα τις "
+"επαναφέρει. Ενεργοποίησε την επέκταση %1$sDuckDuckGo No AI%2$s για να γίνουν "
+"μόνιμες."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26354,4 +26290,4 @@ msgstr "έ."
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/en_AU/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_AU/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -484,6 +494,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1848,6 +1870,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3082,6 +3109,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3683,6 +3715,11 @@ msgstr "Clipart"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3718,6 +3755,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4025,6 +4067,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4079,6 +4126,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4116,6 +4168,11 @@ msgstr "Copy &amp; paste %sabout:preferences#search%s into the address bar"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4212,6 +4269,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4246,6 +4308,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4371,6 +4440,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4607,9 +4681,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4637,6 +4721,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4890,6 +4979,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5056,6 +5150,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5231,6 +5330,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5338,6 +5442,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5826,6 +5935,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6066,6 +6180,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6199,6 +6318,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6280,6 +6409,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6611,6 +6745,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7032,6 +7171,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7061,6 +7205,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7078,6 +7232,11 @@ msgstr "Get this song on:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Get your friends to switch and help us grow!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7628,6 +7787,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8931,6 +9095,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8986,6 +9156,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9882,6 +10057,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "More than 20 minutes"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10276,6 +10456,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10826,6 +11011,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "On but no numbers"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10996,6 +11186,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11596,9 +11791,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11613,6 +11818,11 @@ msgstr "Pink"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11869,6 +12079,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12038,6 +12253,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12480,6 +12700,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12507,6 +12737,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12629,6 +12864,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12931,6 +13171,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Reset All Settings"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12939,6 +13184,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13498,6 +13748,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Search Anonymously"
 
@@ -13779,6 +14034,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14181,6 +14441,11 @@ msgstr "Set as Default Search Engine"
 msgid "Set as Homepage"
 msgstr "Set as Homepage"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14233,6 +14498,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14262,6 +14537,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14310,6 +14591,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14421,6 +14707,11 @@ msgstr "Show Bookmarklet and Settings Data"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14545,6 +14836,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14573,6 +14869,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14871,6 +15172,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15103,6 +15409,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15581,6 +15892,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Switch to the search engine that doesn't track you. Ever."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15693,6 +16011,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15763,6 +16086,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Reclaim Your Privacy!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16134,9 +16471,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16237,6 +16584,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16493,6 +16854,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16830,9 +17196,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Give a search a try!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16886,6 +17262,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16896,6 +17277,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16919,6 +17305,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Try our homepage that never shows these messages:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17118,6 +17509,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17405,6 +17801,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17701,6 +18102,11 @@ msgstr "Use in Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Use in Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18621,6 +19027,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "What brought you back today?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18960,6 +19371,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19306,6 +19724,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19414,6 +19838,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19450,6 +19879,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19751,6 +20185,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20224,6 +20665,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/en_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_CA/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -484,6 +494,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1848,6 +1870,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3082,6 +3109,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3683,6 +3715,11 @@ msgstr "Clipart"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3718,6 +3755,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4025,6 +4067,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4079,6 +4126,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4116,6 +4168,11 @@ msgstr "Copy &amp; paste %sabout:preferences#search%s into the address bar"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4212,6 +4269,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4246,6 +4308,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4371,6 +4440,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4607,9 +4681,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4637,6 +4721,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4890,6 +4979,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5056,6 +5150,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5231,6 +5330,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5338,6 +5442,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5826,6 +5935,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6066,6 +6180,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6199,6 +6318,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6280,6 +6409,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6611,6 +6745,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7032,6 +7171,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7061,6 +7205,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7078,6 +7232,11 @@ msgstr "Get this song on:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Get your friends to switch and help us grow!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7628,6 +7787,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8931,6 +9095,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8986,6 +9156,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9882,6 +10057,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "More than 20 minutes"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10276,6 +10456,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10826,6 +11011,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "On but no numbers"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10996,6 +11186,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11596,9 +11791,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11613,6 +11818,11 @@ msgstr "Pink"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11869,6 +12079,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12038,6 +12253,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12480,6 +12700,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12507,6 +12737,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12629,6 +12864,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12931,6 +13171,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Reset All Settings"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12939,6 +13184,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13498,6 +13748,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Search Anonymously"
 
@@ -13779,6 +14034,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14181,6 +14441,11 @@ msgstr "Set as Default Search Engine"
 msgid "Set as Homepage"
 msgstr "Set as Homepage"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14233,6 +14498,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14262,6 +14537,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14310,6 +14591,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14421,6 +14707,11 @@ msgstr "Show Bookmarklet and Settings Data"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14545,6 +14836,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14573,6 +14869,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14871,6 +15172,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15103,6 +15409,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15581,6 +15892,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Switch to the search engine that doesn't track you. Ever."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15693,6 +16011,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15763,6 +16086,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Take Back Your Privacy!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16134,9 +16471,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16237,6 +16584,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16493,6 +16854,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16830,9 +17196,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Try a search!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16886,6 +17262,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16896,6 +17277,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16919,6 +17305,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Try our homepage that never shows these messages:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17118,6 +17509,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17405,6 +17801,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17701,6 +18102,11 @@ msgstr "Use in Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Use in Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18621,6 +19027,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "What brought you back today?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18960,6 +19371,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19306,6 +19724,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19414,6 +19838,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19450,6 +19879,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19751,6 +20185,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20224,6 +20665,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/en_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_GB/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -484,6 +494,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1848,6 +1870,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3082,6 +3109,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3683,6 +3715,11 @@ msgstr "Clipart"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3718,6 +3755,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4025,6 +4067,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4079,6 +4126,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4116,6 +4168,11 @@ msgstr "Copy &amp; paste %sabout:preferences#search%s into the address bar"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4212,6 +4269,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4246,6 +4308,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4371,6 +4440,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4607,9 +4681,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4637,6 +4721,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4890,6 +4979,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5056,6 +5150,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5231,6 +5330,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5338,6 +5442,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5826,6 +5935,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6066,6 +6180,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6199,6 +6318,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6280,6 +6409,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6611,6 +6745,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7032,6 +7171,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7061,6 +7205,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7078,6 +7232,11 @@ msgstr "Get this song on:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Get your friends to switch and help us grow!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7628,6 +7787,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8931,6 +9095,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8986,6 +9156,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9882,6 +10057,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "More than 20 minutes"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10276,6 +10456,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10826,6 +11011,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "On but no numbers"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10996,6 +11186,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11596,9 +11791,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11613,6 +11818,11 @@ msgstr "Pink"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11869,6 +12079,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12038,6 +12253,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12480,6 +12700,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12507,6 +12737,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12629,6 +12864,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12931,6 +13171,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Reset All Settings"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12939,6 +13184,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13498,6 +13748,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Search Anonymously"
 
@@ -13779,6 +14034,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14181,6 +14441,11 @@ msgstr "Set as Default Search Engine"
 msgid "Set as Homepage"
 msgstr "Set as Homepage"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14233,6 +14498,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14262,6 +14537,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14310,6 +14591,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14421,6 +14707,11 @@ msgstr "Show Bookmarklet and Settings Data"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14545,6 +14836,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14573,6 +14869,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14871,6 +15172,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15103,6 +15409,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15581,6 +15892,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Switch to the search engine that doesn't track you. Ever."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15693,6 +16011,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15763,6 +16086,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Take Back Your Privacy!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16134,9 +16471,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16237,6 +16584,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16493,6 +16854,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16830,9 +17196,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Try a search!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16886,6 +17262,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16896,6 +17277,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16919,6 +17305,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Try our homepage that never shows these messages:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17118,6 +17509,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17405,6 +17801,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17701,6 +18102,11 @@ msgstr "Use in Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Use in Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18621,6 +19027,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "What brought you back today?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18960,6 +19371,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19306,6 +19724,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19414,6 +19838,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19450,6 +19879,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19751,6 +20185,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20224,6 +20665,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/en_US/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_US/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4013,6 +4055,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4067,6 +4114,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4104,6 +4156,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4200,6 +4257,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4234,6 +4296,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4359,6 +4428,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4595,9 +4669,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4625,6 +4709,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4878,6 +4967,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5044,6 +5138,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5219,6 +5318,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5326,6 +5430,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5814,6 +5923,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6053,6 +6167,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6186,6 +6305,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6267,6 +6396,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6596,6 +6730,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7017,6 +7156,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7046,6 +7190,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7062,6 +7216,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7613,6 +7772,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8908,6 +9072,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8963,6 +9133,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9859,6 +10034,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10253,6 +10433,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10801,6 +10986,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr ""
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10969,6 +11159,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11565,9 +11760,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11582,6 +11787,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11838,6 +12048,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12007,6 +12222,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12449,6 +12669,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12476,6 +12706,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12598,6 +12833,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12900,6 +13140,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12908,6 +13153,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13465,6 +13715,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13745,6 +14000,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14142,6 +14402,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14194,6 +14459,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14223,6 +14498,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14271,6 +14552,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14382,6 +14668,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14506,6 +14797,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14534,6 +14830,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14832,6 +15133,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15064,6 +15370,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15542,6 +15853,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15654,6 +15972,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15723,6 +16046,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16092,9 +16429,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16195,6 +16542,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16451,6 +16812,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16788,8 +17154,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16844,6 +17220,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16854,6 +17235,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16876,6 +17262,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17076,6 +17467,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17360,6 +17756,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17655,6 +18056,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18568,6 +18974,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18907,6 +19318,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19251,6 +19669,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19359,6 +19783,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19393,6 +19822,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19690,6 +20124,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20162,4 +20603,9 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""

--- a/locales/eo_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/eo_XX/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -489,6 +499,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "antaŭ 1 tago"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1228,6 +1243,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1854,6 +1876,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3088,6 +3115,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3692,6 +3724,11 @@ msgstr "Bildetaro"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3727,6 +3764,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4034,6 +4076,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4088,6 +4135,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4125,6 +4177,11 @@ msgstr "Kopiu kaj algluu %sabout:preferences#search%s en la adresbreton"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4221,6 +4278,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4255,6 +4317,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4380,6 +4449,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4616,9 +4690,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4646,6 +4730,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4899,6 +4988,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5065,6 +5159,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5240,6 +5339,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5347,6 +5451,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5835,6 +5944,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6075,6 +6189,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6208,6 +6327,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6289,6 +6418,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6620,6 +6754,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7041,6 +7180,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7070,6 +7214,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7087,6 +7241,11 @@ msgstr "Ekhavu ĉi-kanton ĉe:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Konvinku viajn amikojn ekuzi DuckDuckGo kaj helpu nin grandiĝi!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7637,6 +7796,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8940,6 +9104,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Permesas al vi serĉi anonime per DuckDuckGo"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8995,6 +9165,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9891,6 +10066,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Pli ol 20 minutoj"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10285,6 +10465,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10835,6 +11020,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Aktiva sed sen numeroj"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11005,6 +11195,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11605,9 +11800,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11622,6 +11827,11 @@ msgstr "Roza"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11878,6 +12088,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12047,6 +12262,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12489,6 +12709,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12516,6 +12746,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12638,6 +12873,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12940,6 +13180,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restarigi ĉiujn agordojn"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12948,6 +13193,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13507,6 +13757,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Serĉi anonime"
 
@@ -13788,6 +14043,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14191,6 +14451,11 @@ msgstr "Agordi kiel defaŭltan serĉilon"
 msgid "Set as Homepage"
 msgstr "Agordi kiel hejmpaĝon"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14243,6 +14508,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14272,6 +14547,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14320,6 +14601,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14432,6 +14718,11 @@ msgstr "Montri legosigneton kaj agordajn datumojn"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Montri Detalojn"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14555,6 +14846,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14583,6 +14879,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14881,6 +15182,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15113,6 +15419,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15593,6 +15904,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Aliĝu al la serĉilo, kiu ne spuras vin. Neniam."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15705,6 +16023,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15775,6 +16098,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Reprenu Vian Privatecon!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16149,9 +16486,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16252,6 +16599,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16510,6 +16871,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16847,9 +17213,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Provu serĉon!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16903,6 +17279,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16913,6 +17294,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16936,6 +17322,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Provu nian hejmpaĝon, kiu neniam montras tiajn ĉi mesaĝojn:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17135,6 +17526,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17422,6 +17818,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17718,6 +18119,11 @@ msgstr "Uzi en Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Uzi en Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18638,6 +19044,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Kio revenigis vin hodiaŭ?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18977,6 +19388,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19323,6 +19741,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19431,6 +19855,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19469,6 +19898,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19772,6 +20206,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20246,6 +20687,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/es_AR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_AR/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -484,6 +494,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1850,6 +1872,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3084,6 +3111,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3699,6 +3731,11 @@ msgstr "Clip de arte"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3734,6 +3771,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4042,6 +4084,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4096,6 +4143,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4133,6 +4185,11 @@ msgstr "Copiá y pegá %sabout:preferences#search%s en la barra de direcciones"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4229,6 +4286,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4263,6 +4325,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4388,6 +4457,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4624,9 +4698,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4654,6 +4738,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4907,6 +4996,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5073,6 +5167,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5248,6 +5347,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5355,6 +5459,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5843,6 +5952,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6084,6 +6198,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6217,6 +6336,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6298,6 +6427,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6631,6 +6765,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7052,6 +7191,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7081,6 +7225,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7098,6 +7252,11 @@ msgstr "Obtén esta canción en:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "¡Hacé que tus amigos se pasen y nos ayuden a crecer!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7648,6 +7807,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8960,6 +9124,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9015,6 +9185,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9913,6 +10088,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Más de 20 minutos"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10307,6 +10487,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10857,6 +11042,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activado, pero sin números"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11027,6 +11217,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11627,9 +11822,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11644,6 +11849,11 @@ msgstr "Rosa"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11900,6 +12110,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12069,6 +12284,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12511,6 +12731,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12538,6 +12768,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12660,6 +12895,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12962,6 +13202,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restablecer todos los ajustes"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12970,6 +13215,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13529,6 +13779,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Buscá anónimamente"
 
@@ -13811,6 +14066,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14221,6 +14481,11 @@ msgstr "Establecer como motor de búsqueda predeterminado"
 msgid "Set as Homepage"
 msgstr "Establecer como página de inicio"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14275,6 +14540,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14304,6 +14579,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14352,6 +14633,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14463,6 +14749,11 @@ msgstr "Mostrar Datos de Ajustes y Bookmarklets"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14587,6 +14878,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14615,6 +14911,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14914,6 +15215,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15146,6 +15452,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15624,6 +15935,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Cambiate al motor de búsqueda que no te persigue. Jamás."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15736,6 +16054,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15806,6 +16129,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "¡Recuperá tu privacidad!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16178,9 +16515,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16281,6 +16628,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16539,6 +16900,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16876,9 +17242,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "¡Prueba una búsqueda!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16933,6 +17309,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16943,6 +17324,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16966,6 +17352,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Prueba que en nuestra página nunca aparezcan estos mensajes:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17165,6 +17556,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17458,6 +17854,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17755,6 +18156,11 @@ msgstr "Usar en Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Usar en Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18676,6 +19082,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "¿Qué te trajo de nuevo hoy?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19017,6 +19428,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19363,6 +19781,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19475,6 +19899,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19511,6 +19940,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19813,6 +20247,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20287,6 +20728,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/es_CL/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CL/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3687,6 +3719,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3722,6 +3759,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4029,6 +4071,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4083,6 +4130,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4120,6 +4172,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4216,6 +4273,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4250,6 +4312,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4375,6 +4444,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4611,9 +4685,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4641,6 +4725,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4894,6 +4983,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5060,6 +5154,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5235,6 +5334,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5342,6 +5446,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5830,6 +5939,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6071,6 +6185,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6204,6 +6323,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6285,6 +6414,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6617,6 +6751,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7038,6 +7177,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7067,6 +7211,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7084,6 +7238,11 @@ msgstr "Obtén esta canción en:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Haz que tus amigos nos prefieran y ayúdanos a que podamos crecer!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7634,6 +7793,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8935,6 +9099,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8990,6 +9160,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9888,6 +10063,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10282,6 +10462,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10832,6 +11017,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activado sin números"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11002,6 +11192,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11602,9 +11797,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11619,6 +11824,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11875,6 +12085,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12044,6 +12259,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12486,6 +12706,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12513,6 +12743,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12635,6 +12870,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12938,6 +13178,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restaurar todos los ajustes"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12946,6 +13191,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13505,6 +13755,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13787,6 +14042,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14197,6 +14457,11 @@ msgstr "Establecer como motor de búsqueda predeterminado"
 msgid "Set as Homepage"
 msgstr "Establecer como página de inicio"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14251,6 +14516,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14280,6 +14555,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14328,6 +14609,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14439,6 +14725,11 @@ msgstr "Mostrar Favorito y Datos de COnfiguración"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14563,6 +14854,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14591,6 +14887,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14889,6 +15190,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15121,6 +15427,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15599,6 +15910,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15711,6 +16029,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15781,6 +16104,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "¡Recupera tu privacidad!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16149,9 +16486,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16252,6 +16599,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16510,6 +16871,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16847,9 +17213,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "¡Prueba una búsqueda!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16904,6 +17280,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16914,6 +17295,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16937,6 +17323,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Intente nuestra página web que nunca muestra esos mensages:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17136,6 +17527,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17429,6 +17825,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17725,6 +18126,11 @@ msgstr "Usar en Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Usar en Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18639,6 +19045,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18978,6 +19389,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19324,6 +19742,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19433,6 +19857,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19467,6 +19896,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19767,6 +20201,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20241,6 +20682,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/es_CO/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CO/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -484,6 +494,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1849,6 +1871,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3083,6 +3110,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3695,6 +3727,11 @@ msgstr "Imágenes prediseñadas"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3730,6 +3767,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4037,6 +4079,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4091,6 +4138,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4128,6 +4180,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4224,6 +4281,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4258,6 +4320,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4383,6 +4452,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4619,9 +4693,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4649,6 +4733,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4902,6 +4991,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5068,6 +5162,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5243,6 +5342,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5350,6 +5454,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5838,6 +5947,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6079,6 +6193,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6212,6 +6331,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6293,6 +6422,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6626,6 +6760,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7047,6 +7186,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7076,6 +7220,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7093,6 +7247,11 @@ msgstr "Obtén esta canción en:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "¡Haz que tus amigos cambien y ayudanos a crecer!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7643,6 +7802,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8945,6 +9109,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9000,6 +9170,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9898,6 +10073,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Mas de 20 minutos"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10292,6 +10472,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10842,6 +11027,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Configuración"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11012,6 +11202,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11612,9 +11807,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11629,6 +11834,11 @@ msgstr "Rosado"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11885,6 +12095,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12054,6 +12269,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12496,6 +12716,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12523,6 +12753,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12645,6 +12880,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12947,6 +13187,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restablecer todos los ajustes"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12955,6 +13200,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13515,6 +13765,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Búsqueda anónima"
 
@@ -13797,6 +14052,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14205,6 +14465,11 @@ msgstr "Establecer como motor de búsqueda por defecto"
 msgid "Set as Homepage"
 msgstr "Establecer como página de inicio"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14259,6 +14524,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14289,6 +14564,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14337,6 +14618,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14448,6 +14734,11 @@ msgstr "Mostrar marcadores y ajustes de datos"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14572,6 +14863,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14600,6 +14896,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14898,6 +15199,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15130,6 +15436,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15608,6 +15919,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Cambia al motor de búsqueda que no te sigue. Siempre."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15720,6 +16038,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15790,6 +16113,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Vuelva a ganar su privacidad"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16158,9 +16495,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16261,6 +16608,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16519,6 +16880,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16856,9 +17222,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Intenta una búsqueda!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16913,6 +17289,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16923,6 +17304,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16946,6 +17332,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Pruebe nuestra página inicial que nunca presenta estos mensajes:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17145,6 +17536,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17437,6 +17833,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17733,6 +18134,11 @@ msgstr "Usar en Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Usar en Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18653,6 +19059,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "¿Qué te trae por aquí hoy?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18993,6 +19404,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19339,6 +19757,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19448,6 +19872,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19484,6 +19913,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19785,6 +20219,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20259,6 +20700,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/es_CR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CR/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3078,6 +3105,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3674,6 +3706,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3709,6 +3746,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4016,6 +4058,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4070,6 +4117,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4107,6 +4159,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4203,6 +4260,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4237,6 +4299,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4362,6 +4431,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4598,9 +4672,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4628,6 +4712,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4881,6 +4970,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5047,6 +5141,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5222,6 +5321,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5329,6 +5433,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5817,6 +5926,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6056,6 +6170,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6189,6 +6308,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6270,6 +6399,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6601,6 +6735,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7022,6 +7161,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7051,6 +7195,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7067,6 +7221,11 @@ msgstr "Obtén esta canción en:"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7618,6 +7777,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8917,6 +9081,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8972,6 +9142,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9868,6 +10043,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10262,6 +10442,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10810,6 +10995,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activar pero sin números"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10978,6 +11168,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11574,9 +11769,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11591,6 +11796,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11847,6 +12057,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12016,6 +12231,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12458,6 +12678,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12485,6 +12715,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12607,6 +12842,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12909,6 +13149,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restablecer Toda la Configuración "
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12917,6 +13162,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13474,6 +13724,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13756,6 +14011,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14153,6 +14413,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Establecer como página de inicio"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14207,6 +14472,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14236,6 +14511,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14284,6 +14565,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14395,6 +14681,11 @@ msgstr "Mostrar Datos de Configuración y Marcadores"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14519,6 +14810,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14547,6 +14843,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14845,6 +15146,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15077,6 +15383,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15555,6 +15866,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15667,6 +15985,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15736,6 +16059,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16105,9 +16442,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16208,6 +16555,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16464,6 +16825,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16801,9 +17167,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Realice una búsqueda!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16858,6 +17234,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16868,6 +17249,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16890,6 +17276,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17090,6 +17481,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17374,6 +17770,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17669,6 +18070,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18582,6 +18988,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18921,6 +19332,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19267,6 +19685,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19378,6 +19802,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19412,6 +19841,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19712,6 +20146,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20186,6 +20627,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/es_EC/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_EC/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3678,6 +3710,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3713,6 +3750,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4020,6 +4062,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4074,6 +4121,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4111,6 +4163,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4207,6 +4264,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4241,6 +4303,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4366,6 +4435,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4602,9 +4676,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4632,6 +4716,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4885,6 +4974,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5051,6 +5145,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5226,6 +5325,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5333,6 +5437,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5821,6 +5930,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6061,6 +6175,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6194,6 +6313,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6275,6 +6404,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6608,6 +6742,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7029,6 +7168,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7058,6 +7202,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7075,6 +7229,11 @@ msgstr "Obtener esta canción en:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "¡Pídele a tus amigos que se cambien y ayúdanos a crecer!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7625,6 +7784,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8924,6 +9088,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8979,6 +9149,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9875,6 +10050,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10269,6 +10449,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10817,6 +11002,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activar pero sin números"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10987,6 +11177,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11583,9 +11778,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11600,6 +11805,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11856,6 +12066,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12025,6 +12240,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12467,6 +12687,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12494,6 +12724,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12616,6 +12851,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12919,6 +13159,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restaurar todos los cambios"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12927,6 +13172,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13484,6 +13734,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13766,6 +14021,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14167,6 +14427,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Establecer como Página de inicio"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14221,6 +14486,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14250,6 +14525,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14298,6 +14579,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14409,6 +14695,11 @@ msgstr "Mostrar marcadores y datos de configuración"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14533,6 +14824,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14561,6 +14857,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14859,6 +15160,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15091,6 +15397,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15569,6 +15880,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15681,6 +15999,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15750,6 +16073,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16119,9 +16456,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16222,6 +16569,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16480,6 +16841,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16817,9 +17183,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "¡Prueba una búsqueda!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16874,6 +17250,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16884,6 +17265,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16906,6 +17292,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17106,6 +17497,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17393,6 +17789,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17689,6 +18090,11 @@ msgstr "Usar en Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Usar en Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18608,6 +19014,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "¿Qué te trajo de vuelta hoy?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18947,6 +19358,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19293,6 +19711,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19402,6 +19826,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19438,6 +19867,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19739,6 +20173,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20213,6 +20654,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "hace %1$s días"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s detectado"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +361,12 @@ msgid "%s used"
 msgstr "%1$s usado"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s visualización"
@@ -416,7 +428,8 @@ msgstr "%1$s palabras"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
+msgstr ""
+"%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -604,6 +617,12 @@ msgstr "1 intento bloqueado por DuckDuckGo en las últimas 24 horas"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "hace 1 día"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1519,6 +1538,14 @@ msgid "Advanced Models"
 msgstr "Modelos avanzados"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Anunciarse en la búsqueda"
@@ -2139,19 +2166,22 @@ msgstr "¿Sigues ahí?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
+msgstr ""
+"¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
+msgstr ""
+"¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
+msgstr ""
+"¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2307,6 +2337,12 @@ msgstr "Pregunta en privado"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask privately"
 msgstr "Pregunta en privado"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -3865,6 +3901,12 @@ msgid "Chat privately with AI"
 msgstr "Chatear en privado con la IA"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4421,7 +4463,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
+msgstr ""
+"Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4448,7 +4491,8 @@ msgstr "Haz clic en %1$sAjustes%2$s en el menú desplegable."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
+msgstr ""
+"Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4581,7 +4625,8 @@ msgstr "Haz clic en el %1$sicono de permisos%2$s en la barra de direcciones"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
+msgstr ""
+"¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4663,6 +4708,12 @@ msgid "Close"
 msgstr "Cerrar"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4705,6 +4756,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Cerrar búsqueda"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5078,6 +5135,12 @@ msgid "Continue Blocking Ads"
 msgstr "Seguir bloqueando anuncios"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5143,6 +5206,12 @@ msgid "Cookie data:"
 msgstr "Datos de la cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5181,13 +5250,20 @@ msgstr "Copiar"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
+msgstr ""
+"Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Copiar código"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5305,6 +5381,12 @@ msgid "Create Image"
 msgstr "Crear imagen"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5346,6 +5428,14 @@ msgstr "Creado por"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Creado por %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5499,6 +5589,12 @@ msgstr "Personaliza las respuestas"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Personaliza las respuestas"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5787,10 +5883,22 @@ msgid "Delete Server Data?"
 msgstr "¿Eliminar datos del servidor?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Eliminar transcripción"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5825,6 +5933,12 @@ msgid "Delete image?"
 msgstr "¿Borrar imagen?"
 
 # smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats to free up storage?"
@@ -5834,7 +5948,8 @@ msgstr "¿Borrar los chats más antiguos para liberar espacio de almacenamiento?
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
+msgstr ""
+"¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5948,7 +6063,8 @@ msgstr "Dictado en Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
+msgstr ""
+"Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6129,6 +6245,12 @@ msgstr "Descartar para siempre"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Descartar promoción"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6339,6 +6461,12 @@ msgstr "Descarga finalizada"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Descarga DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6558,6 +6686,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai de DuckDuckGo. Chat privado de IA. Gratuito."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6597,7 +6731,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
+msgstr ""
+"¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6656,7 +6791,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
+msgstr ""
+"Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6714,6 +6850,12 @@ msgid ""
 msgstr ""
 "Las respuestas de Duck.ai no se basan en fuentes específicas y no se "
 "comprueba su precisión."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7370,6 +7512,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Habilitar Sitios más visitados"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7594,7 +7742,8 @@ msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
+msgstr ""
+"Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7675,6 +7824,12 @@ msgid "Entertainment guide"
 msgstr "Guía de entretenimiento"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Guinea Ecuatorial"
 
@@ -7682,7 +7837,8 @@ msgstr "Guinea Ecuatorial"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
+msgstr ""
+"Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7840,10 +7996,23 @@ msgid "Explicit lyrics"
 msgstr "Letras explícitas"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
+msgstr ""
+"Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7939,6 +8108,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Gratis"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8142,7 +8317,8 @@ msgstr "Asesor financiero"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
+msgstr ""
+"Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8363,6 +8539,12 @@ msgid "Free Up Storage"
 msgstr "Liberar almacenamiento"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8372,7 +8554,8 @@ msgstr "Chats gratuitos y privados, anonimizados por nosotros"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
+msgstr ""
+"Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8402,7 +8585,8 @@ msgstr "Libre de compartir y usar comercialmente"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
+msgstr ""
+"Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8483,9 +8667,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"En la barra de menú de la aplicación en Mac, selecciona "
-"<strong>DuckDuckGo</strong> &gt; <strong>Buscar actualizaciones...</strong> "
-"y, a continuación, selecciona <strong>Instalar actualización</strong>."
+"En la barra de menú de la aplicación en Mac, selecciona <strong>DuckDuckGo</"
+"strong> &gt; <strong>Buscar actualizaciones...</strong> y, a continuación, "
+"selecciona <strong>Instalar actualización</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8877,6 +9061,12 @@ msgid "Get computer help"
 msgstr "Obtener ayuda informática"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8914,6 +9104,18 @@ msgid "Get the Latest Version"
 msgstr "Obtener la última versión"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8934,6 +9136,12 @@ msgstr "Consigue esta canción en:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "¡Anima a tus amigos a cambiarse y ayúdanos a crecer!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9620,6 +9828,12 @@ msgid "Hide Tips"
 msgstr "Ocultar consejos"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9825,7 +10039,8 @@ msgstr "Falta el horario"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Color de fondo al pasar el cursor, de los módulos y de los desplegables"
+msgstr ""
+"Color de fondo al pasar el cursor, de los módulos y de los desplegables"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -9910,13 +10125,15 @@ msgstr "Cómo funciona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
+msgstr ""
+"¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
+msgstr ""
+"Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10171,7 +10388,8 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
+msgstr ""
+"Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10218,8 +10436,8 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr ""
-"Las indicaciones para las imágenes deben cumplir con las directrices de "
-"Duck.ai %1$s."
+"Las indicaciones para las imágenes deben cumplir con las directrices de Duck."
+"ai %1$s."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11135,7 +11353,8 @@ msgstr "Obtén más información sobre la protección de privacidad activa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Más información sobre la privacidad en Internet en tu bandeja de entrada."
+msgstr ""
+"Más información sobre la privacidad en Internet en tu bandeja de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11247,6 +11466,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "¿Hacemos una búsqueda anónima con DuckDuckGo?"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11317,6 +11543,12 @@ msgstr "Dibujo lineal"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Touches ganadas"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12417,6 +12649,12 @@ msgid "More than 20 minutes"
 msgstr "Más de 20 minutos"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12903,6 +13141,12 @@ msgstr "No, gracias"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "No, gracias"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13569,6 +13813,12 @@ msgid "On but no numbers"
 msgstr "Activado pero sin números"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13779,6 +14029,12 @@ msgstr "Abrir sugerencias de chat"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Abrir sugerencias para crear y editar imágenes"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14529,10 +14785,22 @@ msgid "Pin"
 msgstr "Anclar"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Fija chats aquí desde %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14550,6 +14818,12 @@ msgstr "Rosa"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Anclados"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14608,13 +14882,15 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
+msgstr ""
+"Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
+msgstr ""
+"Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14869,6 +15145,12 @@ msgid "Poor formatting"
 msgstr "Formato deficiente"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15075,6 +15357,12 @@ msgstr "Imagen anterior"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Pestañas anteriores"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15369,7 +15657,8 @@ msgstr "Pedir confirmación"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
+msgstr ""
+"Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15615,6 +15904,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "IA de razonamiento con moderación media integrada"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15648,6 +15949,12 @@ msgstr "Pestañas recientes"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "El almacenamiento de chats recientes se puede ajustar en %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15803,6 +16110,12 @@ msgstr "Rehacer la búsqueda sin este sitio"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Reducir el uso"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16182,6 +16495,12 @@ msgid "Reset All Settings"
 msgstr "Restablecer todos los ajustes"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16192,6 +16511,12 @@ msgstr "Se reinicia en %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Resolución"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16391,7 +16716,8 @@ msgstr "Reseñas"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Reescribe esta receta ajustándola para un número diferente de raciones."
+msgstr ""
+"Reescribe esta receta ajustándola para un número diferente de raciones."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16676,7 +17002,8 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
+msgstr ""
+"Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -16895,6 +17222,12 @@ msgstr "Buscar"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "¿Quieres buscar %1$s para encontrar resultados más cerca de ti?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17208,7 +17541,8 @@ msgstr "Segunda opinión"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
+msgstr ""
+"Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17271,6 +17605,12 @@ msgstr ""
 "Almacenado de forma segura en el servidor de DuckDuckGo con encriptación de "
 "extremo a extremo. Nadie más que tú puede ver tus datos, ni siquiera "
 "nosotros."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17425,7 +17765,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
+msgstr ""
+"Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17524,7 +17865,8 @@ msgstr "Selecciona %1$sMotor de búsqueda%2$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
+msgstr ""
+"Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17549,7 +17891,8 @@ msgstr "Selecciona %1$sAjustes%2$s en el menú desplegable."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
+msgstr ""
+"Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17564,7 +17907,8 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sSearch Engine%s"
-msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
+msgstr ""
+"Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17799,6 +18143,12 @@ msgid "Set as Homepage"
 msgstr "Establecer como página de inicio"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17866,6 +18216,18 @@ msgid "Seychelles"
 msgstr "Seychelles"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17904,6 +18266,13 @@ msgstr ""
 "Comparte una ubicación a nivel de ciudad con modelos de IA para mejorar la "
 "relevancia. Duck.ai nunca revela tu ubicación precisa ni a nosotros ni a los "
 "modelos de IA."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17962,6 +18331,12 @@ msgstr "Compartir URL de la página"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Compartir comentarios positivos"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18099,6 +18474,12 @@ msgid "Show Detail"
 msgstr "Mostrar detalles"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "Mostrar DuckAssist <sup>BETA</sup>"
@@ -18226,7 +18607,8 @@ msgstr "Mostrar todos los resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
+msgstr ""
+"Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18246,6 +18628,12 @@ msgstr "Mostrar mapa"
 msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr "Mostrar más"
+
+# smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18281,6 +18669,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Mostrar la barra lateral"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18378,7 +18772,8 @@ msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo al navegador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
+msgstr ""
+"Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18391,7 +18786,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows page numbers at result page breaks"
-msgstr "Muestra los números de página en los saltos de página de los resultados"
+msgstr ""
+"Muestra los números de página en los saltos de página de los resultados"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18404,7 +18800,8 @@ msgstr ""
 #. http://i.imgur.com/94erFcS.png
 msgctxt "settings"
 msgid "Shows suggestions under the search box as you type"
-msgstr "Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
+msgstr ""
+"Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18509,7 +18906,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
+msgstr ""
+"Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18663,6 +19061,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Se ha producido un error, inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18703,7 +19107,8 @@ msgstr "Lo sentimos, se ha producido un error inesperado."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
+msgstr ""
+"Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -18959,6 +19364,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Empezar a usar el límite semanal"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "¡Empieza a buscar!"
@@ -19064,7 +19475,8 @@ msgstr "Detén a los rastreadores ocultos que acechan en otros sitios web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
+msgstr ""
+"Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19539,6 +19951,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Cámbiate al motor de búsqueda que no te rastrea. Nunca."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19690,7 +20110,14 @@ msgstr "Sincronizar con otro dispositivo"
 #. Title shown when sync service is temporarily unavailable.
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
-msgstr "La sincronización y la copia de seguridad no están disponibles temporalmente"
+msgstr ""
+"La sincronización y la copia de seguridad no están disponibles temporalmente"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19780,6 +20207,22 @@ msgid "Take Back Your Privacy!"
 msgstr "¡Recupera tu privacidad!"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19800,7 +20243,8 @@ msgstr "Toma el control de tus datos personales"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
+msgstr ""
+"Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20165,7 +20609,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
+msgstr ""
+"Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20248,10 +20693,22 @@ msgid "This Month"
 msgstr "Este mes"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Esta semana"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20303,13 +20760,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
+msgstr ""
+"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
+msgstr ""
+"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20329,7 +20788,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
+msgstr ""
+"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20337,7 +20797,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
+msgstr ""
+"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20381,6 +20842,22 @@ msgstr "Este tipo de imagen no es compatible. Adjunta un JPG, PNG, WebP o GIF."
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Esta información no es útil"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20533,7 +21010,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
+msgstr ""
+"Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20719,6 +21197,12 @@ msgstr "Hoy"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Hoy"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20940,7 +21424,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
+msgstr ""
+"Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20948,7 +21433,8 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
+msgstr ""
+"Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21128,9 +21614,21 @@ msgid "Try Them Out"
 msgstr "Pruébalos"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "¡Prueba con una búsqueda!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21173,14 +21671,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Prueba a activar la ubicación anónima para obtener resultados más precisos."
+msgstr ""
+"Prueba a activar la ubicación anónima para obtener resultados más precisos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
+msgstr ""
+"Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21197,6 +21697,12 @@ msgid "Try for free"
 msgstr "Probar Gratis"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21209,6 +21715,12 @@ msgstr "Probar Gratis"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "¡Pruébalo gratis! Una VPN segura, IA avanzada y privada y mucho más."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21236,6 +21748,12 @@ msgstr "Prueba nuestro navegador"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Prueba nuestra página de inicio que no muestra estos mensajes:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21310,13 +21828,15 @@ msgstr "Prueba %1$s y %2$s de código abierto recientemente añadidos"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
+msgstr ""
+"Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
+msgstr ""
+"Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21482,6 +22002,12 @@ msgstr "Activa %1$sUbicación precisa%2$s para obtener resultados más precisos"
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Activar Duck Player para ver YouTube sin anuncios personalizados"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21692,7 +22218,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
+msgstr ""
+"En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21855,6 +22382,12 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "¡Desbloquea la IA avanzada con tu suscripción!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -21866,7 +22399,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
+msgstr ""
+"Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22216,6 +22750,12 @@ msgid "Use in Safari"
 msgstr "Usar en Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22424,7 +22964,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
+msgstr ""
+"Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22771,7 +23312,8 @@ msgstr "No te perseguimos con anuncios."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "No almacenamos nombres de usuario ni información personal identificable."
+msgstr ""
+"No almacenamos nombres de usuario ni información personal identificable."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22930,12 +23472,14 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
+msgstr ""
+"Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
+msgstr ""
+"Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23169,7 +23713,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
+msgstr ""
+"¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23210,7 +23755,8 @@ msgstr "Conferencia Oeste"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "We’re currently experiencing an issue with DuckDuckGo Search."
-msgstr "En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
+msgstr ""
+"En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong even though we were able to show some organic results.
@@ -23412,6 +23958,12 @@ msgid "What brought you back today?"
 msgstr "¿Qué te ha hecho volver hoy?"
 
 # smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -23606,7 +24158,8 @@ msgstr "¿Sobre qué te gustaría dar tu opinión?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
+msgstr ""
+"Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23638,7 +24191,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
+msgstr ""
+"Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23656,7 +24210,8 @@ msgstr "Dónde ver <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
+msgstr ""
+"Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23828,6 +24383,14 @@ msgstr "Victorias"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Lluvia y viento"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24260,6 +24823,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Solo puedes adjuntar %1$s imágenes por conversación."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24315,7 +24885,8 @@ msgstr "Puedes empezar de cero en este nuevo dominio (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
+msgstr ""
+"Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -24388,7 +24959,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "No volverás a ver este mensaje a menos que borres los datos de tu navegador."
+msgstr ""
+"No volverás a ver este mensaje a menos que borres los datos de tu navegador."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24399,6 +24971,12 @@ msgid ""
 msgstr ""
 "Recibirás actualizaciones automáticas de la aplicación DuckDuckGo una vez "
 "que tengas la última versión."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24449,6 +25027,12 @@ msgid "You've blocked 1 site"
 msgstr "Has bloqueado 1 sitio"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24481,12 +25065,14 @@ msgstr "Has alcanzado la duración máxima del chat de voz para una sola sesión
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
+msgstr ""
+"Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
+msgstr ""
+"Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24845,6 +25431,14 @@ msgstr "Tu rol"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Tus búsquedas no pueden vincularse a ti"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25441,3 +26035,9 @@ msgstr "años"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "año"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s detectado"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s archivos usados"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,6 +365,8 @@ msgstr "%1$s usado"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
+"%1$s consume los límites hasta de 2 a 5 veces más rápido que los modelos "
+"básicos %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -428,8 +430,7 @@ msgstr "%1$s palabras"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
+msgstr "%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -622,7 +623,7 @@ msgstr "hace 1 día"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 archivo usado"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1544,6 +1545,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Los modelos avanzados pueden consumir los límites de 2 a 5 veces más rápido "
+"que otros modelos. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2166,22 +2169,19 @@ msgstr "¿Sigues ahí?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
+msgstr "¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
+msgstr "¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
+msgstr "¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2342,7 +2342,7 @@ msgstr "Pregunta en privado"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Pregunta en privado"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -3904,7 +3904,7 @@ msgstr "Chatear en privado con la IA"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Chatea en privado con IA populares"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4463,8 +4463,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
+msgstr "Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4491,8 +4490,7 @@ msgstr "Haz clic en %1$sAjustes%2$s en el menú desplegable."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
+msgstr "Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4625,8 +4623,7 @@ msgstr "Haz clic en el %1$sicono de permisos%2$s en la barra de direcciones"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
+msgstr "¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4711,7 +4708,7 @@ msgstr "Cerrar"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Cerrar"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4761,7 +4758,7 @@ msgstr "Cerrar búsqueda"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Cerrar segunda opinión"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5138,7 +5135,7 @@ msgstr "Seguir bloqueando anuncios"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Continúa tus chats recientes aquí. O elimínalos con el Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5209,7 +5206,7 @@ msgstr "Datos de la cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Copiado"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5250,8 +5247,7 @@ msgstr "Copiar"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
+msgstr "Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5263,7 +5259,7 @@ msgstr "Copiar código"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Copiar enlace"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5384,7 +5380,7 @@ msgstr "Crear imagen"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Crear enlace para compartir"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5436,6 +5432,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Al crear un enlace se crea una copia del chat que puede ver cualquiera que "
+"lo abra."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5594,7 +5592,7 @@ msgstr "Personaliza las respuestas"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Personaliza las respuestas"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5886,7 +5884,7 @@ msgstr "¿Eliminar datos del servidor?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Eliminar enlace compartido"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5898,7 +5896,7 @@ msgstr "Eliminar transcripción"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Borrar un chat"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5936,7 +5934,7 @@ msgstr "¿Borrar imagen?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Elimíname"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5948,8 +5946,7 @@ msgstr "¿Borrar los chats más antiguos para liberar espacio de almacenamiento?
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
+msgstr "¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6063,8 +6060,7 @@ msgstr "Dictado en Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
+msgstr "Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6250,7 +6246,7 @@ msgstr "Descartar promoción"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Descartar la visita guiada"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6466,7 +6462,7 @@ msgstr "Descarga DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Descarga DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6689,7 +6685,7 @@ msgstr "Duck.ai de DuckDuckGo. Chat privado de IA. Gratuito."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai ahora puede analizar PDF. ¡Pruébalo!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6731,8 +6727,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
+msgstr "¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6791,8 +6786,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
+msgstr "Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6855,7 +6849,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai admite modelos de Anthropic, OpenAI y otros."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7515,7 +7509,7 @@ msgstr "Habilitar Sitios más visitados"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Activar ahora"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7742,8 +7736,7 @@ msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
+msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7827,7 +7820,7 @@ msgstr "Guía de entretenimiento"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Chat completo"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7837,8 +7830,7 @@ msgstr "Guinea Ecuatorial"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
+msgstr "Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7999,20 +7991,19 @@ msgstr "Letras explícitas"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Explora Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Explora Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
+msgstr "Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8113,7 +8104,7 @@ msgstr "Gratis"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRATIS Y OPCIONAL"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8317,8 +8308,7 @@ msgstr "Asesor financiero"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
+msgstr "Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8542,7 +8532,7 @@ msgstr "Liberar almacenamiento"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Gratis y siempre privado"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8554,8 +8544,7 @@ msgstr "Chats gratuitos y privados, anonimizados por nosotros"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
+msgstr "Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8585,8 +8574,7 @@ msgstr "Libre de compartir y usar comercialmente"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
+msgstr "Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8667,9 +8655,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"En la barra de menú de la aplicación en Mac, selecciona <strong>DuckDuckGo</"
-"strong> &gt; <strong>Buscar actualizaciones...</strong> y, a continuación, "
-"selecciona <strong>Instalar actualización</strong>."
+"En la barra de menú de la aplicación en Mac, selecciona "
+"<strong>DuckDuckGo</strong> &gt; <strong>Buscar actualizaciones...</strong> "
+"y, a continuación, selecciona <strong>Instalar actualización</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9064,7 +9052,7 @@ msgstr "Obtener ayuda informática"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Obtén límites de uso más altos con una subscripción a DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9107,13 +9095,15 @@ msgstr "Obtener la última versión"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Obtén la app"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9141,7 +9131,7 @@ msgstr "¡Anima a tus amigos a cambiarse y ayúdanos a crecer!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Lista de comprobación para empezar"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9831,7 +9821,7 @@ msgstr "Ocultar consejos"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Ocultar tutorial"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10039,8 +10029,7 @@ msgstr "Falta el horario"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Color de fondo al pasar el cursor, de los módulos y de los desplegables"
+msgstr "Color de fondo al pasar el cursor, de los módulos y de los desplegables"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10125,15 +10114,13 @@ msgstr "Cómo funciona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
+msgstr "¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
+msgstr "Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10388,8 +10375,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
+msgstr "Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10436,8 +10422,8 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr ""
-"Las indicaciones para las imágenes deben cumplir con las directrices de Duck."
-"ai %1$s."
+"Las indicaciones para las imágenes deben cumplir con las directrices de "
+"Duck.ai %1$s."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11353,8 +11339,7 @@ msgstr "Obtén más información sobre la protección de privacidad activa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Más información sobre la privacidad en Internet en tu bandeja de entrada."
+msgstr "Más información sobre la privacidad en Internet en tu bandeja de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11471,6 +11456,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Te permite alternar entre enviar consultas de búsqueda y sugerencias a "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11548,7 +11535,7 @@ msgstr "Touches ganadas"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "El enlace caduca en 7 días."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12652,7 +12639,7 @@ msgstr "Más de 20 minutos"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Más consejos"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13146,7 +13133,7 @@ msgstr "No, gracias"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "No, gracias"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13816,7 +13803,7 @@ msgstr "Activado pero sin números"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Incorporación completada"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -14034,7 +14021,7 @@ msgstr "Abrir sugerencias para crear y editar imágenes"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Abrir la lista de comprobación para empezar"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14788,7 +14775,7 @@ msgstr "Anclar"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Anclar un chat"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14800,7 +14787,7 @@ msgstr "Fija chats aquí desde %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Ánclame"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14823,7 +14810,7 @@ msgstr "Anclados"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Los chats anclados aparecerán en la parte superior de tus chats recientes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14882,15 +14869,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
+msgstr "Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
+msgstr "Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15149,6 +15134,8 @@ msgstr "Formato deficiente"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Modelos de IA populares disponibles. No necesitas ninguna cuenta. Chats "
+"anonimizados por nosotros."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15362,7 +15349,7 @@ msgstr "Pestañas anteriores"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Consejos anteriores"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15657,8 +15644,7 @@ msgstr "Pedir confirmación"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
+msgstr "Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15907,13 +15893,15 @@ msgstr "IA de razonamiento con moderación media integrada"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"El razonamiento es más exhaustivo, pero usa los límites de 2 a 5 veces más "
+"rápido. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15954,7 +15942,7 @@ msgstr "El almacenamiento de chats recientes se puede ajustar en %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Chats recientes"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16115,7 +16103,7 @@ msgstr "Reducir el uso"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Reduce el uso con un modelo más eficiente"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16498,7 +16486,7 @@ msgstr "Restablecer todos los ajustes"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Reiniciar tutorial"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16516,7 +16504,7 @@ msgstr "Resolución"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Respuesta"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16716,8 +16704,7 @@ msgstr "Reseñas"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Reescribe esta receta ajustándola para un número diferente de raciones."
+msgstr "Reescribe esta receta ajustándola para un número diferente de raciones."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17002,8 +16989,7 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
+msgstr "Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17227,7 +17213,7 @@ msgstr "¿Quieres buscar %1$s para encontrar resultados más cerca de ti?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Interruptor de búsqueda y Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17541,8 +17527,7 @@ msgstr "Segunda opinión"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
+msgstr "Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17610,7 +17595,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Almacenado de forma segura en nuestro servidor encriptado."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17765,8 +17750,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
+msgstr "Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17865,8 +17849,7 @@ msgstr "Selecciona %1$sMotor de búsqueda%2$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
+msgstr "Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17891,8 +17874,7 @@ msgstr "Selecciona %1$sAjustes%2$s en el menú desplegable."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
+msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17907,8 +17889,7 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sSearch Engine%s"
-msgstr ""
-"Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
+msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18146,7 +18127,7 @@ msgstr "Establecer como página de inicio"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Establece el tono y el estilo de las respuestas de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18219,13 +18200,13 @@ msgstr "Seychelles"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Compartir"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Compartir"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18272,7 +18253,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Compartir chat"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18336,7 +18317,7 @@ msgstr "Compartir comentarios positivos"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Alcance de la compartición"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18477,7 +18458,7 @@ msgstr "Mostrar detalles"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Mostrar tutorial de Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18607,8 +18588,7 @@ msgstr "Mostrar todos los resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
+msgstr "Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18633,7 +18613,7 @@ msgstr "Mostrar más"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Mostrar más modelos"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18674,7 +18654,7 @@ msgstr "Mostrar la barra lateral"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Mostrar consejos paso a paso para aprovechar al máximo Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18772,8 +18752,7 @@ msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo al navegador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
+msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18786,8 +18765,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows page numbers at result page breaks"
-msgstr ""
-"Muestra los números de página en los saltos de página de los resultados"
+msgstr "Muestra los números de página en los saltos de página de los resultados"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18800,8 +18778,7 @@ msgstr ""
 #. http://i.imgur.com/94erFcS.png
 msgctxt "settings"
 msgid "Shows suggestions under the search box as you type"
-msgstr ""
-"Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
+msgstr "Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18906,8 +18883,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
+msgstr "Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19064,7 +19040,7 @@ msgstr "Se ha producido un error, inténtalo de nuevo más tarde."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Se ha producido un error. Inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19107,8 +19083,7 @@ msgstr "Lo sentimos, se ha producido un error inesperado."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
+msgstr "Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -19367,7 +19342,7 @@ msgstr "Empezar a usar el límite semanal"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Inicia un nuevo chat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19475,8 +19450,7 @@ msgstr "Detén a los rastreadores ocultos que acechan en otros sitios web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
+msgstr "Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19956,7 +19930,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Cambiar a esta segunda opinión"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20110,14 +20084,13 @@ msgstr "Sincronizar con otro dispositivo"
 #. Title shown when sync service is temporarily unavailable.
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
-msgstr ""
-"La sincronización y la copia de seguridad no están disponibles temporalmente"
+msgstr "La sincronización y la copia de seguridad no están disponibles temporalmente"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sincronizar chats entre dispositivos"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20213,6 +20186,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Llévate Duck.ai a todas partes. Consíguelo integrado en nuestra aplicación "
+"gratuita para un acceso más rápido, estés donde estés."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20221,6 +20196,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Lleva Duck.ai contigo a todas partes. Consíguelo integrado en nuestro "
+"navegador gratuito para un acceso más rápido, estés donde estés navegando."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20243,8 +20220,7 @@ msgstr "Toma el control de tus datos personales"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
+msgstr "Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20609,8 +20585,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
+msgstr "Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20696,7 +20671,7 @@ msgstr "Este mes"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Esta respuesta"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20708,7 +20683,7 @@ msgstr "Esta semana"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Este chat se queda en Duck.ai y sigue siendo privado para ti."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20760,15 +20735,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
+msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
+msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20788,8 +20761,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
+msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20797,8 +20769,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
+msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20850,6 +20821,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Este es solo un chat de muestra. ¡Abre su menú (los tres puntos) y elige "
+"Fijar para mantenerlo en la parte superior de tus chats!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20858,6 +20831,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Este es solo un chat de muestra. ¡Usa el Fire Button del menú lateral para "
+"eliminarlo!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21010,8 +20985,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
+msgstr "Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21203,6 +21177,8 @@ msgstr "Hoy"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21424,8 +21400,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
+msgstr "Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21433,8 +21408,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
+msgstr "Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21617,7 +21591,7 @@ msgstr "Pruébalos"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Prueba un modelo diferente"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21628,7 +21602,7 @@ msgstr "¡Prueba con una búsqueda!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Prueba una sugerencia"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21671,16 +21645,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Prueba a activar la ubicación anónima para obtener resultados más precisos."
+msgstr "Prueba a activar la ubicación anónima para obtener resultados más precisos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
+msgstr "Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21700,7 +21672,7 @@ msgstr "Probar Gratis"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Probar Gratis"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21720,7 +21692,7 @@ msgstr "¡Pruébalo gratis! Una VPN segura, IA avanzada y privada y mucho más."
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Prueba gratuita durante 7 días"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21753,7 +21725,7 @@ msgstr "Prueba nuestra página de inicio que no muestra estos mensajes:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Prueba el razonamiento"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21828,15 +21800,13 @@ msgstr "Prueba %1$s y %2$s de código abierto recientemente añadidos"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
+msgstr "Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
+msgstr "Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22007,7 +21977,7 @@ msgstr "Activar Duck Player para ver YouTube sin anuncios personalizados"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Activar alternar Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22218,8 +22188,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
+msgstr "En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22385,7 +22354,7 @@ msgstr "¡Desbloquea la IA avanzada con tu suscripción!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Desbloquea modelos avanzados"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22399,8 +22368,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
+msgstr "Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22753,7 +22721,7 @@ msgstr "Usar en Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Usa el Fire Button para eliminar un chat del historial."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22964,8 +22932,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
+msgstr "Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23312,8 +23279,7 @@ msgstr "No te perseguimos con anuncios."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"No almacenamos nombres de usuario ni información personal identificable."
+msgstr "No almacenamos nombres de usuario ni información personal identificable."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23472,14 +23438,12 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
+msgstr "Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
+msgstr "Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23713,8 +23677,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
+msgstr "¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23755,8 +23718,7 @@ msgstr "Conferencia Oeste"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "We’re currently experiencing an issue with DuckDuckGo Search."
-msgstr ""
-"En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
+msgstr "En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong even though we were able to show some organic results.
@@ -23961,7 +23923,7 @@ msgstr "¿Qué te ha hecho volver hoy?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "¿Qué puedes hacer?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24158,8 +24120,7 @@ msgstr "¿Sobre qué te gustaría dar tu opinión?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
+msgstr "Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24191,8 +24152,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
+msgstr "Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24210,8 +24170,7 @@ msgstr "Dónde ver <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
+msgstr "Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24391,6 +24350,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Con Duck.ai, tus chats están anonimizados y nunca se usan para entrenar la "
+"IA. Actívalo o desactívalo en cualquier momento en el menú «%1$s»."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24827,7 +24788,7 @@ msgstr "Solo puedes adjuntar %1$s imágenes por conversación."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Solo puedes adjuntar %1$s pestañas a la vez."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24885,8 +24846,7 @@ msgstr "Puedes empezar de cero en este nuevo dominio (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
+msgstr "Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -24959,8 +24919,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"No volverás a ver este mensaje a menos que borres los datos de tu navegador."
+msgstr "No volverás a ver este mensaje a menos que borres los datos de tu navegador."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24976,7 +24935,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "¡Todo Listo!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -25030,7 +24989,7 @@ msgstr "Has bloqueado 1 sitio"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Has dominado los conceptos básicos de Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25065,14 +25024,12 @@ msgstr "Has alcanzado la duración máxima del chat de voz para una sola sesión
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
+msgstr "Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
+msgstr "Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25439,6 +25396,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Tus ajustes están guardados, pero borrar las cookies los restablecerá. "
+"Habilita la extensión %1$sDuckDuckGo No AI%2$s para que sea permanente."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26040,4 +25999,4 @@ msgstr "año"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/es_MX/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_MX/LC_MESSAGES/duckduckgo.po
@@ -106,6 +106,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -287,6 +292,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -486,6 +496,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Hace un día"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1226,6 +1241,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1851,6 +1873,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3093,6 +3120,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3704,6 +3736,11 @@ msgstr "Clipart"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3739,6 +3776,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4046,6 +4088,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4100,6 +4147,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4137,6 +4189,11 @@ msgstr "Copia y pega %sabout:preferences#search%s en la barra de dirección"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4233,6 +4290,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4267,6 +4329,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4392,6 +4461,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4628,9 +4702,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4658,6 +4742,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4911,6 +5000,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5077,6 +5171,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5252,6 +5351,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5359,6 +5463,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5847,6 +5956,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6088,6 +6202,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6221,6 +6340,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6302,6 +6431,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6635,6 +6769,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7056,6 +7195,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7087,6 +7231,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7104,6 +7258,11 @@ msgstr "Obtener esta canción en:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "¡Haz que tus amigos cambien y ayúdanos a crecer!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7654,6 +7813,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8964,6 +9128,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Vamos a buscar anónimamente con DuckDuckGo"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9019,6 +9189,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9917,6 +10092,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Más de 20 minutos"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10313,6 +10493,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10863,6 +11048,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Habilitar pero sin números"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11033,6 +11223,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11636,9 +11831,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11653,6 +11858,11 @@ msgstr "Rosa"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11909,6 +12119,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12080,6 +12295,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12522,6 +12742,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12549,6 +12779,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12671,6 +12906,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12973,6 +13213,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restablecer Todos los Ajustes"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12981,6 +13226,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13540,6 +13790,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Buscar de forma Anónima"
 
@@ -13824,6 +14079,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14234,6 +14494,11 @@ msgstr "Configurar como Motor de Búsqueda Predeterminado"
 msgid "Set as Homepage"
 msgstr "Establecer como Página principal"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14288,6 +14553,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14317,6 +14592,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14365,6 +14646,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14477,6 +14763,11 @@ msgstr "Mostrar Marcador y datos de la configuración"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Mostrar Detalles"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14600,6 +14891,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14628,6 +14924,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14927,6 +15228,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15159,6 +15465,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15637,6 +15948,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Cámbiate al buscador que no te rastrea. Nunca."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15749,6 +16067,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15819,6 +16142,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "¡Recupera Tu Privacidad!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16193,9 +16530,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16296,6 +16643,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16554,6 +16915,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16891,9 +17257,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "¡Prueba buscando algo!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16948,6 +17324,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16958,6 +17339,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16982,6 +17368,11 @@ msgstr ""
 msgid "Try our homepage that never shows these messages:"
 msgstr ""
 "Prueba nuestra página de inicio que nunca muestra los siguientes mensajes:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17181,6 +17572,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17480,6 +17876,11 @@ msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr ""
 
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -17774,6 +18175,11 @@ msgstr "Usar en Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Usar en Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18697,6 +19103,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "¿Qué te trajo de vuelto el día de hoy?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19037,6 +19448,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19383,6 +19801,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19493,6 +19917,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19531,6 +19960,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19834,6 +20268,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20308,6 +20749,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/es_PE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_PE/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3683,6 +3715,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3718,6 +3755,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4025,6 +4067,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4079,6 +4126,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4116,6 +4168,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4212,6 +4269,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4246,6 +4308,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4371,6 +4440,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4607,9 +4681,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4637,6 +4721,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4890,6 +4979,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5056,6 +5150,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5231,6 +5330,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5338,6 +5442,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5826,6 +5935,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6065,6 +6179,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6198,6 +6317,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6279,6 +6408,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6610,6 +6744,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7031,6 +7170,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7060,6 +7204,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7077,6 +7231,11 @@ msgstr "Obtener esta canción en:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "¡Anima a tus amigos para ayúdarnos a crecer!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7627,6 +7786,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8927,6 +9091,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8982,6 +9152,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9878,6 +10053,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10272,6 +10452,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10820,6 +11005,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Prendido pero sin números"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10990,6 +11180,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11586,9 +11781,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11603,6 +11808,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11859,6 +12069,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12028,6 +12243,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12470,6 +12690,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12497,6 +12727,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12619,6 +12854,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12921,6 +13161,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restablecer todos los ajustes"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12929,6 +13174,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13486,6 +13736,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13768,6 +14023,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14173,6 +14433,11 @@ msgstr "Fijar como motor de búsqueda predeterminado"
 msgid "Set as Homepage"
 msgstr "Establecer como página de inicio"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14227,6 +14492,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14256,6 +14531,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14304,6 +14585,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14415,6 +14701,11 @@ msgstr "Mostrar datos de ajustes y miniaplicación enlazada"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14539,6 +14830,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14567,6 +14863,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14866,6 +15167,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15098,6 +15404,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15576,6 +15887,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15688,6 +16006,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15757,6 +16080,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16126,9 +16463,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16229,6 +16576,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16487,6 +16848,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16824,9 +17190,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "¡Prueba una búsqueda!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16881,6 +17257,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16891,6 +17272,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16913,6 +17299,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17113,6 +17504,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17401,6 +17797,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17697,6 +18098,11 @@ msgstr ""
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Usar en Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18609,6 +19015,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18948,6 +19359,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19294,6 +19712,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19404,6 +19828,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19438,6 +19867,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19737,6 +20171,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20211,6 +20652,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/es_UY/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_UY/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4015,6 +4057,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4069,6 +4116,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4106,6 +4158,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4202,6 +4259,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4236,6 +4298,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4361,6 +4430,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4597,9 +4671,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4627,6 +4711,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4880,6 +4969,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5046,6 +5140,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5221,6 +5320,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5328,6 +5432,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5816,6 +5925,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6055,6 +6169,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6188,6 +6307,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6269,6 +6398,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6600,6 +6734,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7021,6 +7160,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7050,6 +7194,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7066,6 +7220,11 @@ msgstr "Obtén esta canción en:"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7617,6 +7776,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8914,6 +9078,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8969,6 +9139,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9865,6 +10040,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10259,6 +10439,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10807,6 +10992,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Encendido, sin valor"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10975,6 +11165,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11571,9 +11766,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11588,6 +11793,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11844,6 +12054,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12013,6 +12228,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12455,6 +12675,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12482,6 +12712,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12604,6 +12839,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12906,6 +13146,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12914,6 +13159,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13471,6 +13721,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13751,6 +14006,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14148,6 +14408,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Establecer como página de inicio"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14202,6 +14467,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14231,6 +14506,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14279,6 +14560,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14390,6 +14676,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14514,6 +14805,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14542,6 +14838,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14840,6 +15141,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15072,6 +15378,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15550,6 +15861,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15662,6 +15980,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15731,6 +16054,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16100,9 +16437,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16203,6 +16550,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16459,6 +16820,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16796,9 +17162,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "¡Intenta una búsqueda!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16853,6 +17229,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16863,6 +17244,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16885,6 +17271,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17085,6 +17476,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17369,6 +17765,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17664,6 +18065,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18577,6 +18983,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18916,6 +19327,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19260,6 +19678,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19370,6 +19794,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19404,6 +19833,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19704,6 +20138,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20176,6 +20617,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/es_VE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_VE/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3081,6 +3108,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3679,6 +3711,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3714,6 +3751,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4022,6 +4064,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4076,6 +4123,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4113,6 +4165,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4209,6 +4266,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4243,6 +4305,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4368,6 +4437,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4604,9 +4678,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4634,6 +4718,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4887,6 +4976,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5053,6 +5147,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5228,6 +5327,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5335,6 +5439,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5823,6 +5932,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6062,6 +6176,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6195,6 +6314,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6276,6 +6405,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6609,6 +6743,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7030,6 +7169,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7059,6 +7203,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7075,6 +7229,11 @@ msgstr "Obtén esta canción en:"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7626,6 +7785,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8925,6 +9089,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8980,6 +9150,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9876,6 +10051,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10270,6 +10450,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10818,6 +11003,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activado pero sin números"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10988,6 +11178,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11584,9 +11779,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11601,6 +11806,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11857,6 +12067,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12026,6 +12241,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12468,6 +12688,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12495,6 +12725,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12617,6 +12852,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12919,6 +13159,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Reiniciar todas las configuraciones"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12927,6 +13172,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13484,6 +13734,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13764,6 +14019,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14165,6 +14425,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Establecer como Página de inicio"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14219,6 +14484,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14248,6 +14523,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14296,6 +14577,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14407,6 +14693,11 @@ msgstr "Mostrar marcadores y configurador de datos"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14531,6 +14822,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14559,6 +14855,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14859,6 +15160,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15091,6 +15397,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15569,6 +15880,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15681,6 +15999,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15750,6 +16073,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16119,9 +16456,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16222,6 +16569,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16478,6 +16839,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16815,9 +17181,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "¡Intenta una búsqueda!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16872,6 +17248,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16882,6 +17263,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16904,6 +17290,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17104,6 +17495,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17390,6 +17786,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17686,6 +18087,11 @@ msgstr ""
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Usar en Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18598,6 +19004,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18937,6 +19348,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19283,6 +19701,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19392,6 +19816,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19426,6 +19855,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19726,6 +20160,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20200,6 +20641,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s tuvastatud"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s faili kasutatud"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -364,7 +364,7 @@ msgstr "%1$s kasutatud"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s kasutab piiranguid kuni 2–5 korda kiiremini kui baasmudelid %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -428,8 +428,7 @@ msgstr "%1$s sõna"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
+msgstr "%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -620,7 +619,7 @@ msgstr "1 päev tagasi"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "üks fail kasutatud"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1537,6 +1536,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Täiustatud mudelid võivad kasutada piiranguid 2–5 korda kiiremini kui teised "
+"mudelid. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2332,7 +2333,7 @@ msgstr "Küsi privaatselt"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Küsi privaatselt"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2371,8 +2372,8 @@ msgstr ""
 "mõnedele otsingutele, tuginedes asjakohase veebisisu kokkuvõttele. Saate "
 "valida, kui tihti soovite Assisti kuvada: mitte kunagi (eemaldab "
 "otsingutulemustest täielikult Assisti kasutajaliidese), nõudmisel (AI-toega "
-"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord (AI-"
-"toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
+"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord "
+"(AI-toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
 "sageli (kuvatakse sagedamini laiema otsingute valiku puhul). Praegu on AI "
 "abil genereeritud vastused saadaval ainult USA (ingliskeelses) piirkonnas."
 
@@ -2483,8 +2484,7 @@ msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse lõppu."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
+msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3890,7 +3890,7 @@ msgstr "Vestle privaatselt AI-ga"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Vestle privaatselt populaarsete tehisintellektidega"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4373,9 +4373,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi %1$sDuck."
-"ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab vestlusmudeleid "
-"OpenAI, Anthropic ja teised."
+"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi "
+"%1$sDuck.ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab "
+"vestlusmudeleid OpenAI, Anthropic ja teised."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4434,8 +4434,7 @@ msgstr "Klõpsa %1$sSiia%2$s, et laadida alla DuckDuckGo laiend"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
+msgstr "Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4684,7 +4683,7 @@ msgstr "Sulge"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Sulge"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4734,7 +4733,7 @@ msgstr "Sulge otsing"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Sule teine arvamus"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5111,7 +5110,7 @@ msgstr "Jätka reklaamide blokeerimist"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Jätka hiljutisi vestlusi siin. Või kustuta need Fire Buttoni abil."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5182,7 +5181,7 @@ msgstr "Küpsise andmed:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Kopeeritud"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5235,7 +5234,7 @@ msgstr "Kopeeri kood"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopeeri link"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5354,7 +5353,7 @@ msgstr "Loo pilt"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Loo jagamislink"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5406,6 +5405,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Lingi loomine teeb vestlusest koopia, mida saab vaadata igaüks, kes selle "
+"avab."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5564,7 +5565,7 @@ msgstr "Kohanda vastuseid"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Kohanda vastuseid"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5631,8 +5632,7 @@ msgstr "Päevane piirang on saavutatud"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr "Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5855,7 +5855,7 @@ msgstr "Kas kustutada serveri andmed?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Kustuta jagatud link"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5867,7 +5867,7 @@ msgstr "Kustuta ärakiri"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Kustuta vestlus"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5905,7 +5905,7 @@ msgstr "Kas kustutada pilt?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Kustuta mind"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6034,8 +6034,8 @@ msgstr "Dikteerimine Duck.ai-s"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi AI-"
-"mudelite koolitamiseks."
+"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi "
+"AI-mudelite koolitamiseks."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6221,7 +6221,7 @@ msgstr "Loobu reklaamist"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Loobu tuurist"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6439,7 +6439,7 @@ msgstr "Laadi alla DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Laadi alla DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6660,7 +6660,7 @@ msgstr "Duck.ai by DuckDuckGo. Privaatne AI-vestlus. Tasuta."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai saab nüüd PDF-faile analüüsida. Proovi järele!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6818,7 +6818,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai toetab Anthropicu, OpenAI ja teiste mudeleid."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6894,9 +6894,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
-"põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab vestlusmudeleid "
-"OpenAI, Anthropic ja teisi."
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
+"AI-põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab "
+"vestlusmudeleid OpenAI, Anthropic ja teisi."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6905,8 +6905,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
-"põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
+"AI-põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
 "Anthropicu vestlusmudeleid."
 
 # smartling.placeholder_format=C
@@ -7012,8 +7012,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
+msgstr "DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7464,7 +7463,7 @@ msgstr "Luba enim külastatud saidid"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Luba kohe"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7767,7 +7766,7 @@ msgstr "Meelelahutusjuhend"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Kogu vestlus"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7837,8 +7836,7 @@ msgstr "Laienda kaarti"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
+msgstr "Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7935,13 +7933,13 @@ msgstr "Selged laulusõnad"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Avasta Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Avasta Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8048,7 +8046,7 @@ msgstr "Tasuta"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "TASUTA JA VALIKULINE"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8468,7 +8466,7 @@ msgstr "Vabasta salvestusruumi"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Tasuta ja alati privaatne"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8480,8 +8478,7 @@ msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
+msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8511,8 +8508,7 @@ msgstr "Tasuta jagatavad ja kaubanduslikult kasutatavad"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
+msgstr "Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8990,7 +8986,7 @@ msgstr "Hangi abi arvutilt"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Hangi DuckDuckGo tellimusega kõrgemad kasutuspiirangud."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9033,13 +9029,13 @@ msgstr "Hangi uusim versioon"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Hangi rakendus"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
+msgstr "Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9067,7 +9063,7 @@ msgstr "Soovita oma sõpradel üle minna ja aita meil kasvada!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Alustamise kontrollnimekiri"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9756,7 +9752,7 @@ msgstr "Peida nõuanded"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Peida õpetus"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10053,8 +10049,7 @@ msgstr "Kui tihti soovid, et ilmuksid AI-toega vastused?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
+msgstr "Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10874,8 +10869,7 @@ msgstr "See on kiire, tasuta ja pakub sulle veelgi suuremat võrgukaitset."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
+msgstr "Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11378,7 +11372,7 @@ msgstr "Võimaldab sul DuckDuckGo abil anonüümselt otsida"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11454,7 +11448,7 @@ msgstr "Võidetud lahtimängud"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Link aegub seitsme päeva pärast."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11470,8 +11464,7 @@ msgstr "Lingid:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
+msgstr "Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11762,8 +11755,7 @@ msgstr "Veendu, et kõik sõnad on korrektselt kirjutatud."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
+msgstr "Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12556,7 +12548,7 @@ msgstr "Rohkem kui 20 minutit"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Veel nõuandeid"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13049,7 +13041,7 @@ msgstr "Ei aitäh"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Ei aitäh"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13717,7 +13709,7 @@ msgstr "Sees, aga numbrid puuduvad"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Kasutuselevõtt lõpetatud"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13776,8 +13768,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
+msgstr "Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13934,7 +13925,7 @@ msgstr "Ava piltide loomise ja muutmise soovitused"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Ava alustamise kontrollnimekiri"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14672,8 +14663,7 @@ msgstr "Vali konkreetne probleem"
 #. Header instructing the user to follow the instructions for their ad blocker
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
-msgstr ""
-"Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
+msgstr "Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14685,7 +14675,7 @@ msgstr "Kinnita"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Kinnita vestlus"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14697,7 +14687,7 @@ msgstr "Kinnita vestlused siia %1$s %2$s jaoks"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Kinnita mind"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14720,7 +14710,7 @@ msgstr "Kinnitatud"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Kinnitatud vestlused ilmuvad su hiljutiste vestluste ülaosas."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14769,22 +14759,19 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
+msgstr "Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
+msgstr "Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
+msgstr "Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15043,6 +15030,8 @@ msgstr "Kehv vormindus"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Saadaval on populaarsed tehisintellekti mudelid. Kontot pole vaja. Meie "
+"poolt anonüümistatud vestlused."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15256,7 +15245,7 @@ msgstr "Eelmised vahekaardid"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Eelmised soovitused"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15802,13 +15791,13 @@ msgstr "Keskmise sisseehitatud modereerimisega arutlev AI"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Arutlus võib anda paremaid vastuseid keerulistele küsimustele."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15849,7 +15838,7 @@ msgstr "Hiljutist vestluse salvestust saab kohandada siin %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Hiljutised vestlused"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16010,7 +15999,7 @@ msgstr "Vähenda kasutuspiirangut"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Vähenda kasutusmahtu tõhusama mudeliga"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16393,7 +16382,7 @@ msgstr "Lähtesta kõik seaded"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Lähtesta õpetus"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16411,7 +16400,7 @@ msgstr "Resolutsioon"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Vastus"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16540,8 +16529,7 @@ msgstr "Tulemused ei sisalda blokeeritud saitide teavet."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
+msgstr "Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16612,8 +16600,7 @@ msgstr "Arvustused"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
+msgstr "Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16905,8 +16892,7 @@ msgstr "Salvesta oma seadmesse kuni 30 viimast vestlust."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
+msgstr "Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17083,8 +17069,7 @@ msgstr "Keri alla ja leia loendist %1$soma brauser%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
+msgstr "Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17118,7 +17103,7 @@ msgstr "Kas otsida märksõna „%1$s“, et leida endale lähemal asuvaid vaste
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Otsingu ja Duck.ai lüliti"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17478,8 +17463,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
+msgstr "Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17495,7 +17479,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Turvaliselt salvestatud meie krüptitud serverisse."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17639,8 +17623,7 @@ msgstr "Vali Safari menüüst %1$sSelle veebisaidi seadistamine...%2$s."
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
+msgstr "Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18005,7 +17988,7 @@ msgstr "Määra avaleheks"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Määra Duck.ai vastuste toon ja stiil."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18027,8 +18010,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
+msgstr "Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18077,13 +18059,13 @@ msgstr "Seišellid"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Jaga"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Jaga"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18094,8 +18076,7 @@ msgstr "Jaga"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
+msgstr "Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18122,15 +18103,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. Duck."
-"ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
+"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. "
+"Duck.ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Jaga vestlust"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18194,7 +18175,7 @@ msgstr "Anna positiivset tagasisidet"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Jagamise ulatus"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18335,7 +18316,7 @@ msgstr "Kuva detaile"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Kuva Duck.ai õpetust"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18490,7 +18471,7 @@ msgstr "Näita rohkem"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Näita rohkem mudeleid"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18531,7 +18512,7 @@ msgstr "Näita külgriba"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Kuva samm-sammult näpunäiteid Duck.ai parimaks kasutamiseks."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18906,7 +18887,7 @@ msgstr "Midagi läks valesti, proovi hiljem uuesti."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Midagi läks valesti. Proovi uuesti."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19052,8 +19033,7 @@ msgstr "Algtekst kustutatud"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
+msgstr "Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19205,7 +19185,7 @@ msgstr "Alusta nädalapiirangu kasutamist"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Alusta uut vestlust"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19791,7 +19771,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Mine üle sellele teisele arvamusele"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19954,7 +19934,7 @@ msgstr "Sünkroonimine ja varundamine pole ajutiselt saadaval"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Vestluste sünkroonimine seadmete vahel"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20050,6 +20030,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Võta Duck.ai endaga kõikjale kaasa. Hangi see kiiremaks juurdepääsuks meie "
+"tasuta rakendusse integreeritult, kus iganes viibid."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20058,6 +20040,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Võta Duck.ai endaga kõikjale kaasa. Hangi see meie tasuta brauserisse "
+"sisseehitatuna kiiremaks juurdepääsuks, kus iganes sirvid."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20347,8 +20331,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
+msgstr "Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20498,8 +20481,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
+msgstr "See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20527,7 +20509,7 @@ msgstr "Sel kuul"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "See vastus"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20539,7 +20521,7 @@ msgstr "Sel nädalal"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "See vestlus jääb Duck.ai-sse ja püsib sinu jaoks privaatne."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20676,6 +20658,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"See on lihtsalt näidisvestlus. Ava selle menüü (kolm punkti) ja seejärel "
+"vali „Kinnita”, et see sinu vestluste ülaosas püsiks!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20684,6 +20668,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"See on lihtsalt näidisvestlus. Selle kustutamiseks kasuta külgmenüüs nuppu "
+"Fire Button!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20799,8 +20785,7 @@ msgstr "See tõlge on vale"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
+msgstr "Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20920,8 +20905,7 @@ msgstr "Soovitused"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
+msgstr "Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20979,8 +20963,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "Sünkroonitud andmete taastamiseks vajad taastamiskoodi, mille salvestasid "
-"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud PDF-"
-"vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
+"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud "
+"PDF-vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21022,6 +21006,8 @@ msgstr "Täna"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Lülita sisse, et proovida privaatset AI-vestlust, või %1$skeela see menüüs "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21369,8 +21355,7 @@ msgstr "Proovi %1$s, et selliseid sõnumeid enam ei näeks."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
+msgstr "Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21439,7 +21424,7 @@ msgstr "Proovi neid"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Proovi teist mudelit"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21450,7 +21435,7 @@ msgstr "Proovi otsingut!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Proovi soovitust"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21485,8 +21470,7 @@ msgstr "Proovi teisi märksõnu."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
+msgstr "Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21519,7 +21503,7 @@ msgstr "Proovi tasuta"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Proovi tasuta"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21541,7 +21525,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Proovi tasuta seitse päeva"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21574,7 +21558,7 @@ msgstr "Proovi meie kodulehte, mis ei näita kunagi neid sõnumeid:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Proovi arutlust"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21825,7 +21809,7 @@ msgstr "Sihitud reklaamideta Youtube'i vaatamiseks lülita sisse Duck Player"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Lülita Duck.ai lüliti sisse"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21837,8 +21821,7 @@ msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Täpne asukoht“
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
+msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22030,8 +22013,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: https://"
-"duckduckgo.com"
+"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22196,7 +22179,7 @@ msgstr "Ava oma tellimusega täiustatud tehisintellekt!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Ava edasijõudnutele mõeldud mudelid"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22535,8 +22518,7 @@ msgstr "Kasuta DuckDuckGo privaatset otsingut"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
+msgstr "Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22564,7 +22546,7 @@ msgstr "Kasuta Safaris"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Kasuta nuppu Fire Button vestluse ajaloost kustutamiseks."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23119,8 +23101,7 @@ msgstr "Me ei jälita sind reklaamidega."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
+msgstr "Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23280,8 +23261,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
+msgstr "Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23449,8 +23429,7 @@ msgstr "Nädala kasutuspiirang on saavutatud"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr "Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23753,7 +23732,7 @@ msgstr "Mis sind täna tagasi tõi?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Mida sa saad teha?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24180,6 +24159,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Duck.ai abil on sinu vestlused anonümiseeritud ja neid ei kasutata kunagi "
+"tehisintellekti treenimiseks. Saad selle igal ajal sisse või välja lülitada "
+"„%1$s“ menüüs."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24454,8 +24436,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
+msgstr "Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24495,8 +24476,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka %1$sDuck."
-"ai%2$s."
+"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka "
+"%1$sDuck.ai%2$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -24570,8 +24551,7 @@ msgstr "Saad vestlust jätkata, kasutades oma igakuist piirangut."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
+msgstr "Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24614,7 +24594,7 @@ msgstr "Saad vestlusele lisada ainult %1$s pilti."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Korraga saad lisada ainult %1$s vahekaarti."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24745,8 +24725,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
+msgstr "Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24762,7 +24741,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Kõik on valmis!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24816,7 +24795,7 @@ msgstr "Oled blokeerinud ühe saidi"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Oled selgeks saanud Duck.ai põhitõed"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24836,8 +24815,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
+msgstr "Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24850,8 +24828,7 @@ msgstr "Oled saavutanud ühe seansi maksimaalse häälvestluse kestuse."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
+msgstr "Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24969,8 +24946,7 @@ msgstr "Sinu brauser näitab, kui oled seda linki külastanud"
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
+msgstr "Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -25012,8 +24988,8 @@ msgstr "Sinu vestlused salvestatakse nüüd."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi AI-"
-"mudelite treenimiseks"
+"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi "
+"AI-mudelite treenimiseks"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25227,6 +25203,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Sinu sätted on salvestatud, kuid küpsiste kustutamine lähtestab need. Luba "
+"%1$sDuckDuckGo No AI%2$s laiendus, et muuta see püsivaks."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25827,4 +25805,4 @@ msgstr "a"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "%1$s päeva tagasi"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s tuvastatud"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +361,12 @@ msgid "%s used"
 msgstr "%1$s kasutatud"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s vaatamine"
@@ -416,7 +428,8 @@ msgstr "%1$s sõna"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
+msgstr ""
+"%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -602,6 +615,12 @@ msgstr "DuckDuckGo blokeeris viimase 24 tunni jooksul 1 katse"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 päev tagasi"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1512,6 +1531,14 @@ msgid "Advanced Models"
 msgstr "Täiustatud mudelid"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Reklaami otsingus"
@@ -2302,6 +2329,12 @@ msgid "Ask privately"
 msgstr "Küsi privaatselt"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2338,8 +2371,8 @@ msgstr ""
 "mõnedele otsingutele, tuginedes asjakohase veebisisu kokkuvõttele. Saate "
 "valida, kui tihti soovite Assisti kuvada: mitte kunagi (eemaldab "
 "otsingutulemustest täielikult Assisti kasutajaliidese), nõudmisel (AI-toega "
-"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord "
-"(AI-toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
+"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord (AI-"
+"toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
 "sageli (kuvatakse sagedamini laiema otsingute valiku puhul). Praegu on AI "
 "abil genereeritud vastused saadaval ainult USA (ingliskeelses) piirkonnas."
 
@@ -2450,7 +2483,8 @@ msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse lõppu."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
+msgstr ""
+"Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3853,6 +3887,12 @@ msgid "Chat privately with AI"
 msgstr "Vestle privaatselt AI-ga"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4333,9 +4373,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi "
-"%1$sDuck.ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab "
-"vestlusmudeleid OpenAI, Anthropic ja teised."
+"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi %1$sDuck."
+"ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab vestlusmudeleid "
+"OpenAI, Anthropic ja teised."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4394,7 +4434,8 @@ msgstr "Klõpsa %1$sSiia%2$s, et laadida alla DuckDuckGo laiend"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
+msgstr ""
+"Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4640,6 +4681,12 @@ msgid "Close"
 msgstr "Sulge"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4682,6 +4729,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Sulge otsing"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5055,6 +5108,12 @@ msgid "Continue Blocking Ads"
 msgstr "Jätka reklaamide blokeerimist"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5120,6 +5179,12 @@ msgid "Cookie data:"
 msgstr "Küpsise andmed:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5165,6 +5230,12 @@ msgstr "Kopeeri ja kleebi aadressiribale %1$sabout:preferences # search%2$s"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopeeri kood"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5280,6 +5351,12 @@ msgid "Create Image"
 msgstr "Loo pilt"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5321,6 +5398,14 @@ msgstr "Loonud"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Loodud %1$s poolt"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5476,6 +5561,12 @@ msgid "Customize responses"
 msgstr "Kohanda vastuseid"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "Selle lehe kohandamine"
@@ -5540,7 +5631,8 @@ msgstr "Päevane piirang on saavutatud"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr ""
+"Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5760,10 +5852,22 @@ msgid "Delete Server Data?"
 msgstr "Kas kustutada serveri andmed?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Kustuta ärakiri"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5796,6 +5900,12 @@ msgstr "Kustuta pilt"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Kas kustutada pilt?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5924,8 +6034,8 @@ msgstr "Dikteerimine Duck.ai-s"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi "
-"AI-mudelite koolitamiseks."
+"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi AI-"
+"mudelite koolitamiseks."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6106,6 +6216,12 @@ msgstr "Tühista igaveseks"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Loobu reklaamist"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6318,6 +6434,12 @@ msgstr "Allalaadimine lõpetatud"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Laadi alla DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6535,6 +6657,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai by DuckDuckGo. Privaatne AI-vestlus. Tasuta."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6687,6 +6815,12 @@ msgstr ""
 "kontrollitud."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6760,9 +6894,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
-"AI-põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab "
-"vestlusmudeleid OpenAI, Anthropic ja teisi."
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
+"põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab vestlusmudeleid "
+"OpenAI, Anthropic ja teisi."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6771,8 +6905,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
-"AI-põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
+"põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
 "Anthropicu vestlusmudeleid."
 
 # smartling.placeholder_format=C
@@ -6878,7 +7012,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
+msgstr ""
+"DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7326,6 +7461,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Luba enim külastatud saidid"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7623,6 +7764,12 @@ msgid "Entertainment guide"
 msgstr "Meelelahutusjuhend"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Ekvatoriaal-Guinea"
 
@@ -7690,7 +7837,8 @@ msgstr "Laienda kaarti"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
+msgstr ""
+"Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7782,6 +7930,18 @@ msgstr "Paljastav sisu"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Selged laulusõnad"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7883,6 +8043,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Tasuta"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8299,6 +8465,12 @@ msgid "Free Up Storage"
 msgstr "Vabasta salvestusruumi"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8308,7 +8480,8 @@ msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
+msgstr ""
+"Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8338,7 +8511,8 @@ msgstr "Tasuta jagatavad ja kaubanduslikult kasutatavad"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
+msgstr ""
+"Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8813,6 +8987,12 @@ msgid "Get computer help"
 msgstr "Hangi abi arvutilt"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8850,6 +9030,18 @@ msgid "Get the Latest Version"
 msgstr "Hangi uusim versioon"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8870,6 +9062,12 @@ msgstr "Hangi see lugu siit:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Soovita oma sõpradel üle minna ja aita meil kasvada!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9555,6 +9753,12 @@ msgid "Hide Tips"
 msgstr "Peida nõuanded"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9849,7 +10053,8 @@ msgstr "Kui tihti soovid, et ilmuksid AI-toega vastused?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
+msgstr ""
+"Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10669,7 +10874,8 @@ msgstr "See on kiire, tasuta ja pakub sulle veelgi suuremat võrgukaitset."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
+msgstr ""
+"Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11168,6 +11374,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Võimaldab sul DuckDuckGo abil anonüümselt otsida"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Libeeria"
 
@@ -11238,6 +11451,12 @@ msgid "Lineouts Won"
 msgstr "Võidetud lahtimängud"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Lingi font:"
@@ -11251,7 +11470,8 @@ msgstr "Lingid:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
+msgstr ""
+"Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11542,7 +11762,8 @@ msgstr "Veendu, et kõik sõnad on korrektselt kirjutatud."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
+msgstr ""
+"Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12332,6 +12553,12 @@ msgid "More than 20 minutes"
 msgstr "Rohkem kui 20 minutit"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12817,6 +13044,12 @@ msgstr "Ei aitäh"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Ei aitäh"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13481,6 +13714,12 @@ msgid "On but no numbers"
 msgstr "Sees, aga numbrid puuduvad"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13537,7 +13776,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
+msgstr ""
+"Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13689,6 +13929,12 @@ msgstr "Ava vestluse soovitused"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Ava piltide loomise ja muutmise soovitused"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14426,7 +14672,8 @@ msgstr "Vali konkreetne probleem"
 #. Header instructing the user to follow the instructions for their ad blocker
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
-msgstr "Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
+msgstr ""
+"Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14435,10 +14682,22 @@ msgid "Pin"
 msgstr "Kinnita"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Kinnita vestlused siia %1$s %2$s jaoks"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14456,6 +14715,12 @@ msgstr "Roosa"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Kinnitatud"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14504,19 +14769,22 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
+msgstr ""
+"Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
+msgstr ""
+"Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
+msgstr ""
+"Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14771,6 +15039,12 @@ msgid "Poor formatting"
 msgstr "Kehv vormindus"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14977,6 +15251,12 @@ msgstr "Eelmine pilt"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Eelmised vahekaardid"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15519,6 +15799,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Keskmise sisseehitatud modereerimisega arutlev AI"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15552,6 +15844,12 @@ msgstr "Hiljutised vahelehed"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Hiljutist vestluse salvestust saab kohandada siin %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15707,6 +16005,12 @@ msgstr "Otsi uuesti ilma selle saidita"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Vähenda kasutuspiirangut"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16086,6 +16390,12 @@ msgid "Reset All Settings"
 msgstr "Lähtesta kõik seaded"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16096,6 +16406,12 @@ msgstr "Lähtestatakse %1$s pärast"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Resolutsioon"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16224,7 +16540,8 @@ msgstr "Tulemused ei sisalda blokeeritud saitide teavet."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
+msgstr ""
+"Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16295,7 +16612,8 @@ msgstr "Arvustused"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
+msgstr ""
+"Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16587,7 +16905,8 @@ msgstr "Salvesta oma seadmesse kuni 30 viimast vestlust."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
+msgstr ""
+"Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16764,7 +17083,8 @@ msgstr "Keri alla ja leia loendist %1$soma brauser%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
+msgstr ""
+"Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16793,6 +17113,12 @@ msgstr "Otsing"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Kas otsida märksõna „%1$s“, et leida endale lähemal asuvaid vasteid?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17152,7 +17478,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
+msgstr ""
+"Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17163,6 +17490,12 @@ msgid ""
 msgstr ""
 "Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega. "
 "Keegi peale sinu ei näe sinu andmeid, isegi mitte meie."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17306,7 +17639,8 @@ msgstr "Vali Safari menüüst %1$sSelle veebisaidi seadistamine...%2$s."
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
+msgstr ""
+"Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17668,6 +18002,12 @@ msgid "Set as Homepage"
 msgstr "Määra avaleheks"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17687,7 +18027,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
+msgstr ""
+"Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17733,6 +18074,18 @@ msgid "Seychelles"
 msgstr "Seišellid"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17741,7 +18094,8 @@ msgstr "Jaga"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
+msgstr ""
+"Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17768,8 +18122,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. "
-"Duck.ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
+"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. Duck."
+"ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17828,6 +18189,12 @@ msgstr "Jaga lehekülje URL-i"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Anna positiivset tagasisidet"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17963,6 +18330,12 @@ msgstr "Kuva bookmarkleti ja seadete andmed"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Kuva detaile"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18114,6 +18487,12 @@ msgid "Show more"
 msgstr "Näita rohkem"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18147,6 +18526,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Näita külgriba"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18518,6 +18903,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Midagi läks valesti, proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18661,7 +19052,8 @@ msgstr "Algtekst kustutatud"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
+msgstr ""
+"Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18808,6 +19200,12 @@ msgstr "Alusta igakuise piirangu kasutamist"
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "Alusta nädalapiirangu kasutamist"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19388,6 +19786,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Lülitu otsingumootorile, mis ei jälita sind. Kunagi."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19545,6 +19951,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sünkroonimine ja varundamine pole ajutiselt saadaval"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19630,6 +20042,22 @@ msgstr "Tadžikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Võta tagasi oma privaatsus!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19919,7 +20347,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
+msgstr ""
+"Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20069,7 +20498,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
+msgstr ""
+"See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20094,10 +20524,22 @@ msgid "This Month"
 msgstr "Sel kuul"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Sel nädalal"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20228,6 +20670,22 @@ msgid "This information isn’t useful"
 msgstr "See teave pole kasulik"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20341,7 +20799,8 @@ msgstr "See tõlge on vale"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
+msgstr ""
+"Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20461,7 +20920,8 @@ msgstr "Soovitused"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
+msgstr ""
+"Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20519,8 +20979,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "Sünkroonitud andmete taastamiseks vajad taastamiskoodi, mille salvestasid "
-"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud "
-"PDF-vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
+"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud PDF-"
+"vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20556,6 +21016,12 @@ msgstr "Täna"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Täna"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20903,7 +21369,8 @@ msgstr "Proovi %1$s, et selliseid sõnumeid enam ei näeks."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
+msgstr ""
+"Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -20969,9 +21436,21 @@ msgid "Try Them Out"
 msgstr "Proovi neid"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Proovi otsingut!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21006,7 +21485,8 @@ msgstr "Proovi teisi märksõnu."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
+msgstr ""
+"Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21036,6 +21516,12 @@ msgid "Try for free"
 msgstr "Proovi tasuta"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21050,6 +21536,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Proovi tasuta! Turvaline VPN, täiustatud ja privaatne tehisintellekt ning "
 "palju muud."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21077,6 +21569,12 @@ msgstr "Proovi meie brauserit,"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Proovi meie kodulehte, mis ei näita kunagi neid sõnumeid:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21324,6 +21822,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Sihitud reklaamideta Youtube'i vaatamiseks lülita sisse Duck Player"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21333,7 +21837,8 @@ msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Täpne asukoht“
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
+msgstr ""
+"Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21525,8 +22030,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: "
-"https://duckduckgo.com"
+"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21686,6 +22191,12 @@ msgstr "Lukusta lahti täiustatud AI mudelid DuckDuckGo tellimusega"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Ava oma tellimusega täiustatud tehisintellekt!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22024,7 +22535,8 @@ msgstr "Kasuta DuckDuckGo privaatset otsingut"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
+msgstr ""
+"Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22047,6 +22559,12 @@ msgstr "Kasuta Firefoxis"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Kasuta Safaris"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22601,7 +23119,8 @@ msgstr "Me ei jälita sind reklaamidega."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
+msgstr ""
+"Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22761,7 +23280,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
+msgstr ""
+"Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22929,7 +23449,8 @@ msgstr "Nädala kasutuspiirang on saavutatud"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr ""
+"Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23227,6 +23748,12 @@ msgstr "Mis häiris sind kõige rohkem?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Mis sind täna tagasi tõi?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23647,6 +24174,14 @@ msgid "Wintry Mix"
 msgstr "Talvine segailm"
 
 # smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -23919,7 +24454,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
+msgstr ""
+"Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23959,8 +24495,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka "
-"%1$sDuck.ai%2$s."
+"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka %1$sDuck."
+"ai%2$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -24034,7 +24570,8 @@ msgstr "Saad vestlust jätkata, kasutades oma igakuist piirangut."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
+msgstr ""
+"Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24071,6 +24608,13 @@ msgstr "Saad vestluse kohta lisada ainult %1$s pilti"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Saad vestlusele lisada ainult %1$s pilti."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24201,7 +24745,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
+msgstr ""
+"Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24212,6 +24757,12 @@ msgid ""
 msgstr ""
 "Kui sul on uusim versioon, saad automaatselt DuckDuckGo rakenduse "
 "värskendused."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24262,6 +24813,12 @@ msgid "You've blocked 1 site"
 msgstr "Oled blokeerinud ühe saidi"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24279,7 +24836,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
+msgstr ""
+"Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24292,7 +24850,8 @@ msgstr "Oled saavutanud ühe seansi maksimaalse häälvestluse kestuse."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
+msgstr ""
+"Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24410,7 +24969,8 @@ msgstr "Sinu brauser näitab, kui oled seda linki külastanud"
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
+msgstr ""
+"Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -24452,8 +25012,8 @@ msgstr "Sinu vestlused salvestatakse nüüd."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi "
-"AI-mudelite treenimiseks"
+"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi AI-"
+"mudelite treenimiseks"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24659,6 +25219,14 @@ msgstr "Sinu roll"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Sinu otsinguid ei saa sinuga siduda"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25254,3 +25822,9 @@ msgstr "aastat"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "a"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/eu_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/eu_ES/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4015,6 +4057,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4069,6 +4116,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4106,6 +4158,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4202,6 +4259,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4236,6 +4298,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4361,6 +4430,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4597,9 +4671,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4627,6 +4711,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4880,6 +4969,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5046,6 +5140,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5221,6 +5320,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5328,6 +5432,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5816,6 +5925,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6055,6 +6169,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6188,6 +6307,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6269,6 +6398,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6600,6 +6734,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7021,6 +7160,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7050,6 +7194,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7066,6 +7220,11 @@ msgstr "Lortu abesti hau hemen:"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7617,6 +7776,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8914,6 +9078,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8969,6 +9139,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9865,6 +10040,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10259,6 +10439,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10807,6 +10992,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Aktibatuta baino zenbakirik ez"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10975,6 +11165,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11571,9 +11766,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11588,6 +11793,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11844,6 +12054,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12013,6 +12228,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12455,6 +12675,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12482,6 +12712,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12604,6 +12839,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12906,6 +13146,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Berrezarri ezarpen guztiak"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12914,6 +13159,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13471,6 +13721,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13753,6 +14008,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14150,6 +14410,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Ezarri Etxeko-orrialde bezala"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14202,6 +14467,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14231,6 +14506,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14279,6 +14560,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14390,6 +14676,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14514,6 +14805,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14542,6 +14838,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14840,6 +15141,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15072,6 +15378,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15550,6 +15861,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15662,6 +15980,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15731,6 +16054,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16100,9 +16437,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16203,6 +16550,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16459,6 +16820,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16796,9 +17162,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Probatu bilaketa bat!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16852,6 +17228,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16862,6 +17243,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16884,6 +17270,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17084,6 +17475,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17368,6 +17764,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17663,6 +18064,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18576,6 +18982,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18915,6 +19326,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19261,6 +19679,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19370,6 +19794,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19404,6 +19833,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19704,6 +20138,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20178,6 +20619,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/fa_IR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fa_IR/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -486,6 +496,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "۱ روز پیش"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1231,6 +1246,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1858,6 +1880,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3094,6 +3121,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3701,6 +3733,11 @@ msgstr "کلیپ آرت"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3736,6 +3773,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4043,6 +4085,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4097,6 +4144,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4134,6 +4186,11 @@ msgstr "‫عبارت %sabout:preferences#search%s را در آدرس بار ک�
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4230,6 +4287,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4264,6 +4326,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4389,6 +4458,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4625,9 +4699,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4655,6 +4739,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4908,6 +4997,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5076,6 +5170,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5251,6 +5350,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5358,6 +5462,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5858,6 +5967,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6101,6 +6215,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6234,6 +6353,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6315,6 +6444,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6650,6 +6784,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7071,6 +7210,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7100,6 +7244,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7117,6 +7271,11 @@ msgstr "این ترانه را از این‌جا بگیرید:‏"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "دوستانتان را ترغیب کنید و به رشد ما کمک نمایید!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7673,6 +7832,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8989,6 +9153,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9044,6 +9214,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9942,6 +10117,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "بیش از ۲۰ دقیقه"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10338,6 +10518,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10888,6 +11073,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "روشن ولی بدون شماره"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11058,6 +11248,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11658,9 +11853,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11675,6 +11880,11 @@ msgstr "صورتی"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11931,6 +12141,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12100,6 +12315,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12542,6 +12762,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12569,6 +12799,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12691,6 +12926,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12994,6 +13234,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "همه تنظیمات را به حالت اولیه بازگردان"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -13002,6 +13247,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13561,6 +13811,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "بی‌نام جستجو کنید"
 
@@ -13845,6 +14100,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14257,6 +14517,11 @@ msgstr "قرار دادن چون موتور جستجوی پیش فرض"
 msgid "Set as Homepage"
 msgstr "قرار دادن چون صفحه نخست"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14309,6 +14574,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14342,6 +14617,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14390,6 +14671,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14501,6 +14787,11 @@ msgstr "بوکمارکلِت و داده‌های تنظیمات را نشان �
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14625,6 +14916,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14653,6 +14949,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14951,6 +15252,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15185,6 +15491,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15665,6 +15976,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "از موتور جستجویی استفاده کنید که هیچ وقت رد شما را نمی‌گیرد."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15777,6 +16095,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15847,6 +16170,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "حریم شخصی خود را بازگردانید!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16221,9 +16558,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16324,6 +16671,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16580,6 +16941,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16917,9 +17283,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "جستجویی بکنید!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16973,6 +17349,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16983,6 +17364,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -17006,6 +17392,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "صفحه نخست ما را امتحان کنید که هیچگاه از این پیامها نشان نمی‌دهد:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17207,6 +17598,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17498,6 +17894,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17798,6 +18199,11 @@ msgstr "در فایرفاکس بکار ببرید"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "استفاده در سافاری"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18720,6 +19126,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "چه شما را دوباره به اینجا آورد؟"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19061,6 +19472,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19407,6 +19825,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19516,6 +19940,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19552,6 +19981,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19854,6 +20288,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20327,6 +20768,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/fi_FI/LC_MESSAGES/duckduckgo.po
+++ b/locales/fi_FI/LC_MESSAGES/duckduckgo.po
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr "%1$s tunnistettu"
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -352,6 +358,12 @@ msgstr "%1$s seurantayritystä estetty"
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
 msgstr "%1$s käytetty"
+
+# smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -601,6 +613,12 @@ msgstr "DuckDuckGo on estänyt 1 yrityksen viimeisten 24 tunnin aikana"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 päivä sitten"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1511,6 +1529,14 @@ msgid "Advanced Models"
 msgstr "Edistyneet mallit"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Mainosta haussa"
@@ -2291,6 +2317,12 @@ msgstr "Kysy yksityisesti"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask privately"
 msgstr "Kysy yksityisesti"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -3844,6 +3876,12 @@ msgid "Chat privately with AI"
 msgstr "Keskustele yksityisesti tekoälyn kanssa"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4632,6 +4670,12 @@ msgid "Close"
 msgstr "Sulje"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4674,6 +4718,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Sulje haku"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5047,6 +5097,12 @@ msgid "Continue Blocking Ads"
 msgstr "Jatka mainosten estämistä"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5112,6 +5168,12 @@ msgid "Cookie data:"
 msgstr "Evästetiedot:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5157,6 +5219,12 @@ msgstr "Kopioi ja liitä %1$sabout:preferences#search%2$s osoitepalkkiin"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopioi koodi"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5272,6 +5340,12 @@ msgid "Create Image"
 msgstr "Luo kuva"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5313,6 +5387,14 @@ msgstr "Tekijä"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Luotu: %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5466,6 +5548,12 @@ msgstr "Mukauta vastauksia"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Mukauta vastauksia"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5754,10 +5842,22 @@ msgid "Delete Server Data?"
 msgstr "Poistetaanko palvelimen tiedot?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Poista transkriptio"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5790,6 +5890,12 @@ msgstr "Poista kuva"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Poistetaanko kuva?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6104,6 +6210,12 @@ msgid "Dismiss promotion"
 msgstr "Kampanjan hylkääminen"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6308,6 +6420,12 @@ msgstr "Lataus valmis"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Lataa DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6526,6 +6644,12 @@ msgstr ""
 "DuckDuckGo:n kehittämä Duck.ai. Yksityinen tekoälykeskustelu. Ilmainen."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6673,6 +6797,12 @@ msgid ""
 msgstr ""
 "Duck.ai-vastaukset eivät perustu tiettyihin lähteisiin eikä niiden "
 "paikkansapitävyyttä ole tarkistettu."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7317,6 +7447,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Ota suosituimmat sivut käyttöön"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7615,6 +7751,12 @@ msgid "Entertainment guide"
 msgstr "Viihdeopas"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Päiväntasaajan Guinea"
 
@@ -7778,6 +7920,18 @@ msgid "Explicit lyrics"
 msgstr "Selkeät sanoitukset"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7877,6 +8031,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Ilmainen"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8287,6 +8447,12 @@ msgstr "Ilmainen tilaus"
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
 msgstr "Vapauta tallennustilaa"
+
+# smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8808,6 +8974,12 @@ msgid "Get computer help"
 msgstr "Hanki tietokoneisiin liittyvää apua"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8845,6 +9017,18 @@ msgid "Get the Latest Version"
 msgstr "Hanki uusin versio"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8865,6 +9049,12 @@ msgstr "Hanki kappale täältä:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Kerro kavereillesi ja auta meitä kasvamaan!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9537,6 +9727,12 @@ msgstr "Piilota vaiheet"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Piilota vinkit"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -11157,6 +11353,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Antaa sinun tehdä anonyymeja hakuja DuckDuckGossa"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11225,6 +11428,12 @@ msgstr "Viivapiirros"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Voitettujen linjapallojen määrä"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12322,6 +12531,12 @@ msgid "More than 20 minutes"
 msgstr "Enemmän kuin 20 minuuttia"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12808,6 +13023,12 @@ msgstr "Ei kiitos"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Ei kiitos"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13472,6 +13693,12 @@ msgid "On but no numbers"
 msgstr "Päällä, ei numeroita"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13679,6 +13906,12 @@ msgstr "Avaa keskusteluehdotukset"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Avaa kuvien luonti- ja muokkausehdotukset"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14428,10 +14661,22 @@ msgid "Pin"
 msgstr "Kiinnitä"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Kiinnitä keskustelut tänne kohdasta %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14449,6 +14694,12 @@ msgstr "Pinkki"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Kiinnitetty"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14764,6 +15015,12 @@ msgid "Poor formatting"
 msgstr "Huono muotoilu"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14970,6 +15227,12 @@ msgstr "Edellinen kuva"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Edelliset välilehdet"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15512,6 +15775,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Päättelevä tekoäly keskitasoisella integroidulla moderoinnilla"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15545,6 +15820,12 @@ msgstr "Viimeisimmät välilehdet"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Viimeaikaisen keskustelun tallennusta voi muuttaa kohdassa %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15700,6 +15981,12 @@ msgstr "Tee haku uudelleen ilman tätä sivustoa"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Vähennä käyttöä"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16080,6 +16367,12 @@ msgid "Reset All Settings"
 msgstr "Palauta kaikki asetukset"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16090,6 +16383,12 @@ msgstr "Nollautuu %1$s kuluttua"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Resoluutio"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16793,6 +17092,12 @@ msgid "Search %s to find results closer to you?"
 msgstr "Etsi haulla %1$s löytääksesi tuloksia lähempää sinua?"
 
 # smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Search Anonymously"
 msgstr "Etsi anonyymisti"
 
@@ -17167,6 +17472,12 @@ msgid ""
 msgstr ""
 "Tallennettu turvallisesti DuckDuckGon palvelimelle päästä päähän -"
 "salauksella. Kukaan muu kuin sinä ei voi nähdä tietojasi, emme edes me."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17674,6 +17985,12 @@ msgid "Set as Homepage"
 msgstr "Aseta kotisivuksi"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17741,6 +18058,18 @@ msgid "Seychelles"
 msgstr "Seychellit"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17780,6 +18109,13 @@ msgid ""
 msgstr ""
 "Jaa kaupunkitason sijainti tekoälymalleille parantaaksesi osuvuutta. Duck.ai "
 "ei koskaan paljasta tarkkaa sijaintiasi meille tai tekoälymalleille."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17838,6 +18174,12 @@ msgstr "Jaa sivun URL"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Anna positiivista palautetta"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17973,6 +18315,12 @@ msgstr "Näytä kirjanmerkit ja tallennetut asetukset"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Näytä tiedot"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18123,6 +18471,12 @@ msgid "Show more"
 msgstr "Näytä lisää"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18156,6 +18510,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Näytä sivupalkki"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18531,6 +18891,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Jokin meni pieleen, yritä myöhemmin uudelleen."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18823,6 +19189,12 @@ msgstr "Aloita kuukausirajan käyttö"
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "Aloita viikkorajoituksen käyttö"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19403,6 +19775,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Siirry hakukoneeseen, joka ei seuraa sinua. Koskaan."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19559,6 +19939,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Synkronointi ja varmuuskopiointi on tilapäisesti poissa käytöstä"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19644,6 +20030,22 @@ msgstr "Tadžikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Ota yksityisyytesi takaisin!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20114,10 +20516,22 @@ msgid "This Month"
 msgstr "Tämä kuukausi"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Tämä viikko"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20248,6 +20662,22 @@ msgstr "Kuvatyyppiä ei tueta. Liitä JPG-, PNG-, WebP- tai GIF-tiedosto."
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Nämä tiedot eivät ole hyödyllisiä"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20585,6 +21015,12 @@ msgstr "Tänään"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Tänään"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21000,9 +21436,21 @@ msgid "Try Them Out"
 msgstr "Kokeile niitä"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Kokeile hakua!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21068,6 +21516,12 @@ msgid "Try for free"
 msgstr "Ilmaiskokeilu"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21082,6 +21536,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Kokeile ilmaiseksi! Turvallinen VPN, edistynyt ja yksityinen tekoäly ja "
 "paljon muuta."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21110,6 +21570,12 @@ msgstr "Kokeile selaintamme,"
 msgid "Try our homepage that never shows these messages:"
 msgstr ""
 "Kokeile seuraavaa etusivuamme, joka ei koskaan vaivaa näillä viesteillä:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21354,6 +21820,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr ""
 "Ota Duck Player käyttöön, niin voit katsoa YouTubea ilman kohdennettuja "
 "mainoksia."
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21730,6 +22202,12 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "Avaa edistynyt tekoäly tilauksellasi!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -22090,6 +22568,12 @@ msgstr "Käytä Firefoxissa"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Käytä Safarissa"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23264,6 +23748,12 @@ msgid "What brought you back today?"
 msgstr "Mikä toi sinut takaisin tänään?"
 
 # smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -23677,6 +24167,14 @@ msgstr "Voitot"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Talvinen sää"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24107,6 +24605,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Voit liittää vain %1$s kuvaa keskustelua kohti."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24248,6 +24753,12 @@ msgstr ""
 "versio."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24294,6 +24805,12 @@ msgstr "Olet estänyt %1$s sivustoa"
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "Olet estänyt 1 sivuston"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24695,6 +25212,14 @@ msgstr "Roolisi"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Hakujasi ei voida yhdistää sinuun"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25282,3 +25807,9 @@ msgstr "vuotta"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "v"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/fr_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_BE/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3689,6 +3721,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3724,6 +3761,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4031,6 +4073,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4085,6 +4132,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4122,6 +4174,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4218,6 +4275,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4252,6 +4314,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4377,6 +4446,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4613,9 +4687,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4643,6 +4727,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4896,6 +4985,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5062,6 +5156,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5237,6 +5336,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5344,6 +5448,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5834,6 +5943,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6075,6 +6189,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6208,6 +6327,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6289,6 +6418,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6620,6 +6754,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7041,6 +7180,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7070,6 +7214,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7087,6 +7241,11 @@ msgstr "Obtenir cette chanson de :"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Invitez vos amis à faire le saut et aidez-nous à croître !"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7637,6 +7796,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8942,6 +9106,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8997,6 +9167,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9895,6 +10070,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Plus de 20 minutes"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10289,6 +10469,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10841,6 +11026,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activé mais sans numérotation"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11011,6 +11201,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11611,9 +11806,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11628,6 +11833,11 @@ msgstr "Rose"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11884,6 +12094,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12053,6 +12268,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12495,6 +12715,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12522,6 +12752,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12644,6 +12879,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12947,6 +13187,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restaurer tous les paramètres"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12955,6 +13200,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13515,6 +13765,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Rechercher anonymement"
 
@@ -13797,6 +14052,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14209,6 +14469,11 @@ msgstr "Choisir comme moteur de recherche par défaut"
 msgid "Set as Homepage"
 msgstr "Définir comme page d'accueil"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14261,6 +14526,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14292,6 +14567,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14340,6 +14621,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14451,6 +14737,11 @@ msgstr "Affichez les favoris et les données de configuration"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14575,6 +14866,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14603,6 +14899,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14903,6 +15204,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15135,6 +15441,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15613,6 +15924,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Passez au moteur de recherche qui ne vous piste pas.Jamais."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15725,6 +16043,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15795,6 +16118,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Récupérez votre vie privée ! "
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16163,9 +16500,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16266,6 +16613,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16523,6 +16884,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16860,9 +17226,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Tentez une recherche !"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16916,6 +17292,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16926,6 +17307,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16949,6 +17335,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Essayez notre page d'accueil qui n'affiche jamais ces messages :"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17148,6 +17539,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17441,6 +17837,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17739,6 +18140,11 @@ msgstr "Utiliser dans Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Utilisation dans Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18660,6 +19066,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Qu'est ce qui vous a fait revenir aujourd'hui ?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18999,6 +19410,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19345,6 +19763,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19457,6 +19881,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19493,6 +19922,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19795,6 +20229,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20269,6 +20710,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/fr_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CA/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -483,6 +493,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1223,6 +1238,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1848,6 +1870,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3082,6 +3109,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3693,6 +3725,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3728,6 +3765,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4035,6 +4077,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4089,6 +4136,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4126,6 +4178,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4222,6 +4279,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4256,6 +4318,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4381,6 +4450,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4617,9 +4691,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4647,6 +4731,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4900,6 +4989,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5066,6 +5160,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5241,6 +5340,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5348,6 +5452,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5836,6 +5945,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6076,6 +6190,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6209,6 +6328,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6290,6 +6419,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6621,6 +6755,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7042,6 +7181,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7071,6 +7215,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7088,6 +7242,11 @@ msgstr "Obtenez cette chanson sur :"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Passez le mot à vos amis et aidez-nous à prendre de l'expansion!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7638,6 +7797,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8945,6 +9109,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9000,6 +9170,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9900,6 +10075,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Plus de 20 minutes"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10294,6 +10474,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10844,6 +11029,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activé sans nombre"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11014,6 +11204,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11614,9 +11809,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11631,6 +11836,11 @@ msgstr "Rose"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11887,6 +12097,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12056,6 +12271,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12498,6 +12718,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12525,6 +12755,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12647,6 +12882,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12950,6 +13190,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Réinitialise tous les paramètres"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12958,6 +13203,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13517,6 +13767,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Rechercher de façon anonyme"
 
@@ -13799,6 +14054,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14208,6 +14468,11 @@ msgstr "Définir en tant que moteur de recherche par défaut"
 msgid "Set as Homepage"
 msgstr "Utiliser comme page d'accueil"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14262,6 +14527,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14293,6 +14568,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14341,6 +14622,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14452,6 +14738,11 @@ msgstr "Afficher le Bookmarklet et les données de paramétrage"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14576,6 +14867,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14604,6 +14900,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14902,6 +15203,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15134,6 +15440,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15612,6 +15923,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Optez pour le moteur de recherche qui ne vous suit pas. Ni jamais."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15724,6 +16042,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15794,6 +16117,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Reprenez le contrôle sur votre vie privée !"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16162,9 +16499,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16265,6 +16612,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16523,6 +16884,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16860,9 +17226,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Essayez une recherche !"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16917,6 +17293,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16927,6 +17308,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16950,6 +17336,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Essayez notre page d'accueil qui n'affiche jamais ces messages :"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17149,6 +17540,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17443,6 +17839,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17741,6 +18142,11 @@ msgstr "Ouvrir dans Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Utilisez dans Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18665,6 +19071,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Qu'est-ce qui vous a fait revenir aujourd'hui?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19005,6 +19416,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19351,6 +19769,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19461,6 +19885,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19500,6 +19929,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19804,6 +20238,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20278,6 +20719,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/fr_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CH/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3688,6 +3720,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3723,6 +3760,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4031,6 +4073,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4085,6 +4132,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4122,6 +4174,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4218,6 +4275,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4252,6 +4314,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4377,6 +4446,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4613,9 +4687,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4643,6 +4727,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4896,6 +4985,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5062,6 +5156,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5237,6 +5336,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5344,6 +5448,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5832,6 +5941,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6072,6 +6186,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6205,6 +6324,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6286,6 +6415,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6618,6 +6752,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7039,6 +7178,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7068,6 +7212,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7085,6 +7239,11 @@ msgstr "Obtenir cette chanson sur :"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Faites passer vos amis chez nous et aidez nous à grandir"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7635,6 +7794,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8937,6 +9101,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8992,6 +9162,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9891,6 +10066,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10285,6 +10465,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10835,6 +11020,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activé mais sans numérotation"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11005,6 +11195,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11605,9 +11800,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11622,6 +11827,11 @@ msgstr "Rose"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11878,6 +12088,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12047,6 +12262,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12489,6 +12709,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12516,6 +12746,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12638,6 +12873,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12941,6 +13181,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Réinitialiser tous les réglages"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12949,6 +13194,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13508,6 +13758,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13790,6 +14045,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14200,6 +14460,11 @@ msgstr "Définir comme moteur de recherche par défaut"
 msgid "Set as Homepage"
 msgstr "Définir comme page d'accueil"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14254,6 +14519,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14283,6 +14558,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14331,6 +14612,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14442,6 +14728,11 @@ msgstr "Afficher les favoris et les données des paramètres"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14566,6 +14857,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14594,6 +14890,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14894,6 +15195,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15126,6 +15432,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15604,6 +15915,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15716,6 +16034,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15786,6 +16109,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Reprenez le contrôle de votre vie privée !"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16154,9 +16491,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16257,6 +16604,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16515,6 +16876,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16852,9 +17218,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Essayez une recherche!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16909,6 +17285,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16919,6 +17300,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16942,6 +17328,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Essayez notre page d'accueil qui ne montre jamais ces messages:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17141,6 +17532,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17434,6 +17830,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17730,6 +18131,11 @@ msgstr "Utiliser sur Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Utiliser dans Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18646,6 +19052,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18986,6 +19397,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19332,6 +19750,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19444,6 +19868,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19478,6 +19907,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19777,6 +20211,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20251,6 +20692,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "Il y a %1$s jours"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s détecté"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -353,6 +359,12 @@ msgstr "%1$s tentatives de pistage bloquées"
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
 msgstr "%1$s utilisés"
+
+# smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -606,6 +618,12 @@ msgstr "1 tentative bloquée par DuckDuckGo ces dernières 24 heures"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Il y a 1 jour"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -957,8 +975,8 @@ msgstr ""
 "AI Chat vous permet d'avoir des conversations anonymes avec des modèles de "
 "chat IA tiers. La désactivation de cette option masquera la fonctionnalité "
 "AI Chat sur DuckDuckGo Search. Vous pouvez toujours accéder à l'AI Chat "
-"lorsque ce paramètre est désactivé en consultant "
-"%1$sduckduckgo.com/aichat%2$s."
+"lorsque ce paramètre est désactivé en consultant %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1375,7 +1393,8 @@ msgstr "Ajouter un champ de recherche %1$s à votre site !"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr "Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
+msgstr ""
+"Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1520,6 +1539,14 @@ msgctxt ""
 "app variant)"
 msgid "Advanced Models"
 msgstr "Modèles avancés"
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2153,7 +2180,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
+msgstr ""
+"Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2320,6 +2348,12 @@ msgid "Ask privately"
 msgstr "Demander en privé"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2459,18 +2493,21 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2772,8 +2809,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Avant de stocker ce rapport, DuckDuckGo anonymisera votre conversation en "
-"supprimant les données à caractère personnel comme les noms, les adresses "
-"e-mail et les métadonnées d'identification."
+"supprimant les données à caractère personnel comme les noms, les adresses e-"
+"mail et les métadonnées d'identification."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2899,7 +2936,8 @@ msgstr "Bloquez les traqueurs d'e-mails et masquez votre adresse."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
+msgstr ""
+"La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2915,7 +2953,8 @@ msgstr "Bloquer ce site dans tous les résultats"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
+msgstr ""
+"Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3263,7 +3302,8 @@ msgstr "En cliquant sur « %1$s », vous acceptez nos %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
+msgstr ""
+"En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3648,7 +3688,8 @@ msgstr "Change l'affichage de l'URL des résultats"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
+msgstr ""
+"Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3886,6 +3927,12 @@ msgid "Chat privately with AI"
 msgstr "Discuter en privé avec l'IA"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4116,7 +4163,8 @@ msgstr "Choix de modèles d'IA, y compris %1$s et %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
+msgstr ""
+"Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4474,7 +4522,8 @@ msgstr "Cliquez sur %1$sParamètres%2$s dans le menu déroulant."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
+msgstr ""
+"Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4697,6 +4746,12 @@ msgid "Close"
 msgstr "Fermer"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4739,6 +4794,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Fermer la recherche"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5112,6 +5173,12 @@ msgid "Continue Blocking Ads"
 msgstr "Continuer à bloquer les publicités"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5177,6 +5244,12 @@ msgid "Cookie data:"
 msgstr "Données du cookie :"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5222,6 +5295,12 @@ msgstr "Copier/Coller %1$sabout:preferences#search%2$s dans la barre d'adresse"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Copier le code"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5339,6 +5418,12 @@ msgid "Create Image"
 msgstr "Créer une image"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5380,6 +5465,14 @@ msgstr "Créé par"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Créé par %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5533,6 +5626,12 @@ msgstr "Personnaliser les réponses"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Personnaliser les réponses"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5821,10 +5920,22 @@ msgid "Delete Server Data?"
 msgstr "Supprimer les données du serveur ?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Supprimer la transcription"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5857,6 +5968,12 @@ msgstr "Supprimer l'image"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Supprimer l'image ?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5896,7 +6013,8 @@ msgstr "Discussions supprimées"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "La suppression des cookies aura pour effet de réinitialiser ces paramètres."
+msgstr ""
+"La suppression des cookies aura pour effet de réinitialiser ces paramètres."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -5918,7 +6036,8 @@ msgstr "Décrivez les modifications en fonction de l'image"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Décrivez les modifications souhaitées pour continuer à modifier cette image"
+msgstr ""
+"Décrivez les modifications souhaitées pour continuer à modifier cette image"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6087,7 +6206,8 @@ msgstr "Désactiver et déconnecter"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
+msgstr ""
+"Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6169,6 +6289,12 @@ msgstr "Ne plus afficher"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Ignorer la promotion"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6381,6 +6507,12 @@ msgstr "Téléchargement terminé"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Télécharger DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6598,6 +6730,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai par DuckDuckGo. Chat IA privé. Gratuit."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6636,7 +6774,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
+msgstr ""
+"Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6727,7 +6866,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
+msgstr ""
+"Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6743,7 +6883,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
+msgstr ""
+"Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6753,6 +6894,12 @@ msgid ""
 msgstr ""
 "Les réponses de Duck.ai ne s'appuient pas sur des sources spécifiques et "
 "leur exactitude n'est pas vérifiée."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7377,7 +7524,8 @@ msgstr "Activer les fonctionnalités d'IA"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
+msgstr ""
+"Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7411,6 +7559,12 @@ msgstr "Activer les sites les plus visités"
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Activer les sites les plus visités"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7632,13 +7786,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
+msgstr ""
+"Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Vérifiez que votre navigateur est autorisé à accéder à la localisation."
+msgstr ""
+"Vérifiez que votre navigateur est autorisé à accéder à la localisation."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7718,6 +7874,12 @@ msgstr "Saisissez votre phrase de passe pour charger vos paramètres."
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "Guide de divertissement"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7885,6 +8047,18 @@ msgid "Explicit lyrics"
 msgstr "Paroles explicites"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7986,6 +8160,12 @@ msgid "FREE"
 msgstr "Gratuit"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -8062,8 +8242,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, "
-"copiez-collez le code dans votre site."
+"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, copiez-"
+"collez le code dans votre site."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8140,7 +8320,8 @@ msgstr "Filtres inefficaces"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Filtre les images générées par l'IA des résultats de recherche d'images"
+msgstr ""
+"Filtre les images générées par l'IA des résultats de recherche d'images"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8197,7 +8378,8 @@ msgstr "Vous trouverez <b>%1$s</b> dans votre dossier de téléchargements"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
+msgstr ""
+"Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8308,7 +8490,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
+msgstr ""
+"Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8402,6 +8585,12 @@ msgstr "Plan gratuit"
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
 msgstr "Libérer du stockage"
+
+# smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8529,8 +8718,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dans la barre de menu de l'application sur Mac, sélectionnez "
-"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à "
-"jour…</strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
+"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à jour…</"
+"strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8926,6 +9115,12 @@ msgid "Get computer help"
 msgstr "Obtenir de l’aide informatique"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8963,6 +9158,18 @@ msgid "Get the Latest Version"
 msgstr "Obtenir la dernière version"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8983,6 +9190,12 @@ msgstr "Obtenez cette chanson sur :"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Parlez-en à vos amis pour nous aider à grandir !"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9057,7 +9270,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
+msgstr ""
+"Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9328,7 +9542,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
+msgstr ""
+"Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9528,7 +9743,8 @@ msgstr "Aide-nous à améliorer DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
+msgstr ""
+"Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9586,7 +9802,8 @@ msgstr "Aidez votre famille et vos ami(e)s à rejoindre le côté Duck !"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
+msgstr ""
+"Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9669,6 +9886,12 @@ msgstr "Masquer les étapes"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Masquer les conseils"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9982,7 +10205,8 @@ msgstr "À quelle fréquence souhaitez-vous voir des réponses %1$s ?"
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
+msgstr ""
+"À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10271,7 +10495,8 @@ msgstr "Les prompts d’image doivent respecter les %1$s"
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
-msgstr "Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
+msgstr ""
+"Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10791,7 +11016,8 @@ msgstr "Cela peut prendre quelques minutes."
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "Il est rapide, gratuit et vous offre encore plus de protection en ligne."
+msgstr ""
+"Il est rapide, gratuit et vous offre encore plus de protection en ligne."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11301,6 +11527,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Vous permet d'effectuer des recherches anonymes avec DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11371,6 +11604,12 @@ msgid "Lineouts Won"
 msgstr "Touches gagnées"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Police des liens :"
@@ -11384,7 +11623,8 @@ msgstr "Liens :"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
+msgstr ""
+"Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12469,6 +12709,12 @@ msgid "More than 20 minutes"
 msgstr "Plus de 20 minutes"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12956,6 +13202,12 @@ msgstr "Non merci"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Non merci"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13574,7 +13826,8 @@ msgstr "Oman"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
+msgstr ""
+"Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13620,6 +13873,12 @@ msgstr ""
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activé mais sans numérotation"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13755,7 +14014,8 @@ msgstr "Ouvrir %1$sParamètres%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
+msgstr ""
+"Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13836,6 +14096,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Ouvrir les suggestions de création et de modification des images"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13898,7 +14164,8 @@ msgstr "Ouvrir le volet « Comment fonctionne Duck.ai »"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
+msgstr ""
+"Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14586,10 +14853,22 @@ msgid "Pin"
 msgstr "Épingle"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Épinglez les discussions ici depuis le %2$s %1$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14607,6 +14886,12 @@ msgstr "Rose"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Épinglé"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14932,6 +15217,12 @@ msgid "Poor formatting"
 msgstr "Mauvais formatage"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15138,6 +15429,12 @@ msgstr "Image précédente"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Onglets précédents"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15682,6 +15979,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "IA de raisonnement avec modération intégrée moyenne"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15715,6 +16024,12 @@ msgstr "Onglets récents"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Le stockage des discussions récentes peut être ajusté dans %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15870,6 +16185,12 @@ msgstr "Relancer la recherche sans ce site"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Réduire l'utilisation"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16030,7 +16351,8 @@ msgstr "Mémoriser mon choix"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
+msgstr ""
+"Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16251,6 +16573,12 @@ msgid "Reset All Settings"
 msgstr "Réinitialiser tous les paramètres"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16261,6 +16589,12 @@ msgstr "Réinitialisation dans %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Résolution"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16462,7 +16796,8 @@ msgstr "Avis"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Réécris cette recette pour l'adapter à un nombre de portions différent."
+msgstr ""
+"Réécris cette recette pour l'adapter à un nombre de portions différent."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -16937,7 +17272,8 @@ msgstr ""
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down and locate %syour browser%s in the list."
-msgstr "Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
+msgstr ""
+"Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -16976,6 +17312,12 @@ msgstr "Rechercher"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Rechercher %1$s pour trouver des résultats plus proches de vous ?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17363,6 +17705,12 @@ msgstr ""
 "même nous."
 
 # smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "Security issue"
 msgstr "Problème de sécurité"
@@ -17500,31 +17848,35 @@ msgstr "Sélectionner %1$s%2$s%3$s, puis %4$sMoteur de recherche%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
+msgstr ""
+"Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Selectionnez %1$sPersonnaliser%2$s et saisissez "
-"%3$shttps://duckduckgo.com%4$s dans le champ de saisie"
+"Selectionnez %1$sPersonnaliser%2$s et saisissez %3$shttps://duckduckgo."
+"com%4$s dans le champ de saisie"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17565,7 +17917,8 @@ msgstr "Sélectionnez %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
+msgstr ""
+"Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17639,7 +17992,8 @@ msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sRéglages avancés%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
+msgstr ""
+"Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17700,7 +18054,8 @@ msgstr "Sélectionnez tous les carrés contenant un canard :"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr "Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
+msgstr ""
+"Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -17735,7 +18090,8 @@ msgstr "Texte sélectionné de %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
+msgstr ""
+"Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17879,6 +18235,12 @@ msgid "Set as Homepage"
 msgstr "Définir comme page d'accueil"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17946,6 +18308,18 @@ msgid "Seychelles"
 msgstr "Seychelles"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17984,6 +18358,13 @@ msgstr ""
 "Partagez une position en ville avec des modèles d'IA pour améliorer la "
 "pertinence. Duck.ai ne révèle jamais votre position précise, ni à nous ni "
 "aux modèles d'IA."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18042,6 +18423,12 @@ msgstr "Partager l'URL de la page"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Partager des commentaires positifs"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18177,6 +18564,12 @@ msgstr "Afficher les Bookmarklet et les valeurs des paramètres"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Afficher les détails"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18330,6 +18723,12 @@ msgid "Show more"
 msgstr "Afficher plus"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18363,6 +18762,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Afficher la barre latérale"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18509,7 +18914,8 @@ msgstr "Montre l'arrière-plan du bouton de recherche"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Affiche un message de bienvenue en haut de la page des résultats de recherche"
+msgstr ""
+"Affiche un message de bienvenue en haut de la page des résultats de recherche"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18708,7 +19114,8 @@ msgstr "Résolvez des problèmes complexes grâce au mode de raisonnement !"
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
 msgctxt "Promotional text for reasoning mode"
 msgid "Solve complex problems with the new reasoning mode!"
-msgstr "Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
+msgstr ""
+"Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
@@ -18753,6 +19160,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Une erreur s'est produite ; veuillez réessayer ultérieurement."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18768,7 +19181,8 @@ msgstr "Parfois"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
+msgstr ""
+"Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19051,6 +19465,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Commencer à utiliser la limite hebdomadaire"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Lancer la recherche !"
@@ -19101,7 +19521,8 @@ msgstr "Reste sur DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
+msgstr ""
+"Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19156,7 +19577,8 @@ msgstr "Arrêtez les traqueurs qui se cachent sur d'autres sites Web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
+msgstr ""
+"Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19246,8 +19668,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans "
-"Duck.ai, ou revenez plus tard pour créer plus d'images."
+"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans Duck."
+"ai, ou revenez plus tard pour créer plus d'images."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19576,7 +19998,8 @@ msgstr "Changer de modèle"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr "Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
+msgstr ""
+"Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -19629,6 +20052,14 @@ msgstr "Passer à un modèle plus efficace"
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Changez pour le moteur de recherche qui ne vous suit pas. Jamais."
+
+# smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19760,8 +20191,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Comment fonctionne ce code ?\n"
-"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de "
-"Duck.ai.\n"
+"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de Duck."
+"ai.\n"
 "2. Sélectionnez « Activer Sync & Backup », puis « Récupérer les données "
 "synchronisées »\n"
 "3. Copiez le code de récupération ci-dessus et collez-le là où il est écrit "
@@ -19788,6 +20219,12 @@ msgstr "Synchroniser avec un autre appareil"
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "Synchronisation et sauvegarde temporairement indisponibles"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19875,6 +20312,22 @@ msgstr "Tadjikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Prenez le contrôle de votre vie privée !"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20098,13 +20551,15 @@ msgstr "Merci pour vos commentaires !"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre !"
+msgstr ""
+"Merci pour votre patience pendant que nous mettons les choses en ordre !"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre."
+msgstr ""
+"Merci pour votre patience pendant que nous mettons les choses en ordre."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -20149,7 +20604,8 @@ msgstr "Les fichiers joints dépassent la limite totale de taille de %1$s Mo."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
+msgstr ""
+"L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20174,7 +20630,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
+msgstr ""
+"Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20234,7 +20691,8 @@ msgstr "Thèmes"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "There was an error displaying the search results."
-msgstr "Une erreur s'est produite lors de l'affichage des résultats de recherche."
+msgstr ""
+"Une erreur s'est produite lors de l'affichage des résultats de recherche."
 
 # smartling.placeholder_format=C
 #. Error message displayed when there was an issue in saving the chat locally to the browser's storage
@@ -20352,10 +20810,22 @@ msgid "This Month"
 msgstr "Ce mois-ci"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Cette semaine"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20407,13 +20877,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
+msgstr ""
+"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
+msgstr ""
+"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20451,7 +20923,8 @@ msgstr ""
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
 msgctxt "Error message when an uploaded file type is not supported"
 msgid "This file type is not supported, please attach a %s."
-msgstr "Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
+msgstr ""
+"Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20495,6 +20968,22 @@ msgid "This information isn’t useful"
 msgstr "Ces informations sont inutiles"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20514,8 +21003,8 @@ msgid ""
 "Other model providers follow a zero data retention model."
 msgstr ""
 "Ce fournisseur de modèles supprime les données associées à cette discussion "
-"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de "
-"non-conservation des données."
+"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de non-"
+"conservation des données."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20621,7 +21110,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
+msgstr ""
+"Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20762,7 +21252,8 @@ msgstr "Souligner le titre"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
+msgstr ""
+"Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -20776,7 +21267,8 @@ msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
+msgstr ""
+"Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20837,6 +21329,12 @@ msgstr "Auj."
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Auj."
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21184,7 +21682,8 @@ msgstr "Essayez %1$s pour ne plus voir de messages comme celui-ci."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
+msgstr ""
+"Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21250,9 +21749,21 @@ msgid "Try Them Out"
 msgstr "Essayer les modèles"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Essayez une recherche !"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21295,14 +21806,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
+msgstr ""
+"Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
+msgstr ""
+"N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21319,6 +21832,12 @@ msgid "Try for free"
 msgstr "Essai gratuit"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21333,6 +21852,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Essayez gratuitement ! Un VPN sécurisé, une IA avancée et privée, et plus "
 "encore."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21360,6 +21885,12 @@ msgstr "Essayez notre navigateur"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Tester notre page d'accueil qui n'affichera jamais ces messages :"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21434,13 +21965,15 @@ msgstr "Essayez les logiciels open source %1$s et %2$s récemment ajoutés"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
+msgstr ""
+"Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
+msgstr ""
+"Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21448,7 +21981,8 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr "Essayez d'utiliser un autre terme ou une autre expression de recherche."
+msgstr ""
+"Essayez d'utiliser un autre terme ou une autre expression de recherche."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -21609,6 +22143,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Activez Duck Player pour regarder YouTube sans publicités ciblées"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21618,7 +22158,8 @@ msgstr "Activez la « position exacte » pour des résultats plus précis."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Activez « Utiliser la position exacte » pour des résultats plus précis."
+msgstr ""
+"Activez « Utiliser la position exacte » pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21811,18 +22352,20 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et saisissez "
-": https://duckduckgo.com"
+"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et "
+"saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
+msgstr ""
+"Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
+msgstr ""
+"Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21981,6 +22524,12 @@ msgstr "Débloquez des modèles d'IA avancés avec un abonnement DuckDuckGo"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Accédez à une IA avancée avec votre abonnement !"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22350,6 +22899,12 @@ msgid "Use in Safari"
 msgstr "Utilisez avec Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22510,7 +23065,8 @@ msgstr "Voir les prix de votre séjour"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "DuckDuckGo protège la confidentialité lors de la consultation des publicités."
+msgstr ""
+"DuckDuckGo protège la confidentialité lors de la consultation des publicités."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22590,9 +23146,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de "
-"Duck.ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser "
-"avec un autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
+"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de Duck."
+"ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser avec un "
+"autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
 "récupération."
 
 # smartling.placeholder_format=C
@@ -23047,7 +23603,8 @@ msgstr "Nous avons perdu la connexion ; veuillez réessayer plus tard."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
+msgstr ""
+"Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23316,7 +23873,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
+msgstr ""
+"Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23559,6 +24117,12 @@ msgid "What brought you back today?"
 msgstr "Qu'est-ce qui vous amène aujourd'hui ?"
 
 # smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -23656,7 +24220,8 @@ msgstr "À quoi cela répond-il ?"
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
-msgstr "Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
+msgstr ""
+"Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
 
 # smartling.placeholder_format=C
 #. Header above a list of types of information that gets saved by the cloud save feature.
@@ -23668,7 +24233,8 @@ msgstr "Quelles informations sont sauvegardées ?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr "Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
+msgstr ""
+"Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23677,8 +24243,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi "
-"est-il différent du bookmarklet avec URL de paramétrage ?"
+"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi est-"
+"il différent du bookmarklet avec URL de paramétrage ?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23979,6 +24545,14 @@ msgstr "Victoires"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Précipitations mixtes"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24326,7 +24900,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
+msgstr ""
+"Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24356,7 +24931,8 @@ msgstr "Vous pouvez trouver le"
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
 msgctxt "duckai_migration"
 msgid "You can find the <b>%s</b> file in your downloads folder."
-msgstr "Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
+msgstr ""
+"Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
 
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
@@ -24412,6 +24988,13 @@ msgstr "Vous ne pouvez joindre que %1$s images par conversation"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Vous ne pouvez joindre que %1$s images par conversation."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24562,6 +25145,12 @@ msgstr ""
 "fois que vous aurez la dernière version."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24610,6 +25199,12 @@ msgid "You've blocked 1 site"
 msgstr "Vous avez bloqué 1 site"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24635,7 +25230,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
+msgstr ""
+"Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -24649,7 +25245,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
+msgstr ""
+"Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24773,8 +25370,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Votre navigateur fournit une liste des sites que vous visitez le "
-"plus.DuckDuckGo n'a jamais accès à ces données."
+"Votre navigateur fournit une liste des sites que vous visitez le plus."
+"DuckDuckGo n'a jamais accès à ces données."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25015,6 +25612,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Vos recherches ne peuvent pas être reliées à vous"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -25029,7 +25634,8 @@ msgstr ""
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "Vos discussions synchronisées sont en cours de restauration sur cet appareil."
+msgstr ""
+"Vos discussions synchronisées sont en cours de restauration sur cet appareil."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25097,7 +25703,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
+msgstr ""
+"Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25608,3 +26215,9 @@ msgstr "ans"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "an"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s détecté"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s fichiers utilisés"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,6 +365,8 @@ msgstr "%1$s utilisés"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
+"%1$s atteint les limites d’utilisation jusqu’à 2 à 5 fois plus vite que les "
+"modèles de base %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -623,7 +625,7 @@ msgstr "Il y a 1 jour"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 fichier utilisé"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -975,8 +977,8 @@ msgstr ""
 "AI Chat vous permet d'avoir des conversations anonymes avec des modèles de "
 "chat IA tiers. La désactivation de cette option masquera la fonctionnalité "
 "AI Chat sur DuckDuckGo Search. Vous pouvez toujours accéder à l'AI Chat "
-"lorsque ce paramètre est désactivé en consultant %1$sduckduckgo.com/"
-"aichat%2$s."
+"lorsque ce paramètre est désactivé en consultant "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1393,8 +1395,7 @@ msgstr "Ajouter un champ de recherche %1$s à votre site !"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr ""
-"Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
+msgstr "Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1547,6 +1548,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Les modèles avancés peuvent atteindre les limites d’utilisation 2 à 5 fois "
+"plus vite que les autres modèles. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2180,8 +2183,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
+msgstr "Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2351,7 +2353,7 @@ msgstr "Demander en privé"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Demander en privé"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2493,21 +2495,18 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2809,8 +2808,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Avant de stocker ce rapport, DuckDuckGo anonymisera votre conversation en "
-"supprimant les données à caractère personnel comme les noms, les adresses e-"
-"mail et les métadonnées d'identification."
+"supprimant les données à caractère personnel comme les noms, les adresses "
+"e-mail et les métadonnées d'identification."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2936,8 +2935,7 @@ msgstr "Bloquez les traqueurs d'e-mails et masquez votre adresse."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
+msgstr "La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -2953,8 +2951,7 @@ msgstr "Bloquer ce site dans tous les résultats"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
+msgstr "Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3302,8 +3299,7 @@ msgstr "En cliquant sur « %1$s », vous acceptez nos %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
+msgstr "En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3688,8 +3684,7 @@ msgstr "Change l'affichage de l'URL des résultats"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
+msgstr "Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3930,7 +3925,7 @@ msgstr "Discuter en privé avec l'IA"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Discuter en privé avec des IA populaires"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4163,8 +4158,7 @@ msgstr "Choix de modèles d'IA, y compris %1$s et %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
+msgstr "Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4522,8 +4516,7 @@ msgstr "Cliquez sur %1$sParamètres%2$s dans le menu déroulant."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
+msgstr "Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4749,7 +4742,7 @@ msgstr "Fermer"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Fermer"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4799,7 +4792,7 @@ msgstr "Fermer la recherche"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Fermer le deuxième avis"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5177,6 +5170,8 @@ msgstr "Continuer à bloquer les publicités"
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
+"Reprenez ici vos discussions récentes. Ou supprimez-les à l’aide du Fire "
+"Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5247,7 +5242,7 @@ msgstr "Données du cookie :"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Copié"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5300,7 +5295,7 @@ msgstr "Copier le code"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Copier le lien"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5421,7 +5416,7 @@ msgstr "Créer une image"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Créer un lien de partage"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5473,6 +5468,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"La création d’un lien génère une copie de la conversation que toute personne "
+"qui l’ouvre peut consulter."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5631,7 +5628,7 @@ msgstr "Personnaliser les réponses"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Personnaliser les réponses"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5923,7 +5920,7 @@ msgstr "Supprimer les données du serveur ?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Supprimer le lien partagé"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5935,7 +5932,7 @@ msgstr "Supprimer la transcription"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Supprimer une discussion"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5973,7 +5970,7 @@ msgstr "Supprimer l'image ?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Supprime-moi"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6013,8 +6010,7 @@ msgstr "Discussions supprimées"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"La suppression des cookies aura pour effet de réinitialiser ces paramètres."
+msgstr "La suppression des cookies aura pour effet de réinitialiser ces paramètres."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6036,8 +6032,7 @@ msgstr "Décrivez les modifications en fonction de l'image"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Décrivez les modifications souhaitées pour continuer à modifier cette image"
+msgstr "Décrivez les modifications souhaitées pour continuer à modifier cette image"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6206,8 +6201,7 @@ msgstr "Désactiver et déconnecter"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
+msgstr "Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6294,7 +6288,7 @@ msgstr "Ignorer la promotion"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Fermer la visite guidée"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6512,7 +6506,7 @@ msgstr "Télécharger DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Télécharger DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6733,7 +6727,7 @@ msgstr "Duck.ai par DuckDuckGo. Chat IA privé. Gratuit."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai peut désormais analyser des PDF. Essayez par vous-même !"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6774,8 +6768,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
+msgstr "Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6866,8 +6859,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
+msgstr "Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6883,8 +6875,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
+msgstr "Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6899,7 +6890,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai prend en charge les modèles d'Anthropic, d'OpenAI et d'autres."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7524,8 +7515,7 @@ msgstr "Activer les fonctionnalités d'IA"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
+msgstr "Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7564,7 +7554,7 @@ msgstr "Activer les sites les plus visités"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Activer maintenant"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7786,15 +7776,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
+msgstr "Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Vérifiez que votre navigateur est autorisé à accéder à la localisation."
+msgstr "Vérifiez que votre navigateur est autorisé à accéder à la localisation."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7879,7 +7867,7 @@ msgstr "Guide de divertissement"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Discussion complète"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -8050,13 +8038,13 @@ msgstr "Paroles explicites"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Explorer Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Explorer Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8163,7 +8151,7 @@ msgstr "Gratuit"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRATUIT ET OPTIONNEL"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8242,8 +8230,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, copiez-"
-"collez le code dans votre site."
+"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, "
+"copiez-collez le code dans votre site."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8320,8 +8308,7 @@ msgstr "Filtres inefficaces"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Filtre les images générées par l'IA des résultats de recherche d'images"
+msgstr "Filtre les images générées par l'IA des résultats de recherche d'images"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8378,8 +8365,7 @@ msgstr "Vous trouverez <b>%1$s</b> dans votre dossier de téléchargements"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
+msgstr "Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8490,8 +8476,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
+msgstr "Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8590,7 +8575,7 @@ msgstr "Libérer du stockage"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Gratuit et toujours confidentiel"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8718,8 +8703,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dans la barre de menu de l'application sur Mac, sélectionnez "
-"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à jour…</"
-"strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
+"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à "
+"jour…</strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9119,6 +9104,8 @@ msgstr "Obtenir de l’aide informatique"
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
 msgstr ""
+"Bénéficiez de limites d'utilisation plus élevées avec un abonnement "
+"DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9161,13 +9148,15 @@ msgstr "Obtenir la dernière version"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Obtenir l’application"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Téléchargez le navigateur DuckDuckGo gratuit %1$spour bloquer les publicités "
+"sur YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9195,7 +9184,7 @@ msgstr "Parlez-en à vos amis pour nous aider à grandir !"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Checklist de démarrage"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9270,8 +9259,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
+msgstr "Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9542,8 +9530,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
+msgstr "Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9743,8 +9730,7 @@ msgstr "Aide-nous à améliorer DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
+msgstr "Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9802,8 +9788,7 @@ msgstr "Aidez votre famille et vos ami(e)s à rejoindre le côté Duck !"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
+msgstr "Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9891,7 +9876,7 @@ msgstr "Masquer les conseils"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Masquer le tutoriel"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10205,8 +10190,7 @@ msgstr "À quelle fréquence souhaitez-vous voir des réponses %1$s ?"
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
+msgstr "À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10495,8 +10479,7 @@ msgstr "Les prompts d’image doivent respecter les %1$s"
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
-msgstr ""
-"Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
+msgstr "Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11016,8 +10999,7 @@ msgstr "Cela peut prendre quelques minutes."
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"Il est rapide, gratuit et vous offre encore plus de protection en ligne."
+msgstr "Il est rapide, gratuit et vous offre encore plus de protection en ligne."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11532,6 +11514,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Permet de basculer entre l’envoi de requêtes de recherche et de prompts à "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11607,7 +11591,7 @@ msgstr "Touches gagnées"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Le lien expire dans 7 jours."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11623,8 +11607,7 @@ msgstr "Liens :"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
+msgstr "Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12712,7 +12695,7 @@ msgstr "Plus de 20 minutes"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Plus de conseils"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13207,7 +13190,7 @@ msgstr "Non merci"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Non merci"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13826,8 +13809,7 @@ msgstr "Oman"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
+msgstr "Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13878,7 +13860,7 @@ msgstr "Activé mais sans numérotation"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Intégration terminée"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -14014,8 +13996,7 @@ msgstr "Ouvrir %1$sParamètres%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
+msgstr "Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14099,7 +14080,7 @@ msgstr "Ouvrir les suggestions de création et de modification des images"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Ouvrir la liste de démarrage"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14164,8 +14145,7 @@ msgstr "Ouvrir le volet « Comment fonctionne Duck.ai »"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
+msgstr "Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14856,7 +14836,7 @@ msgstr "Épingle"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Épingler une discussion"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14868,7 +14848,7 @@ msgstr "Épinglez les discussions ici depuis le %2$s %1$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Épingle-moi"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14891,7 +14871,7 @@ msgstr "Épinglé"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Les discussions épinglées apparaîtront en haut de vos discussions récentes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15221,6 +15201,8 @@ msgstr "Mauvais formatage"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Modèles d'IA populaires disponibles. Aucun compte n'est nécessaire. "
+"Discussions anonymisées par nos soins."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15434,7 +15416,7 @@ msgstr "Onglets précédents"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Conseils précédents"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15982,13 +15964,15 @@ msgstr "IA de raisonnement avec modération intégrée moyenne"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Le raisonnement peut donner de meilleures réponses aux questions complexes."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Le mode Raisonnement est plus poussé, mais atteint les limites d’utilisation "
+"2 à 5 fois plus rapidement. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16029,7 +16013,7 @@ msgstr "Le stockage des discussions récentes peut être ajusté dans %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Discussions récentes"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16190,7 +16174,7 @@ msgstr "Réduire l'utilisation"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Réduisez votre utilisation avec un modèle plus efficace"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16351,8 +16335,7 @@ msgstr "Mémoriser mon choix"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
+msgstr "Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16576,7 +16559,7 @@ msgstr "Réinitialiser tous les paramètres"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Réinitialiser le tutoriel"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16594,7 +16577,7 @@ msgstr "Résolution"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Réponse"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16796,8 +16779,7 @@ msgstr "Avis"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Réécris cette recette pour l'adapter à un nombre de portions différent."
+msgstr "Réécris cette recette pour l'adapter à un nombre de portions différent."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17272,8 +17254,7 @@ msgstr ""
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down and locate %syour browser%s in the list."
-msgstr ""
-"Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
+msgstr "Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -17317,7 +17298,7 @@ msgstr "Rechercher %1$s pour trouver des résultats plus proches de vous ?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Bouton Recherche et Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17708,7 +17689,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Stocké en toute sécurité sur notre serveur chiffré."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17848,35 +17829,31 @@ msgstr "Sélectionner %1$s%2$s%3$s, puis %4$sMoteur de recherche%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
+msgstr "Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Selectionnez %1$sPersonnaliser%2$s et saisissez %3$shttps://duckduckgo."
-"com%4$s dans le champ de saisie"
+"Selectionnez %1$sPersonnaliser%2$s et saisissez "
+"%3$shttps://duckduckgo.com%4$s dans le champ de saisie"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17917,8 +17894,7 @@ msgstr "Sélectionnez %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
+msgstr "Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17992,8 +17968,7 @@ msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sRéglages avancés%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
+msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18054,8 +18029,7 @@ msgstr "Sélectionnez tous les carrés contenant un canard :"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr ""
-"Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
+msgstr "Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -18090,8 +18064,7 @@ msgstr "Texte sélectionné de %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
+msgstr "Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18238,7 +18211,7 @@ msgstr "Définir comme page d'accueil"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Définissez le ton et le style des réponses de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18311,13 +18284,13 @@ msgstr "Seychelles"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Partager"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Partager"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18364,7 +18337,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Partager la discussion"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18428,7 +18401,7 @@ msgstr "Partager des commentaires positifs"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Portée du partage"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18569,7 +18542,7 @@ msgstr "Afficher les détails"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Afficher le tutoriel Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18726,7 +18699,7 @@ msgstr "Afficher plus"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Afficher plus de modèles"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18768,6 +18741,8 @@ msgstr "Afficher la barre latérale"
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
+"Découvrez des conseils étape par étape pour tirer le meilleur parti de "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18914,8 +18889,7 @@ msgstr "Montre l'arrière-plan du bouton de recherche"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Affiche un message de bienvenue en haut de la page des résultats de recherche"
+msgstr "Affiche un message de bienvenue en haut de la page des résultats de recherche"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19114,8 +19088,7 @@ msgstr "Résolvez des problèmes complexes grâce au mode de raisonnement !"
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
 msgctxt "Promotional text for reasoning mode"
 msgid "Solve complex problems with the new reasoning mode!"
-msgstr ""
-"Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
+msgstr "Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
@@ -19163,7 +19136,7 @@ msgstr "Une erreur s'est produite ; veuillez réessayer ultérieurement."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Une erreur s’est produite. Veuillez réessayer."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19181,8 +19154,7 @@ msgstr "Parfois"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
+msgstr "Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19468,7 +19440,7 @@ msgstr "Commencer à utiliser la limite hebdomadaire"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Démarre un nouveau chat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19521,8 +19493,7 @@ msgstr "Reste sur DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
+msgstr "Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19577,8 +19548,7 @@ msgstr "Arrêtez les traqueurs qui se cachent sur d'autres sites Web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
+msgstr "Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19668,8 +19638,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans Duck."
-"ai, ou revenez plus tard pour créer plus d'images."
+"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans "
+"Duck.ai, ou revenez plus tard pour créer plus d'images."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19998,8 +19968,7 @@ msgstr "Changer de modèle"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
+msgstr "Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20059,7 +20028,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Passer à ce deuxième avis"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20191,8 +20160,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Comment fonctionne ce code ?\n"
-"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de Duck."
-"ai.\n"
+"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de "
+"Duck.ai.\n"
 "2. Sélectionnez « Activer Sync & Backup », puis « Récupérer les données "
 "synchronisées »\n"
 "3. Copiez le code de récupération ci-dessus et collez-le là où il est écrit "
@@ -20224,7 +20193,7 @@ msgstr "Synchronisation et sauvegarde temporairement indisponibles"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Synchroniser les discussions sur plusieurs appareils"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20320,6 +20289,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Emportez Duck.ai partout avec vous. Intégrez-le à notre application gratuite "
+"pour y accéder plus rapidement, où que vous soyez."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20328,6 +20299,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Emportez Duck.ai partout avec vous. Intégrez-le à notre navigateur gratuit "
+"pour y accéder plus rapidement, où que vous soyez."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20551,15 +20524,13 @@ msgstr "Merci pour vos commentaires !"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Merci pour votre patience pendant que nous mettons les choses en ordre !"
+msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre !"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Merci pour votre patience pendant que nous mettons les choses en ordre."
+msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -20604,8 +20575,7 @@ msgstr "Les fichiers joints dépassent la limite totale de taille de %1$s Mo."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
+msgstr "L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20630,8 +20600,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
+msgstr "Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20691,8 +20660,7 @@ msgstr "Thèmes"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "There was an error displaying the search results."
-msgstr ""
-"Une erreur s'est produite lors de l'affichage des résultats de recherche."
+msgstr "Une erreur s'est produite lors de l'affichage des résultats de recherche."
 
 # smartling.placeholder_format=C
 #. Error message displayed when there was an issue in saving the chat locally to the browser's storage
@@ -20813,7 +20781,7 @@ msgstr "Ce mois-ci"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Cette réponse"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20825,7 +20793,7 @@ msgstr "Cette semaine"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Ce chat reste dans Duck.ai et reste privé pour toi."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20877,15 +20845,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
+msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
+msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20923,8 +20889,7 @@ msgstr ""
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
 msgctxt "Error message when an uploaded file type is not supported"
 msgid "This file type is not supported, please attach a %s."
-msgstr ""
-"Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
+msgstr "Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20974,6 +20939,9 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Il s’agit simplement d’un exemple de conversation. Ouvrez son menu (les "
+"trois points), puis sélectionnez « Épingler » pour la maintenir en haut de "
+"votre liste de conversations !"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20982,6 +20950,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Ceci est juste un exemple de discussion. Utilisez le Fire Button dans le "
+"menu latéral pour la supprimer !"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21003,8 +20973,8 @@ msgid ""
 "Other model providers follow a zero data retention model."
 msgstr ""
 "Ce fournisseur de modèles supprime les données associées à cette discussion "
-"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de non-"
-"conservation des données."
+"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de "
+"non-conservation des données."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21110,8 +21080,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
+msgstr "Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21252,8 +21221,7 @@ msgstr "Souligner le titre"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
+msgstr "Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21267,8 +21235,7 @@ msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
+msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21335,6 +21302,8 @@ msgstr "Auj."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Activez cette option pour essayer le chat privé avec l’IA ou "
+"%1$sdésactivez-la dans le menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21682,8 +21651,7 @@ msgstr "Essayez %1$s pour ne plus voir de messages comme celui-ci."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
+msgstr "Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21752,7 +21720,7 @@ msgstr "Essayer les modèles"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Essayer un autre modèle"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21763,7 +21731,7 @@ msgstr "Essayez une recherche !"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Essayer une suggestion"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21806,16 +21774,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
+msgstr "Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
+msgstr "N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21835,7 +21801,7 @@ msgstr "Essai gratuit"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Essayer gratuitement"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21857,7 +21823,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Essayez gratuitement pendant 7 jours"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21890,7 +21856,7 @@ msgstr "Tester notre page d'accueil qui n'affichera jamais ces messages :"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Essayer le raisonnement"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21965,15 +21931,13 @@ msgstr "Essayez les logiciels open source %1$s et %2$s récemment ajoutés"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
+msgstr "Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
+msgstr "Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21981,8 +21945,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr ""
-"Essayez d'utiliser un autre terme ou une autre expression de recherche."
+msgstr "Essayez d'utiliser un autre terme ou une autre expression de recherche."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -22146,7 +22109,7 @@ msgstr "Activez Duck Player pour regarder YouTube sans publicités ciblées"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Bouton Activer Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22158,8 +22121,7 @@ msgstr "Activez la « position exacte » pour des résultats plus précis."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Activez « Utiliser la position exacte » pour des résultats plus précis."
+msgstr "Activez « Utiliser la position exacte » pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22352,20 +22314,18 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et "
-"saisissez : https://duckduckgo.com"
+"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et saisissez "
+": https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
+msgstr "Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
+msgstr "Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22529,7 +22489,7 @@ msgstr "Accédez à une IA avancée avec votre abonnement !"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Débloquer les modèles avancés"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22902,7 +22862,7 @@ msgstr "Utilisez avec Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Utilisez le Fire Button pour supprimer une conversation de l’historique."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23065,8 +23025,7 @@ msgstr "Voir les prix de votre séjour"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"DuckDuckGo protège la confidentialité lors de la consultation des publicités."
+msgstr "DuckDuckGo protège la confidentialité lors de la consultation des publicités."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23146,9 +23105,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de Duck."
-"ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser avec un "
-"autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
+"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de "
+"Duck.ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser "
+"avec un autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
 "récupération."
 
 # smartling.placeholder_format=C
@@ -23603,8 +23562,7 @@ msgstr "Nous avons perdu la connexion ; veuillez réessayer plus tard."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
+msgstr "Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23873,8 +23831,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
+msgstr "Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24120,7 +24077,7 @@ msgstr "Qu'est-ce qui vous amène aujourd'hui ?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Que peux-tu faire ?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24220,8 +24177,7 @@ msgstr "À quoi cela répond-il ?"
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
-msgstr ""
-"Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
+msgstr "Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
 
 # smartling.placeholder_format=C
 #. Header above a list of types of information that gets saved by the cloud save feature.
@@ -24233,8 +24189,7 @@ msgstr "Quelles informations sont sauvegardées ?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
+msgstr "Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -24243,8 +24198,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi est-"
-"il différent du bookmarklet avec URL de paramétrage ?"
+"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi "
+"est-il différent du bookmarklet avec URL de paramétrage ?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24553,6 +24508,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Avec Duck.ai, vos conversations sont anonymisées et ne sont jamais utilisées "
+"pour entraîner l’IA. Vous pouvez activer ou désactiver cette fonctionnalité "
+"à tout moment dans le menu « %1$s »."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24900,8 +24858,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
+msgstr "Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24931,8 +24888,7 @@ msgstr "Vous pouvez trouver le"
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
 msgctxt "duckai_migration"
 msgid "You can find the <b>%s</b> file in your downloads folder."
-msgstr ""
-"Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
+msgstr "Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
 
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
@@ -24994,7 +24950,7 @@ msgstr "Vous ne pouvez joindre que %1$s images par conversation."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Vous ne pouvez joindre que %1$s onglets à la fois."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -25148,7 +25104,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Tout est prêt !"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -25202,7 +25158,7 @@ msgstr "Vous avez bloqué 1 site"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Vous maîtrisez les bases de Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25230,8 +25186,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
+msgstr "Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25245,8 +25200,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
+msgstr "Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25370,8 +25324,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Votre navigateur fournit une liste des sites que vous visitez le plus."
-"DuckDuckGo n'a jamais accès à ces données."
+"Votre navigateur fournit une liste des sites que vous visitez le "
+"plus.DuckDuckGo n'a jamais accès à ces données."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25618,6 +25572,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Vos paramètres sont enregistrés, mais la suppression des cookies les "
+"réinitialisera. Activez l'extension %1$sDuckDuckGo No AI%2$s pour rendre "
+"cela permanent."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25634,8 +25591,7 @@ msgstr ""
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"Vos discussions synchronisées sont en cours de restauration sur cet appareil."
+msgstr "Vos discussions synchronisées sont en cours de restauration sur cet appareil."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25703,8 +25659,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
+msgstr "Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26220,4 +26175,4 @@ msgstr "an"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -111,6 +111,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%s braite"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -292,6 +297,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -493,6 +503,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Lá ó shin"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1232,6 +1247,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1858,6 +1880,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3095,6 +3122,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3709,6 +3741,11 @@ msgstr "Fáisc-ealaín"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3744,6 +3781,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4051,6 +4093,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4105,6 +4152,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr "Sonraí fianáin:"
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4142,6 +4194,11 @@ msgstr "Cóipeáil &amp; greamaigh %sabout:preferences#search%s sa bharra seolta
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4238,6 +4295,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4272,6 +4334,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4397,6 +4466,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4633,9 +4707,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4663,6 +4747,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4916,6 +5005,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5083,6 +5177,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5258,6 +5357,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5365,6 +5469,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5853,6 +5962,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6096,6 +6210,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6229,6 +6348,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6310,6 +6439,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6643,6 +6777,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7064,6 +7203,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7093,6 +7237,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7110,6 +7264,11 @@ msgstr "Faigh an t-amhrán seo ar:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Áitigh ar do chairde tiontú chuig DuckDuckGo agus cabhraigh linn fás!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7660,6 +7819,11 @@ msgstr "Cuir na céimeanna i bhfolach"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8972,6 +9136,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Ligeann sé duit cuardach a dhéanamh go hanaithnid le DuckDuckGo"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9027,6 +9197,11 @@ msgstr "Línelíníocht"
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9930,6 +10105,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Níos faide ná 20 nóiméad"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10324,6 +10504,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10874,6 +11059,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Ar siúl ach gan aon chomhalta"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11044,6 +11234,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11644,9 +11839,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11661,6 +11866,11 @@ msgstr "Bándearg"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11917,6 +12127,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12086,6 +12301,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12529,6 +12749,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12556,6 +12786,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12678,6 +12913,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12980,6 +13220,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Athshocraigh gach socrú"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12988,6 +13233,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13547,6 +13797,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Cuardaigh go hAnaithnid"
 
@@ -13831,6 +14086,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14240,6 +14500,11 @@ msgstr "Socraigh mar an tInneall Cuardaigh Réamhshocraithe"
 msgid "Set as Homepage"
 msgstr "Socraigh mar Leathanach Baile"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14292,6 +14557,16 @@ msgstr "Nuashonraíodh na socruithe"
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14323,6 +14598,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14371,6 +14652,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14483,6 +14769,11 @@ msgstr "Taispeáin Sonraí an Leabharmharcín agus na Socruithe"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Taispeáin an Mionsonra"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14606,6 +14897,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14634,6 +14930,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14942,6 +15243,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15174,6 +15480,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15655,6 +15966,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Athraigh chuig an inneall cuardaigh nach leanann do lorg. Riamh."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15767,6 +16085,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15837,6 +16160,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Bíodh neart agat ar do Phríobháideachas!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16214,9 +16551,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16317,6 +16664,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16585,6 +16946,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16922,9 +17288,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Déan é a chuardach!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16978,6 +17354,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16988,6 +17369,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -17012,6 +17398,11 @@ msgstr ""
 msgid "Try our homepage that never shows these messages:"
 msgstr ""
 "Féach ár leathanach baile nach taispeánann na teachtaireachtaí seo riamh:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17211,6 +17602,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17506,6 +17902,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17804,6 +18205,11 @@ msgstr "Bain feidhm as in Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Bain feidhm as i Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18728,6 +19134,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Cad a thug ar ais anseo tú inniu?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19069,6 +19480,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19417,6 +19835,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19529,6 +19953,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19565,6 +19994,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19869,6 +20303,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20344,6 +20785,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "bl"
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
 
 #~ msgctxt "SERP footer content"
 #~ msgid "%s Billion Searches"

--- a/locales/gd_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/gd_GB/LC_MESSAGES/duckduckgo.po
@@ -111,6 +111,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -292,6 +297,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -484,6 +494,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1848,6 +1870,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3083,6 +3110,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3694,6 +3726,11 @@ msgstr "ClipArt"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3729,6 +3766,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4037,6 +4079,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4091,6 +4138,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4128,6 +4180,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4224,6 +4281,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4258,6 +4320,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4383,6 +4452,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4619,9 +4693,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4649,6 +4733,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4902,6 +4991,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5070,6 +5164,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5245,6 +5344,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5352,6 +5456,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5840,6 +5949,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6081,6 +6195,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6214,6 +6333,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6295,6 +6424,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6629,6 +6763,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7050,6 +7189,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7079,6 +7223,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7096,6 +7250,11 @@ msgstr "Faigh an t-òran seo air:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Nach mol thu dha do charaidean e?"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7646,6 +7805,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8950,6 +9114,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9005,6 +9175,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9903,6 +10078,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Nas fhaide na 20 mionaidean"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10297,6 +10477,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10847,6 +11032,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Air, ach as aonais àireamhan"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11017,6 +11207,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11617,9 +11812,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11634,6 +11839,11 @@ msgstr "Pinc"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11890,6 +12100,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12059,6 +12274,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12501,6 +12721,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12528,6 +12758,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12650,6 +12885,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12953,6 +13193,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Ath-shuidhich na roghainnean air fad"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12961,6 +13206,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13520,6 +13770,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13802,6 +14057,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14208,6 +14468,11 @@ msgstr "Suidhich mar an t-einnsean-luirg bunaiteach"
 msgid "Set as Homepage"
 msgstr "Cleachd seo mar an duilleag-dhachaidh agad"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14260,6 +14525,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14291,6 +14566,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14339,6 +14620,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14450,6 +14736,11 @@ msgstr "Seall dàta nan roghainnean is bookmarklet"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14574,6 +14865,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14602,6 +14898,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14902,6 +15203,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15134,6 +15440,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15612,6 +15923,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Cleachd an t-einnsean-luirg nach tracaich thu. Idir."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15724,6 +16042,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15794,6 +16117,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Faigh smachd air do phrìobhaideachd!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16162,9 +16499,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16265,6 +16612,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16524,6 +16885,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16861,9 +17227,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Feuch lorg!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16917,6 +17293,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16927,6 +17308,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16951,6 +17337,11 @@ msgstr ""
 msgid "Try our homepage that never shows these messages:"
 msgstr ""
 "Feuch an duilleag-dhachaidh againn nach seall na teachdaireachdan seo idir:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17150,6 +17541,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17441,6 +17837,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17737,6 +18138,11 @@ msgstr "Cleachd ann am Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Cleachd ann an Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18660,6 +19066,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Dè thug ort tilleadh thugainn an-diugh?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19001,6 +19412,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19348,6 +19766,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19460,6 +19884,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19496,6 +19925,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19800,6 +20234,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20274,6 +20715,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/gl_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/gl_ES/LC_MESSAGES/duckduckgo.po
@@ -111,6 +111,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -292,6 +297,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -489,6 +499,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1231,6 +1246,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1857,6 +1879,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3100,6 +3127,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3704,6 +3736,11 @@ msgstr "Imaxes predeseñadas"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3739,6 +3776,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4046,6 +4088,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4100,6 +4147,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4137,6 +4189,11 @@ msgstr "Copie e pegue %sabout:preferences#search%s na barra de enderezos"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4233,6 +4290,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4267,6 +4329,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4392,6 +4461,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4628,9 +4702,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4658,6 +4742,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4911,6 +5000,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5077,6 +5171,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5252,6 +5351,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5359,6 +5463,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5847,6 +5956,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6087,6 +6201,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6220,6 +6339,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6301,6 +6430,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6634,6 +6768,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7055,6 +7194,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7086,6 +7230,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7103,6 +7257,11 @@ msgstr "Obteña esta canción en:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Anima as súas amizades a cambiar e axúdenos a medrar!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7653,6 +7812,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8960,6 +9124,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Permítelle buscar de xeito anónimo co DuckDuckGo"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9015,6 +9185,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9911,6 +10086,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Máis de 20 minutos"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10305,6 +10485,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10855,6 +11040,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Activado pero sen números"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11025,6 +11215,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11628,9 +11823,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11645,6 +11850,11 @@ msgstr "Rosa"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11901,6 +12111,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12070,6 +12285,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12512,6 +12732,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12539,6 +12769,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12661,6 +12896,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12963,6 +13203,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Restablecer todas as preferencias"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12971,6 +13216,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13530,6 +13780,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Buscar de xeito anónimo"
 
@@ -13815,6 +14070,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14222,6 +14482,11 @@ msgstr "Estabelecer como motor de busca predeterminado"
 msgid "Set as Homepage"
 msgstr "Estabelecer como páxina de inicio"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14274,6 +14539,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14304,6 +14579,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14352,6 +14633,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14463,6 +14749,11 @@ msgstr "Mostra marcador e Datos de preferencias"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14587,6 +14878,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14615,6 +14911,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14913,6 +15214,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15145,6 +15451,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15623,6 +15934,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Dea o chimpo ao motor de buscas que non persegue. Nunca."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15735,6 +16053,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15805,6 +16128,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Recupere a súa privacidade!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16180,9 +16517,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16283,6 +16630,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16540,6 +16901,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16877,9 +17243,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Probe unha busca!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16933,6 +17309,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16943,6 +17324,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16966,6 +17352,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Probe a nosa páxina de inicio que nunca mostra estas mensaxes:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17165,6 +17556,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17454,6 +17850,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17750,6 +18151,11 @@ msgstr "Usar no Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Usar no Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18672,6 +19078,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Que o/a trouxo aquí hoxe?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19011,6 +19422,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19357,6 +19775,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19466,6 +19890,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19502,6 +19931,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19805,6 +20239,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20279,6 +20720,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/gu_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/gu_IN/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -484,6 +494,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3675,6 +3707,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3710,6 +3747,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4015,6 +4057,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4069,6 +4116,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4106,6 +4158,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4202,6 +4259,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4236,6 +4298,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4361,6 +4430,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4597,9 +4671,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4627,6 +4711,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4880,6 +4969,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5046,6 +5140,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5221,6 +5320,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5328,6 +5432,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5824,6 +5933,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6063,6 +6177,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6196,6 +6315,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6277,6 +6406,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6606,6 +6740,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7027,6 +7166,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7056,6 +7200,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7072,6 +7226,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7623,6 +7782,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8918,6 +9082,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8973,6 +9143,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9869,6 +10044,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10263,6 +10443,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10811,6 +10996,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "ચાલુ પણ આંકડાઓ નહિ"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10979,6 +11169,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11575,9 +11770,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11592,6 +11797,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11848,6 +12058,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12017,6 +12232,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12459,6 +12679,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12486,6 +12716,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12608,6 +12843,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12910,6 +13150,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12918,6 +13163,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13475,6 +13725,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13757,6 +14012,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14154,6 +14414,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "ગૃહપાના તરીકે રાખો"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14206,6 +14471,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14235,6 +14510,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14283,6 +14564,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14394,6 +14680,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14518,6 +14809,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14546,6 +14842,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14844,6 +15145,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15076,6 +15382,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15554,6 +15865,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15666,6 +15984,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15735,6 +16058,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16104,9 +16441,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16207,6 +16554,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16463,6 +16824,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16800,8 +17166,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16856,6 +17232,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16866,6 +17247,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16888,6 +17274,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17088,6 +17479,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17372,6 +17768,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17667,6 +18068,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18580,6 +18986,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18919,6 +19330,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19263,6 +19681,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19371,6 +19795,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19405,6 +19834,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19702,6 +20136,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20174,6 +20615,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Load Cloud Settings"

--- a/locales/he_IL/LC_MESSAGES/duckduckgo.po
+++ b/locales/he_IL/LC_MESSAGES/duckduckgo.po
@@ -111,6 +111,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%s זוהו"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -292,6 +297,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -485,6 +495,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "לפני יום 1"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1848,6 +1870,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3082,6 +3109,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3683,6 +3715,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3718,6 +3755,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4025,6 +4067,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4079,6 +4126,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4116,6 +4168,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4212,6 +4269,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4246,6 +4308,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4371,6 +4440,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4607,9 +4681,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4637,6 +4721,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4890,6 +4979,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5056,6 +5150,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5231,6 +5330,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5338,6 +5442,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5826,6 +5935,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6065,6 +6179,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6198,6 +6317,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6279,6 +6408,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6609,6 +6743,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7030,6 +7169,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7059,6 +7203,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7076,6 +7230,11 @@ msgstr "השג את שיר זה מתוך:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "גרום לחבריך להחליף ולעזור לנו לגדול!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7626,6 +7785,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8925,6 +9089,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8980,6 +9150,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9876,6 +10051,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "יותר מ־20 דקות"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10270,6 +10450,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10819,6 +11004,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "פועל, אבל בלי מספרים"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10988,6 +11178,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11588,9 +11783,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11605,6 +11810,11 @@ msgstr "ורוד"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11861,6 +12071,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12030,6 +12245,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12472,6 +12692,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12499,6 +12729,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12621,6 +12856,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12923,6 +13163,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "אפס/י את כל ההגדרות"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12931,6 +13176,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13491,6 +13741,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "חפש באנונימיות"
 
@@ -13771,6 +14026,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14170,6 +14430,11 @@ msgstr "הגדר/י כמנוע חיפוש המשמש כברירת מחדל"
 msgid "Set as Homepage"
 msgstr "הגדר/י כדף הבית"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14222,6 +14487,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14251,6 +14526,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14299,6 +14580,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14410,6 +14696,11 @@ msgstr "הראה סימנייה והגדרות מידע"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14534,6 +14825,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14562,6 +14858,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14860,6 +15161,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15092,6 +15398,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15570,6 +15881,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15682,6 +16000,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15752,6 +16075,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "שלוט שוב בפרטיות שלך!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16120,9 +16457,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16223,6 +16570,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16479,6 +16840,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16816,9 +17182,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "נסה חיפוש!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16872,6 +17248,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16882,6 +17263,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16905,6 +17291,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "דף הבית שלנו לעולם לא יציג את ההודעות האלה. נסה/י בעצמך"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17104,6 +17495,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17391,6 +17787,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17687,6 +18088,11 @@ msgstr "השתמש ב־Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "השתמש/י בSafari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18601,6 +19007,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18940,6 +19351,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19286,6 +19704,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19394,6 +19818,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19428,6 +19857,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19727,6 +20161,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20201,6 +20642,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s पाया गया"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s फ़ाइल इस्तेमाल हुईं"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -182,8 +182,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
-"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
+"स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -193,8 +194,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
-"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
+"स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -210,8 +212,9 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल पर स्विच करें।"
+"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस "
+"ब्राउज़र में अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
+"पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -220,8 +223,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में फिर से कोशिश "
-"करें।"
+"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में "
+"फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -312,9 +315,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल प्रोवाइडर भी "
-"आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस चैट को अपने सर्वर पर सेव "
-"कर सकता है।"
+"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल "
+"प्रोवाइडर भी आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस "
+"चैट को अपने सर्वर पर सेव कर सकता है।"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -362,6 +365,8 @@ msgstr "%1$s उपयोग किया गया"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
+"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता "
+"है %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -400,8 +405,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी रखने "
-"के लिए मॉडल बदल सकते हैं।"
+"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी "
+"रखने के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -412,8 +417,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को जारी रखने के "
-"लिए मॉडल बदल सकते हैं।"
+"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को "
+"जारी रखने के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -426,8 +431,8 @@ msgstr "%1$s शब्द"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, फिर %6$sठीक "
-"हैं%7$s पर क्लिक करें"
+"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, "
+"फिर %6$sठीक हैं%7$s पर क्लिक करें"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -435,8 +440,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति दें%7$s पर "
-"निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
+"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -446,8 +451,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
-"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें "
+"%6$sअनुमति दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -481,14 +486,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर किया जाता है।"
+"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर "
+"किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर जानें।%2$s"
+"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर "
+"जानें।%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -500,7 +507,9 @@ msgstr "होम स्क्रीन पर DuckDuckGo ऐप आइकन �
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से कोशिश करें।"
+msgstr ""
+"%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -612,7 +621,7 @@ msgstr "1 दिन पहले"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 फ़ाइल इस्तेमाल की गई"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -833,7 +842,9 @@ msgstr "6 घंटे की उपयोग सीमा पूरी हो �
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
+msgstr ""
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -841,8 +852,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके चैटिंग जारी रख "
-"सकते हैं।"
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके "
+"चैटिंग जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -896,22 +907,26 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना कनेक्शन "
-"जांचें और फिर से कोशिश करें।"
+"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना "
+"कनेक्शन जांचें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
+msgstr ""
+"AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
+msgstr ""
+"Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -955,9 +970,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा देता "
-"है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप जाएगा। जब यह सेटिंग बंद हो "
-"तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI Chat का उपयोग कर सकते हैं।"
+"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
+"सुविधा देता है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप "
+"जाएगा। जब यह सेटिंग बंद हो तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI "
+"Chat का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1018,10 +1034,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते हैं। "
-"हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और अक्सर उससे लिंक "
-"करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और Anthropic, और अन्य के चैट "
-"मॉडलों को सपोर्ट करती है।"
+"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते "
+"हैं। हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और "
+"अक्सर उससे लिंक करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और "
+"Anthropic, और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1206,8 +1222,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
-"पर स्विच करें।"
+"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या "
+"किसी मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1243,8 +1259,8 @@ msgstr "विज्ञापन"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग आपकी "
-"व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका "
+"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1252,8 +1268,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग "
-"आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और "
+"इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1304,7 +1320,8 @@ msgstr "DuckDuckGo एक्सटेंशन जोड़ें"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials जोड़ें:"
+"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials "
+"जोड़ें:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1525,6 +1542,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल "
+"कर सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1566,7 +1585,9 @@ msgstr "जैसे ही वह डाउनलोड होकर खुल�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल क्लिक करें"
+msgstr ""
+"डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल "
+"क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1703,8 +1724,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "सभी चैट DuckDuckGo द्वारा अनाम कर दी जाती हैं, और आपकी बातचीत का इस्तेमाल "
-"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं किया "
-"जाता है"
+"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं "
+"किया जाता है"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1737,8 +1758,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से रोका गया "
-"है।"
+"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से "
+"रोका गया है।"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1753,8 +1774,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) हटा दिया "
-"जाता है।"
+"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) "
+"हटा दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1786,8 +1807,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन एक्सेस की अनुमति "
-"दें।"
+"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन "
+"एक्सेस की अनुमति दें।"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1810,7 +1831,8 @@ msgstr "इस चैट के लिए गुमनाम फ़ाइल र
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
 msgstr ""
-"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को अनुमति दें"
+"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को "
+"अनुमति दें"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1820,10 +1842,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स के जवाबों को "
-"बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही भेजता है, जिनमें डेटा रिटेंशन की "
-"लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स और जवाबों पर अभी भी %3$sप्रोवाइडर की "
-"विज़िबिलिटी शून्य%4$s रहती है।"
+"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स "
+"के जवाबों को बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही "
+"भेजता है, जिनमें डेटा रिटेंशन की लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स "
+"और जवाबों पर अभी भी %3$sप्रोवाइडर की विज़िबिलिटी शून्य%4$s रहती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1831,8 +1853,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता है (Cloud "
-"Save का उपयोग करने के लिए आवश्यक है)"
+"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता "
+"है (Cloud Save का उपयोग करने के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1970,8 +1992,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
-"शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
+"%3$s और %4$s शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1980,8 +2002,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
-"शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
+"%3$s और %4$s शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1995,8 +2017,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। चुनें कि इसे कितनी "
-"बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
+"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। "
+"चुनें कि इसे कितनी बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2043,8 +2065,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे बतख संबंधी "
-"तथ्य बताएं"
+"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे "
+"बतख संबंधी तथ्य बताएं"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2144,8 +2166,8 @@ msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
 msgstr ""
-"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा नहीं किया "
-"जा सकता।"
+"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा "
+"नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2166,8 +2188,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, जिनमें पिन "
-"की गई चैट्स भी शामिल हैं।"
+"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, "
+"जिनमें पिन की गई चैट्स भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2176,8 +2198,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी चैट को भी "
-"डिलीट कर देगा।"
+"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी "
+"चैट को भी डिलीट कर देगा।"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2215,8 +2237,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा नहीं करते "
-"हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
+"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा "
+"नहीं करते हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2317,7 +2339,7 @@ msgstr "गोपनीय रूप से पूछें"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "गोपनीय रूप से पूछें"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2352,12 +2374,13 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ खोजों के लिए गुमनाम "
-"रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन सकते हैं कि Assist को कितनी बार "
-"दिखाना है: कभी नहीं (यह खोज परिणामों से Assist के UI को पूरी तरह हटा देता है), ऑन-"
-"डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ "
-"तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता "
-"है)। फिलहाल, AI की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
+"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ "
+"खोजों के लिए गुमनाम रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन "
+"सकते हैं कि Assist को कितनी बार दिखाना है: कभी नहीं (यह खोज परिणामों से "
+"Assist के UI को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप "
+"'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे "
+"बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फिलहाल, AI "
+"की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2369,11 +2392,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
-"क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके "
-"क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम "
-"शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद "
-"रखना ज़रूरी है कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, "
+"खोज संबंधी क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, "
+"यह वेब को स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री "
+"से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित "
+"नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद रखना ज़रूरी है कि "
+"जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
 "आधारित होते हैं।"
 
 # smartling.placeholder_format=C
@@ -2466,8 +2490,8 @@ msgstr "चैट खत्म होने के बाद ऑडियो ह
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
 msgstr ""
-"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर नहीं किया जाता "
-"है।"
+"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर "
+"नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2509,14 +2533,16 @@ msgstr "स्वत: उत्तर"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां "
+"हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में "
+"अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2541,9 +2567,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, जानकारी को "
-"गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता है। फिलहाल, Assist केवल "
-"अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, "
+"जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता "
+"है। फिलहाल, Assist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2552,15 +2578,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए DuckAssist "
-"जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल DuckAssist केवल अंग्रेज़ी "
-"क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए "
+"DuckAssist जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल "
+"DuckAssist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू ऑटोप्ले करें।"
+msgstr ""
+"वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू "
+"ऑटोप्ले करें।"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2760,8 +2788,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस और पहचान "
-"बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर उसे अनाम बना देगा।"
+"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस "
+"और पहचान बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर "
+"उसे अनाम बना देगा।"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3142,16 +3171,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने खोज इंजन, ट्रैकर "
-"ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल किया है।"
+"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने "
+"खोज इंजन, ट्रैकर ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s "
+"एक्सटेंशन%3$s में बंडल किया है।"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज इंजन, ट्रैकर "
-"ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल कर दिया है।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज "
+"इंजन, ट्रैकर ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s "
+"में बंडल कर दिया है।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3159,8 +3190,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख ब्राउज़र्स%2$s के लिए "
-"गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, सब कुछ एक ही डाउनलोड में।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख "
+"ब्राउज़र्स%2$s के लिए गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, "
+"सब कुछ एक ही डाउनलोड में।"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3267,11 +3299,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र में) में संग्रहित किया "
-"जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से (क्लाउड में रिमोट सर्वर पर) संग्रहित "
-"करने के लिए अनाम क्लाउड सेव का उपयोग कर सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी "
-"जानकारी क्लाउड में संग्रहित नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं "
-"होगा।"
+"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र "
+"में) में संग्रहित किया जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से "
+"(क्लाउड में रिमोट सर्वर पर) संग्रहित करने के लिए अनाम क्लाउड सेव का उपयोग कर "
+"सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी क्लाउड में संग्रहित "
+"नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं होगा।"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3279,8 +3311,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
-"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
+"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3289,8 +3321,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
-"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
+"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3626,7 +3658,9 @@ msgstr "यूआरएल के दिखाई देने का तरी�
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर देता है"
+msgstr ""
+"जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर "
+"देता है"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3774,11 +3808,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम "
-"ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि मॉडलों को सपोर्ट "
-"करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat बटन और लिंक छिप जाएंगे। "
-"हालांकि, यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
-"Chat का इस्तेमाल कर सकते हैं।"
+"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के "
+"साथ गुमनाम ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि "
+"मॉडलों को सपोर्ट करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat "
+"बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर भी आप "
+"%1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Chat का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3834,7 +3868,8 @@ msgstr "गोपनीय ढंग से चैट करें"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय "
+"ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3842,7 +3877,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय "
+"ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3860,7 +3896,7 @@ msgstr "AI के साथ गोपनीय ढंग से चैट कर
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "लोकप्रिय AI के साथ गोपनीय ढंग से चैट करें"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3911,8 +3947,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर स्टोर की "
-"जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
+"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर "
+"स्टोर की जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3924,10 +3960,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए "
-"जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
-"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई "
-"चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
+"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते "
+"हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट "
+"हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और "
+"रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3950,9 +3987,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर अपलोड की गई "
-"सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर द्वारा गुमनाम रूप से किया "
-"जाता है।"
+"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर "
+"अपलोड की गई सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर "
+"द्वारा गुमनाम रूप से किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -3960,7 +3997,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए स्टोरेज खाली करें।"
+"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए "
+"स्टोरेज खाली करें।"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4125,8 +4163,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस ऐप का "
-"इस्तेमाल करना है"
+"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस "
+"ऐप का इस्तेमाल करना है"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4307,8 +4345,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को लंबे समय तक रख "
-"सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर उन्हें ऑटो-डिलीट कर सकते हैं।"
+"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को "
+"लंबे समय तक रख सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर "
+"उन्हें ऑटो-डिलीट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4318,9 +4357,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए बिना, हाल की "
-"चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के बाद अपने-आप हटाया जा "
-"सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
+"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए "
+"बिना, हाल की चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के "
+"बाद अपने-आप हटाया जा सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4329,8 +4368,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी ब्लॉक लिस्ट को "
-"हमेशा के लिए सेव करें"
+"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी "
+"ब्लॉक लिस्ट को हमेशा के लिए सेव करें"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4339,9 +4378,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप प्रश्न "
-"%1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो OpenAI, Anthropic "
-"और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप "
+"प्रश्न %1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो "
+"OpenAI, Anthropic और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4383,8 +4422,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > प्राथमिकताएं%4$s "
-"(Mac पर) क्लिक करें"
+"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > "
+"प्राथमिकताएं%4$s (Mac पर) क्लिक करें"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4400,7 +4439,9 @@ msgstr "DuckDuckGo एकस्टेंशन को डाउनलोड क�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक करें"
+msgstr ""
+"DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक "
+"करें"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4415,8 +4456,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर %3$sगियर "
-"आइकन%4$s पर क्लिक करें)"
+"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर "
+"%3$sगियर आइकन%4$s पर क्लिक करें)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4433,7 +4474,9 @@ msgstr "ड्रॉपडाउन में %1$sसेटिंग्स%2$s �
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s करें।"
+msgstr ""
+"%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s "
+"करें।"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4446,7 +4489,8 @@ msgstr "%1$sहां%2$s पर क्लिक करें"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक करें"
+"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक "
+"करें"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4508,9 +4552,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटा देता है, लेकिन "
-"यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी खोज सेटिंग रीसेट करें%4$s पर "
-"क्लिक/टैप नहीं कर देते।"
+"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा "
+"हटा देता है, लेकिन यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी "
+"खोज सेटिंग रीसेट करें%4$s पर क्लिक/टैप नहीं कर देते।"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4521,8 +4565,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता है, लेकिन यह "
-"आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स रीसेट%4$s पर क्लिक/टैप नहीं करते।"
+"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता "
+"है, लेकिन यह आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स "
+"रीसेट%4$s पर क्लिक/टैप नहीं करते।"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4591,8 +4636,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर क्लिक करें और "
-"%3$sDuckDuckGo%4$s चुनें।"
+"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर "
+"क्लिक करें और %3$sDuckDuckGo%4$s चुनें।"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4600,8 +4645,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र के ऊपरी दाएं "
-"कोने में होता है।"
+"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र "
+"के ऊपरी दाएं कोने में होता है।"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4647,7 +4692,7 @@ msgstr "बंद करें"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "बंद करें"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4697,7 +4742,7 @@ msgstr "सर्च बंद करें"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "सेकंड ओपिनियन बंद करें"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4802,8 +4847,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा सुरक्षित रख "
-"सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
+"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा "
+"सुरक्षित रख सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5074,7 +5119,7 @@ msgstr "विज्ञापनों को ब्लॉक करना ज�
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "हालिया चैट यहां जारी रखें। या उन्हें Fire Button से डिलीट कर दें।"
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5145,7 +5190,7 @@ msgstr "कूकी का डेटा:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "कॉपी किया गया"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5198,7 +5243,7 @@ msgstr "कोड कॉपी करें"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "लिंक कॉपी करें"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5317,7 +5362,7 @@ msgstr "इमेज बनाएं"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "शेयर लिंक बनाएं"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5368,7 +5413,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
+msgstr "लिंक बनाने से चैट की एक कॉपी बन जाती है जिसे कोई भी खोलकर देख सकता है।"
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5527,7 +5572,7 @@ msgstr "जवाबों को अपनी आवश्यकता अन�
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "जवाबों को कस्टमाइज़ करें"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5602,8 +5647,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट करना "
-"जारी रख सकते हैं।"
+"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट "
+"करना जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5817,7 +5862,7 @@ msgstr "सर्वर डेटा डिलीट करें?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "शेयर किया गया लिंक डिलीट करें"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5829,7 +5874,7 @@ msgstr "ट्रांसक्रिप्ट डिलीट करें"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "चैट डिलीट करें"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5867,7 +5912,7 @@ msgstr "इमेज डिलीट करें?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "मुझे डिलीट करें"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5994,8 +6039,8 @@ msgstr "Duck.ai में डिक्टेशन"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए नहीं "
-"किया जाता है।"
+"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
+"के लिए नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6013,8 +6058,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता है, ताकि आप "
-"बिना टाइप किए भी Duck.ai में चैट कर सकें।"
+"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता "
+"है, ताकि आप बिना टाइप किए भी Duck.ai में चैट कर सकें।"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6181,7 +6226,7 @@ msgstr "प्रमोशन हटाएं"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "टूर खारिज करें"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6326,8 +6371,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा नहीं है और "
-"AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा "
+"नहीं है और AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6336,8 +6381,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI फ़ीचर्स "
-"और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI "
+"फ़ीचर्स और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6397,7 +6442,7 @@ msgstr "DuckDuckGo डाउनलोड करें"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "DuckDuckGo डाउनलोड करें"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6453,8 +6498,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
-"जानकारी के साथ ईमेल लिखें।"
+"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
+"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6463,8 +6508,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
-"जानकारी के साथ ईमेल लिखें।"
+"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
+"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6485,8 +6530,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी में लोगों को "
-"आमंत्रित करने के लिए है।"
+"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी "
+"में लोगों को आमंत्रित करने के लिए है।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6495,8 +6540,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग बढ़ाने की मेरी "
-"रणनीतियों के बारे में लिखना है।"
+"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग "
+"बढ़ाने की मेरी रणनीतियों के बारे में लिखना है।"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6618,7 +6663,7 @@ msgstr "Duck.ai by DuckDuckGo. प्राइवेट AI चैट। मु�
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai अब PDF फ़ाइलें एनालाइज़ कर सकता है। इसे आज़माएं!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6628,9 +6673,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। पेज का कंटेंट "
-"तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग में पेजों को ऑटोमैटिकली अटैच "
-"करने का विकल्प न चुना हो।"
+"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। "
+"पेज का कंटेंट तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग "
+"में पेजों को ऑटोमैटिकली अटैच करने का विकल्प न चुना हो।"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6640,8 +6685,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। कृपया अपनी "
-"ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) करें और फिर से कोशिश करें।"
+"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। "
+"कृपया अपनी ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) "
+"करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6650,8 +6696,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस चैट को अब "
-"कल जारी रखें।"
+"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस "
+"चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6667,8 +6713,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन कंपनी हैं, "
-"जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने हाथ में लेना चाहते हैं।"
+"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन "
+"कंपनी हैं, जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने "
+"हाथ में लेना चाहते हैं।"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6683,8 +6730,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी आसान "
-"होगा: https://duck.ai"
+"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी "
+"आसान होगा: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6699,8 +6746,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम कोड "
-"%1$s को %2$s पर ईमेल करें"
+"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम "
+"कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6721,9 +6768,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता है। इसे बंद करने "
-"से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी %1$sduck.ai%2$s पर जा सकते हैं "
-"सीधे ही।"
+"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता "
+"है। इसे बंद करने से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी "
+"%1$sduck.ai%2$s पर जा सकते हैं सीधे ही।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6734,10 +6781,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा "
-"मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग को बंद करने से "
-"DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर "
-"भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Duck.ai का इस्तेमाल कर सकते हैं।"
+"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
+"सुविधा मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग "
+"को बंद करने से DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, "
+"यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
+"Duck.ai का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6752,8 +6800,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी रख "
-"सकते हैं।"
+"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी "
+"रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6767,14 +6815,14 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता संबंधी कोई जांच "
-"नहीं होती है।"
+"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता "
+"संबंधी कोई जांच नहीं होती है।"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai द्वारा Anthropic, OpenAI और अन्य के मॉडलों को सपोर्ट किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6802,9 +6850,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, बिना साइन "
-"अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, गोपनीयता "
-"केंद्रित AI, बिना खाता AI चैट"
+"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, "
+"बिना साइन अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, "
+"गोपनीयता केंद्रित AI, बिना खाता AI चैट"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6832,12 +6880,13 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास "
-"जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार दिखाना है: कभी नहीं "
-"(यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी "
-"दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब "
-"नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, "
-"DuckAssist सिर्फ़ अमेरिका (अंग्रेज़ी) में उपलब्ध है।"
+"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके "
+"बारे में खास जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार "
+"दिखाना है: कभी नहीं (यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा "
+"देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते "
+"हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई "
+"तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, DuckAssist सिर्फ़ अमेरिका "
+"(अंग्रेज़ी) में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6847,8 +6896,8 @@ msgid ""
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा है जो "
-"OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
+"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा "
+"है जो OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6858,8 +6907,8 @@ msgid ""
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा है जो "
-"OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
+"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा "
+"है जो OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6871,12 +6920,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
-"क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और संबंधित साइटों को "
-"स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे जुड़ी खास जानकारी को जनरेट करने "
-"के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल "
-"इसके जवाब Wikipedia और संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं "
-"की जाती है।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज "
+"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और "
+"संबंधित साइटों को स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे "
+"जुड़ी खास जानकारी को जनरेट करने के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी "
+"का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल इसके जवाब Wikipedia और "
+"संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6890,13 +6939,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज "
-"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके क्वेरी से जुड़ी "
-"सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने "
-"के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा "
-"एक या दो स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, ताकि "
-"आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है कि जवाब, दूसरे "
-"स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर आधारित होते हैं।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम "
+"रहकर, खोज संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को "
+"स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी "
+"जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल "
+"लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा एक या दो "
+"स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, "
+"ताकि आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है "
+"कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"आधारित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6904,8 +6955,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते हैं और इनकी "
-"सटीकता की जांच नहीं की जाती है।"
+"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते "
+"हैं और इनकी सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6914,8 +6965,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। कृपया इस चैट को "
-"अब कल जारी रखें।"
+"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। "
+"कृपया इस चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6924,8 +6975,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
-"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
+"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6934,8 +6985,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
-"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
+"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6944,7 +6995,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
+"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6953,8 +7005,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस "
-"अनाम कोड %1$s को %2$s पर ईमेल करें"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो "
+"कृपया इस अनाम कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6963,7 +7015,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से कोशिश करें।"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7088,8 +7141,9 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी मेटाडेटा जैसी "
-"व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को एनोनिमाइज़ कर देता है।"
+"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी "
+"मेटाडेटा जैसी व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को "
+"एनोनिमाइज़ कर देता है।"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7097,8 +7151,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की %2$s से "
-"सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की "
+"%2$s से सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7107,8 +7161,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से सहमत "
-"होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से "
+"सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7117,9 +7171,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता है, जिसमें "
-"Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर आपको अन्य वेबसाइटों पर "
-"ट्रैक करने की कोशिश करते हैं।"
+"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता "
+"है, जिसमें Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर "
+"आपको अन्य वेबसाइटों पर ट्रैक करने की कोशिश करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7131,11 +7185,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो यह केवल "
-"आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो आपकी डिवाइस उसे हमें "
-"भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर बनाने के लिए करते हैं और फिर हम "
-"तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने "
-"इस तकनीक को कैसे डिज़ाइन किया है, इसके बारे में और जानें%2$s।"
+"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो "
+"यह केवल आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो "
+"आपकी डिवाइस उसे हमें भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर "
+"बनाने के लिए करते हैं और फिर हम तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही "
+"रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने इस तकनीक को कैसे डिज़ाइन "
+"किया है, इसके बारे में और जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7155,8 +7210,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक के बेहतर "
-"परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
+"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक "
+"के बेहतर परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7242,9 +7297,10 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक शब्दों की लंबी "
-"सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों का चयन करते हैं, यह सुनिश्चित "
-"करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर लंबा है।"
+"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक "
+"शब्दों की लंबी सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों "
+"का चयन करते हैं, यह सुनिश्चित करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर "
+"लंबा है।"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7315,8 +7371,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब तैयार "
-"होगा।"
+"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब "
+"तैयार होगा।"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7416,7 +7472,7 @@ msgstr "सबसे ज़्यादा देखी गई साइटे�
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "अभी चालू करें"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7454,8 +7510,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना विचार बदल सकते "
-"हैं।"
+"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना "
+"विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7498,8 +7554,9 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते हैं, लेकिन फिर "
-"भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते हैं।"
+"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते "
+"हैं, लेकिन फिर भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7661,8 +7718,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह आपके नए पासफ्रेज़ के "
-"तहत आपके डेटा को बचाएगा।"
+"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह "
+"आपके नए पासफ्रेज़ के तहत आपके डेटा को बचाएगा।"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7688,8 +7745,8 @@ msgstr "टेक्स्ट डालें"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s उपनाम "
-"%6$s: d%7$s"
+"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s "
+"उपनाम %6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7719,7 +7776,7 @@ msgstr "मनोरंजन गाइड"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "पूरी चैट"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7790,8 +7847,8 @@ msgstr "मैप का विस्तार करें"
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
-"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी की सचमुच "
-"परवाह है।"
+"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी "
+"की सचमुच परवाह है।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7888,13 +7945,13 @@ msgstr "आपत्तिजनक बोल"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai एक्सप्लोर करें"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai एक्सप्लोर करें"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8001,7 +8058,7 @@ msgstr "मुफ़्त"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "मुफ़्त और वैकल्पिक"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8060,8 +8117,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार संंबंधी कार्यों में मदद "
-"मिलती है।"
+"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार "
+"संंबंधी कार्यों में मदद मिलती है।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8070,8 +8127,9 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की कोशिश में मदद "
-"मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे आपने शेयर किया है।"
+"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की "
+"कोशिश में मदद मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे "
+"आपने शेयर किया है।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8079,8 +8137,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी वेबसाइट में कॉपी "
-"पेस्ट करें।"
+"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी "
+"वेबसाइट में कॉपी पेस्ट करें।"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8169,7 +8227,9 @@ msgstr "इमेज खोज परिणामों से AI-जनरे�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर जानें%2$s"
+msgstr ""
+"इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर "
+"जानें%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8247,7 +8307,9 @@ msgstr "अपने नज़दीक के परिणामों को �
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती है।"
+msgstr ""
+"अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती "
+"है।"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8311,8 +8373,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई मेन्यू विकल्प चुनें "
-"या कोई बटन क्लिक करें।"
+"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई "
+"मेन्यू विकल्प चुनें या कोई बटन क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8417,7 +8479,7 @@ msgstr "स्टोरेज खाली करें"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "मुफ़्त और हमेशा गोपनीय"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8460,8 +8522,8 @@ msgstr "व्यावसायिक रूप से शेयर और उ�
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
 msgstr ""
-"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट नहीं की "
-"जाएंगी।"
+"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट "
+"नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8542,8 +8604,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट देखें...</"
-"strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
+"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट "
+"देखें...</strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8894,8 +8956,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस प्राप्त करें, जिसमें "
-"हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
+"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस "
+"प्राप्त करें, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8906,8 +8969,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo सब्सक्रिप्शन के साथ, "
-"जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
+"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo "
+"सब्सक्रिप्शन के साथ, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8936,7 +9000,7 @@ msgstr "कंप्यूटर सहायता प्राप्त कर
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "DuckDuckGo सब्सक्रिप्शन के साथ उपयोग की ज़्यादा लिमिट पाएं।"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8977,13 +9041,15 @@ msgstr "नया वर्ज़न पाएं"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "ऐप प्राप्त करें"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक "
+"करें।%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9005,13 +9071,15 @@ msgstr "यह गाना यहां पाएंः"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr "आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद करें!"
+msgstr ""
+"आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद "
+"करें!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "शुरुआत करने की चेकलिस्ट"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9042,9 +9110,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › टेक्स्ट कोड कॉपी "
-"करें%4$sपर जाएं"
+"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में "
+"जाएं और %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › "
+"टेक्स्ट कोड कॉपी करें%4$sपर जाएं"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9053,8 +9121,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9064,8 +9132,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और इस कोड को स्कैन करें:"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और "
+"इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9075,9 +9144,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या अपनी रिकवरी PDF "
-"पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या "
+"अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9092,8 +9161,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि \"स्थान "
-"सेवाएं\" चालू है।"
+"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि "
+"\"स्थान सेवाएं\" चालू है।"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9102,8 +9171,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे स्क्रॉल करके "
-"%3$sDuckDuckGo%4$s पर जाएं।"
+"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे "
+"स्क्रॉल करके %3$sDuckDuckGo%4$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9699,7 +9768,7 @@ msgstr "टिप्स छिपाएं"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "ट्यूटोरियल छिपाएं"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9786,8 +9855,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist उत्तरों में मुख्य "
-"तथ्यों को हाइलाइट करता है।"
+"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist "
+"उत्तरों में मुख्य तथ्यों को हाइलाइट करता है।"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9814,8 +9883,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s दबाएं%3$s। %4$sफिर "
-"%5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
+"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s "
+"दबाएं%3$s। %4$sफिर %5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9829,8 +9898,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा गोपनीयता "
-"संरक्षण खो देंगे।"
+"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा "
+"गोपनीयता संरक्षण खो देंगे।"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9880,8 +9949,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं और इनका "
-"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते "
+"हैं और इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10023,8 +10092,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह व्यवहारकुशलता से "
-"बात करनी चाहिए और क्या कहना चाहिए?"
+"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह "
+"व्यवहारकुशलता से बात करनी चाहिए और क्या कहना चाहिए?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10146,8 +10215,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ कौन-सी हैं और "
-"क्यों?"
+"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ "
+"कौन-सी हैं और क्यों?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10182,8 +10251,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट > 'स्थान और "
-"गोपनीयता रीसेट करें' पर जाएं%2$s।"
+"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट "
+"> 'स्थान और गोपनीयता रीसेट करें' पर जाएं%2$s।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10193,8 +10262,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > सेटिंग्‍स > साइट सेटिंग्स "
-"> स्थान%2$s पर जाएं, और सुनिश्चित करें कि DuckDuckGo को स्थान एक्सेस की अनुमति है।"
+"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > "
+"सेटिंग्‍स > साइट सेटिंग्स > स्थान%2$s पर जाएं, और सुनिश्चित करें कि "
+"DuckDuckGo को स्थान एक्सेस की अनुमति है।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10209,8 +10279,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज इंजन%4$s "
-"की सूची में जोड़ना होगा"
+"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज "
+"इंजन%4$s की सूची में जोड़ना होगा"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10219,8 +10289,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, तो आप सीधे "
-"%1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
+"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, "
+"तो आप सीधे %1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10229,15 +10299,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर करने के लिए "
-"आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के रूप में अपने डिवाइस पर सेव "
-"कर सकते हैं।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर "
+"करने के लिए आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के "
+"रूप में अपने डिवाइस पर सेव कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें %2$s"
+msgstr ""
+"अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10247,15 +10319,17 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे %1$s या "
-"%2$s संस्करणों का उपयोग करें।"
+"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे "
+"%1$s या %2$s संस्करणों का उपयोग करें।"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ खोलें)"
+msgstr ""
+"अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ "
+"खोलें)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10384,7 +10458,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में सुधार करता है"
+"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में "
+"सुधार करता है"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10397,8 +10472,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों को रीडायरेक्ट करना "
-"आवश्यक है। %1$sऔर जानें%2$s।"
+"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों "
+"को रीडायरेक्ट करना आवश्यक है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10409,8 +10484,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य डिवाइस के "
-"साथ सिंक करें” चुनें।"
+"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य "
+"डिवाइस के साथ सिंक करें” चुनें।"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10425,8 +10500,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते हैं कि हम क्या "
-"जानकारी संग्रहित करते हैं।"
+"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते "
+"हैं कि हम क्या जानकारी संग्रहित करते हैं।"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10762,7 +10837,9 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश बताएं।"
+msgstr ""
+"क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश "
+"बताएं।"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10813,7 +10890,8 @@ msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा बार) ठीक है"
+"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा "
+"बार) ठीक है"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10832,9 +10910,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और Microsoft के विज्ञापन "
-"नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे मर्चेंट लैंडिंग पेज पर ले जाते हैं और "
-"विज्ञापनों के विपरीत, DuckDuckGo को इन परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
+"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और "
+"Microsoft के विज्ञापन नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे "
+"मर्चेंट लैंडिंग पेज पर ले जाते हैं और विज्ञापनों के विपरीत, DuckDuckGo को इन "
+"परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10843,8 +10922,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और अधिक सुरक्षित "
-"भी है।"
+"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और "
+"अधिक सुरक्षित भी है।"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11316,6 +11395,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की "
+"सुविधा देता है"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11391,7 +11472,7 @@ msgstr "लाइनआउट जीते"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "लिंक 7 दिनों में समाप्त हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11407,7 +11488,9 @@ msgstr "लिंक्स:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी लिस्ट दें।"
+msgstr ""
+"इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी "
+"लिस्ट दें।"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12045,8 +12128,8 @@ msgstr "माइक्रोनेशिया"
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
 msgstr ""
-"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की अनुमति दें और फिर "
-"से प्रयास करें।"
+"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की "
+"अनुमति दें और फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12489,7 +12572,7 @@ msgstr "20 मिनट से ज़्यादा"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "और टिप्स"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12812,10 +12895,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से "
-"DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को "
-"रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और "
-"नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और "
+"अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
+"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से "
+"पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी "
+"स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12982,7 +13066,7 @@ msgstr "नहीं, धन्यवाद"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "नहीं, धन्यवाद"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13637,8 +13721,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s आइकन "
-"> सेटिंग्स%5$s पर क्लिक करें"
+"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s "
+"आइकन > सेटिंग्स%5$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13650,7 +13734,7 @@ msgstr "चालू लेकिन कोई संख्या नहीं"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "ऑनबोर्डिंग पूरी हुई"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13666,8 +13750,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया %1$s पेज या उससे "
-"कम वाली फ़ाइलें अपलोड करें।"
+"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया "
+"%1$s पेज या उससे कम वाली फ़ाइलें अपलोड करें।"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13694,8 +13778,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल पैरामीटर%2$s पेज "
-"पर है।"
+"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल "
+"पैरामीटर%2$s पेज पर है।"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13710,7 +13794,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में फिर से प्रयास करें।"
+"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में "
+"फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13867,7 +13952,7 @@ msgstr "इमेज बनाने और एडिट करने के स
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "शुरुआत करने की चेकलिस्ट खोलें"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14033,8 +14118,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में हो। हम आपको — "
-"अवधि में ट्रैक नहीं करते हैं।"
+"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में "
+"हो। हम आपको — अवधि में ट्रैक नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14047,8 +14132,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर नहीं "
-"करते हैं।"
+"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर "
+"नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14056,8 +14141,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, एनक्रिप्शन "
-"एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
+"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, "
+"एनक्रिप्शन एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14310,8 +14395,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, ब्राउज़र "
-"फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
+"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, "
+"ब्राउज़र फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14511,9 +14596,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो AI की मदद से "
-"दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। उन्हें बंद "
-"करने और Assist बटन छिपाने के लिए %1$sखोज सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो AI की मदद से दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर "
+"जवाब अक्सर मिलते हैं। उन्हें बंद करने और Assist बटन छिपाने के लिए %1$sखोज "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14522,9 +14608,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
-"के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इस फ़ीचर के काम करने के "
-"तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, %1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो DuckAssist के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। "
+"इस फ़ीचर के काम करने के तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, "
+"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14534,9 +14621,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
-"अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इसे बंद करने और "
-"Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist Settings%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो DuckAssist अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते "
+"हैं। इसे बंद करने और Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist "
+"Settings%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14569,8 +14657,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, Mistral, "
-"वगैरह।"
+"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, "
+"Mistral, वगैरह।"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14589,7 +14677,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा उपलब्ध नहीं होगी।"
+"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा "
+"उपलब्ध नहीं होगी।"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14602,8 +14691,8 @@ msgstr "कोई विशिष्ट समस्या चुनें"
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए निर्देशों का "
-"पालन करें।"
+"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए "
+"निर्देशों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14615,7 +14704,7 @@ msgstr "पिन"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "चैट पिन करें"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14627,7 +14716,7 @@ msgstr "%1$s %2$s से चैट्स को यहां पिन करे
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "मुझे पिन करें"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14650,7 +14739,7 @@ msgstr "पिन किया गया"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "पिन की गई चैट्स आपकी हालिया चैट्स में सबसे ऊपर दिखाई देंगी।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14692,8 +14781,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया निम्नलिखित "
-"चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया "
+"निम्नलिखित चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14702,8 +14791,8 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया निम्नलिखित चुनौती "
-"को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया "
+"निम्नलिखित चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14736,8 +14825,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट सेशन डिलीट हो "
-"जाएगा।"
+"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट "
+"सेशन डिलीट हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14746,8 +14835,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
-"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या गैरकानूनी है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
+"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या "
+"गैरकानूनी है।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14756,8 +14846,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
-"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या नुकसानदेह है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
+"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या "
+"नुकसानदेह है।"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14910,8 +15001,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
-"प्रभावित नहीं करेगा।"
+"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या "
+"सुझावों को प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14974,6 +15065,8 @@ msgstr "खराब फॉर्मेटिंग"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा "
+"अनाम की गईं।"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15187,7 +15280,7 @@ msgstr "पिछले टैब"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "पिछले टिप्स"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15483,8 +15576,8 @@ msgstr "मुझे प्रॉम्प्ट करें"
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
 msgstr ""
-"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के लिए प्रेरित "
-"करें।"
+"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के "
+"लिए प्रेरित करें।"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15503,7 +15596,8 @@ msgstr "खोजते और ब्राउज़ करते समय अ�
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
 msgstr ""
-"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को सुरक्षित रखें।"
+"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को "
+"सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15528,7 +15622,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का टेक्स्ट यहां डालें।]"
+"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का "
+"टेक्स्ट यहां डालें।]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15733,13 +15828,15 @@ msgstr "मॉडल में मौजूद मीडियम मॉडर�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "रीज़निंग जटिल सवालों के बेहतर जवाब दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 "
+"गुना तेज़ी से होता है। %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15780,7 +15877,7 @@ msgstr "हालिया चैट स्टोरेज को %1$s में
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "हालिया चैट"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15789,8 +15886,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
-"पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
+"स्थानीय स्तर पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15799,8 +15896,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
-"पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
+"स्थानीय स्तर पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15810,9 +15907,10 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
-"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि "
-"आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके।"
+"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स "
+"भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर "
+"पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया "
+"जा सके।"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15940,7 +16038,7 @@ msgstr "उपयोग कम करें"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "अधिक कुशल मॉडल काम में लाएं और कुल उपयोग घटाएं"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15948,8 +16046,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट के आकार को "
-"घटाता है"
+"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट "
+"के आकार को घटाता है"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16090,8 +16188,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने ब्राउज़र के &quot;"
-"रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
+"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने "
+"ब्राउज़र के &quot;रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16181,8 +16279,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई देते "
-"हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप "
+"से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16190,8 +16288,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई "
-"देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर "
+"स्वचालित रूप से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित "
+"होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16249,9 +16348,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए DuckDuckGo को "
-"भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए आपकी अनाम प्रतिक्रिया भी "
-"%1$s के साथ शेयर की जाती है।"
+"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए "
+"DuckDuckGo को भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए "
+"आपकी अनाम प्रतिक्रिया भी %1$s के साथ शेयर की जाती है।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16259,8 +16358,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
-"पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई "
+"भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16269,9 +16368,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें आपने इस पेज लोड के "
-"दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
-"पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें "
+"आपने इस पेज लोड के दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने "
+"फ़ीडबैक में कोई भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16321,7 +16420,7 @@ msgstr "सभी सेटिंग्स को रीसेट करें"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "ट्यूटोरियल रीसेट करें"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16339,7 +16438,7 @@ msgstr "रिज़ॉल्यूशन"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "जवाब"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16363,9 +16462,10 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। AI की मदद से दिए गए "
-"जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन हैं।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। AI की मदद से दिए गए जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16374,9 +16474,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। DuckAssist हमारी "
-"%1$sसेवा की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। DuckAssist हमारी %1$sसेवा की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16386,10 +16486,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। ये वेब सामग्री के आधार "
-"पर तैयार किए जाते हैं और इनमें कुछ गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा "
-"की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। ये वेब सामग्री के आधार पर तैयार किए जाते हैं और इनमें कुछ "
+"गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा की शर्तों%2$s के अधीन "
+"है।"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16466,7 +16567,8 @@ msgstr "परिणामों में ब्लॉक की गई सा�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में मैनेज कर सकते हैं।"
+"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में "
+"मैनेज कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16815,8 +16917,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और एन्क्रिप्टेड स्टोरेज के "
-"साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
+"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और "
+"एन्क्रिप्टेड स्टोरेज के साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16829,7 +16931,9 @@ msgstr "अपनी सबसे हाल की 30 चैट तक को �
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच सुरक्षित रखें।"
+msgstr ""
+"एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच "
+"सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16977,8 +17081,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या %5$sनया जोड़ें%6$s) "
-"क्लिक करें"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या "
+"%5$sनया जोड़ें%6$s) क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16987,8 +17091,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर क्लिक करें (या %5$sनया "
-"जोड़ें%6$s)।"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर "
+"क्लिक करें (या %5$sनया जोड़ें%6$s)।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17007,8 +17111,8 @@ msgstr "नीचे स्क्रॉल करें और सूची म�
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह आपकी लोकेशन "
-"यानी स्थान का इस्तेमाल कर सके।"
+"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह "
+"आपकी लोकेशन यानी स्थान का इस्तेमाल कर सके।"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17042,7 +17146,7 @@ msgstr "आपके नज़दीक के परिणामों को �
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "सर्च और Duck.ai टॉगल"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17068,11 +17172,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा करने के लिए "
-"यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक संक्षिप्त जवाब तैयार करता है। "
-"आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी नहीं, केवल मांग पर (जब आप 'Assist' पर "
-"क्लिक करें), कभी-कभी (जब यह बहुत प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू "
-"हो)। फिलहाल, Search Assist केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
+"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा "
+"करने के लिए यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक "
+"संक्षिप्त जवाब तैयार करता है। आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी "
+"नहीं, केवल मांग पर (जब आप 'Assist' पर क्लिक करें), कभी-कभी (जब यह बहुत "
+"प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू हो)। फिलहाल, Search Assist "
+"केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17080,8 +17185,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय जानकारी नहीं "
-"मिली। कुछ और सर्च करके देखें।"
+"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय "
+"जानकारी नहीं मिली। कुछ और सर्च करके देखें।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17090,9 +17195,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब तैयार करता "
-"है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि संबंधित सामग्री मिल सके, "
-"और फिर मिली जानकारी के आधार पर AI की मदद से एक संक्षिप्त उत्तर तैयार करता है।"
+"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब "
+"तैयार करता है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि "
+"संबंधित सामग्री मिल सके, और फिर मिली जानकारी के आधार पर AI की मदद से एक "
+"संक्षिप्त उत्तर तैयार करता है।"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17213,8 +17319,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे Wikipedia पर "
-"“ducks” को खोजा जाएगा।"
+"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे "
+"Wikipedia पर “ducks” को खोजा जाएगा।"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17233,8 +17339,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र में गोपनीय वेब खोज "
-"जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
+"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र "
+"में गोपनीय वेब खोज जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17242,8 +17348,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट अनुरोध का उपयोग "
-"होगा)"
+"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट "
+"अनुरोध का उपयोग होगा)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17255,11 +17361,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल स्टोरेज में रखा जाता "
-"है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके अपनी सेटिंग को क्लाउड में किसी "
-"रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान "
-"योग्य जानकारी स्टोर नहीं की जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं "
-"जाएगा।"
+"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल "
+"स्टोरेज में रखा जाता है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके "
+"अपनी सेटिंग को क्लाउड में किसी रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते "
+"हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान योग्य जानकारी स्टोर नहीं की "
+"जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं जाएगा।"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17362,8 +17468,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17372,8 +17478,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17382,8 +17488,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17392,8 +17498,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप से स्टोर करें, और "
-"उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप "
+"से स्टोर करें, और उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17408,14 +17514,14 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर किया गया। आपके "
-"अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर "
+"किया गया। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "हमारे एन्क्रिप्टेड सर्वर पर सुरक्षित रूप से स्टोर किया गया।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17559,7 +17665,9 @@ msgstr "Safari मेनू से %1$s'इस वेबसाइट के ल�
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज करें"
+msgstr ""
+"%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज "
+"करें"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17569,13 +17677,17 @@ msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट �
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें"
+msgstr ""
+"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
+"करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें।"
+msgstr ""
+"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
+"करें।"
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17624,7 +17736,8 @@ msgstr "ड्रॉपडाउन मेनू से %1$sएड-ऑन प्
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) "
+"चुनें"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17632,7 +17745,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) "
+"चुनें"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17697,8 +17811,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी पसंद का कोई "
-"एक विकल्प) चुनें"
+"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी "
+"पसंद का कोई एक विकल्प) चुनें"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17820,8 +17934,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब देना है। ये निर्देश आगे "
-"चलकर आपके सभी वार्तालापों पर लागू होंगे।"
+"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब "
+"देना है। ये निर्देश आगे चलकर आपके सभी वार्तालापों पर लागू होंगे।"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17922,7 +18036,7 @@ msgstr "होमपेज के रूप में बनाएं"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Duck.ai के जवाबों का लहजा और स्टाइल सेट करें।"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -17937,8 +18051,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी डिवाइसों पर "
-"सिंक रख सकें।"
+"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी "
+"डिवाइसों पर सिंक रख सकें।"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17993,13 +18107,13 @@ msgstr "सेशल्स"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "शेयर करें"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "शेयर करें"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18037,15 +18151,16 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की सटीकता बेहतर "
-"हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं बताता है।"
+"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की "
+"सटीकता बेहतर हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं "
+"बताता है।"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "चैट शेयर करें"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18109,7 +18224,7 @@ msgstr "सकारात्मक फ़ीडबैक शेयर करे
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "शेयर स्कोप"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18134,8 +18249,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और हानिकारक "
-"रिपोर्ट के लिए आवश्यक है)"
+"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और "
+"हानिकारक रिपोर्ट के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18250,7 +18365,7 @@ msgstr "विवरण दिखाएं"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Duck.ai ट्यूटोरियल दिखाएं"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18262,7 +18377,8 @@ msgstr "DuckAssist <sup>बीटा</sup> दिखाएं"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर सकते हैं।)"
+"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर "
+"सकते हैं।)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18404,7 +18520,7 @@ msgstr "ज़्यादा दिखाएं"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "अधिक मॉडल दिखाएं"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18445,7 +18561,7 @@ msgstr "साइडबार दिखाएं"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Duck.ai का ज़्यादा से ज़्यादा लाभ उठाने के लिए स्टेप-बाय-स्टेप टिप्स दिखाएं।"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18500,9 +18616,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
-"गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की गोपनीयता "
-"प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
+"खोज गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की "
+"गोपनीयता प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18510,9 +18626,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
-"हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज सुरक्षा "
-"प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
+"खोज हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे "
+"खोज सुरक्षा प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18550,7 +18666,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर दिखाता है"
+"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर "
+"दिखाता है"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18820,7 +18937,7 @@ msgstr "कुछ गड़बड़ हुई है, कृपया बाद
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "कुछ गड़बड़ हुई है। कृपया फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18838,7 +18955,9 @@ msgstr "कभी-कभी"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों में बताएं।"
+msgstr ""
+"माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों "
+"में बताएं।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18877,8 +18996,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी इमेज या फ़ॉर्मेट "
-"आज़माएं।"
+"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी "
+"इमेज या फ़ॉर्मेट आज़माएं।"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18887,7 +19006,8 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन किया गया है।"
+"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन "
+"किया गया है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18902,14 +19022,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने के लिए, %1$sयहाँ "
-"क्लिक करें%2$s।"
+"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने "
+"के लिए, %1$sयहाँ क्लिक करें%2$s।"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास करें।"
+msgstr ""
+"क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18964,8 +19086,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा हिस्सा चुनकर फिर से "
-"प्रयास करें।"
+"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा "
+"हिस्सा चुनकर फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19117,7 +19239,7 @@ msgstr "साप्ताहिक सीमा का इस्तेमाल
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "नई चैट शुरू करें"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19315,8 +19437,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक इमेज बनाने "
-"के लिए बाद में वापस आएं।"
+"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक "
+"इमेज बनाने के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19385,8 +19507,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' वाले कार्ड पर "
-"लिखने के लिए वाक्य सुझाएं?"
+"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' "
+"वाले कार्ड पर लिखने के लिए वाक्य सुझाएं?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19703,7 +19825,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "इस सेकंड ओपिनियन पर स्विच करें"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19717,8 +19839,8 @@ msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
 msgstr ""
-"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर विज़िबिलिटी ज़ीरो "
-"होगी"
+"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर "
+"विज़िबिलिटी ज़ीरो होगी"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19773,7 +19895,8 @@ msgstr "Sync & Backup चालू है!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
+"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा "
+"सकता।"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19822,25 +19945,26 @@ msgid ""
 msgstr ""
 "सिंक रिकवरी कोड\n"
 "\n"
-" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai चैट को "
-"सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक किया हुआ डेटा "
-"रिकवर कर सकते हैं।\n"
+" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai "
+"चैट को सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक "
+"किया हुआ डेटा रिकवर कर सकते हैं।\n"
 "\n"
 "इस जानकारी को सुरक्षित और गोपनीय रखें।\n"
-"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस कर सकता "
-"है।\n"
+"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस "
+"कर सकता है।\n"
 "\n"
 "%1$s\n"
 "\n"
 "यह कोड कैसे काम करता है?\n"
 "1. अपने ब्राउज़र में Duck.ai पर जाएं और Duck.ai सेटिंग खोलें।\n"
-"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" चुनें\n"
-"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड यहां पेस्ट "
-"करें\" कहा गया है\n"
+"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" "
+"चुनें\n"
+"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड "
+"यहां पेस्ट करें\" कहा गया है\n"
 "\n"
-"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक DuckDuckGo "
-"ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट कर दिया जाएगा और उसे "
-"रीस्टोर नहीं किया जा सकेगा।"
+"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक "
+"DuckDuckGo ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट "
+"कर दिया जाएगा और उसे रीस्टोर नहीं किया जा सकेगा।"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19864,7 +19988,7 @@ msgstr "सिंक और बैकअप की सुविधा अभी 
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "डिवाइसों पर चैट्स सिंक करें"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19960,6 +20084,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे "
+"हमारे मुफ़्त ऐप में पाएं।"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -19968,6 +20094,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से "
+"एक्सेस के लिए इसे हमारे मुफ़्त ब्राउज़र में पाएं।"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20205,9 +20333,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई जानकारी को "
-"किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम मामलों में इसमें पासवर्ड, "
-"या भुगतान विवरण शामिल होते हैं।"
+"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई "
+"जानकारी को किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम "
+"मामलों में इसमें पासवर्ड, या भुगतान विवरण शामिल होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20216,8 +20344,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी सेटिंग्स में कोई भी "
-"बदलाव करने की अनुमति देता है।"
+"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी "
+"सेटिंग्स में कोई भी बदलाव करने की अनुमति देता है।"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20247,8 +20375,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और सिर्फ़ आप ही इसे एक्सेस "
-"कर सकते हैं।"
+"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और "
+"सिर्फ़ आप ही इसे एक्सेस कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20328,8 +20456,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी ब्राउज़र सेटिंग जांचें "
-"और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
+"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी "
+"ब्राउज़र सेटिंग जांचें और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20344,8 +20472,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से पहले कुछ "
-"मिनट इंतज़ार करें।"
+"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से "
+"पहले कुछ मिनट इंतज़ार करें।"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20364,9 +20492,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर ब्लॉक करके, "
-"संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका डिफ़ॉल्ट खोज इंजन बनाकर "
-"गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
+"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर "
+"ब्लॉक करके, संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका "
+"डिफ़ॉल्ट खोज इंजन बनाकर गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20404,7 +20532,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की कोशिश करें।"
+"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20413,8 +20542,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए वर्ज़न के साथ नई "
-"चैट शुरू करें।"
+"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए "
+"वर्ज़न के साथ नई चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20432,7 +20561,7 @@ msgstr "इस माह"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "यह जवाब"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20444,7 +20573,7 @@ msgstr "इस सप्ताह"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "यह चैट Duck.ai में ही रहती है और यह केवल आपके तक ही सीमित रहती है।"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20453,8 +20582,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की गई। "
-"AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %4$s देखें)।"
+"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की "
+"गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
+"लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20464,8 +20594,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई चैट में गलत "
-"या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %2$s देखें)."
+"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई "
+"चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए "
+"%2$s देखें)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20474,8 +20605,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक जानकारी भी "
-"प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
+"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक "
+"जानकारी भी प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20485,9 +20616,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के जरिए "
-"जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
-"लिए %4$s देखें)।"
+"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के "
+"जरिए जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है "
+"(ज़्यादा जानकारी के लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20559,7 +20690,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
+"करें"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20567,7 +20699,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें।"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20581,6 +20714,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स "
+"में सबसे ऊपर रखने के लिए 'पिन करें' चुनें!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20589,6 +20724,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button "
+"का इस्तेमाल करें!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20609,8 +20746,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य मॉडल प्रदाता "
-"'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य "
+"मॉडल प्रदाता 'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20619,8 +20756,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल प्रदाता "
-"'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल "
+"प्रदाता 'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20657,8 +20794,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के साथ सेव करता है, "
-"जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
+"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के "
+"साथ सेव करता है, जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20667,8 +20804,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
-"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
+"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20678,9 +20816,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
-"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं। हालांकि, %1$s पर "
-"हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने वाले जवाब कभी नहीं दिखाता।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
+"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
+"सकते हैं। हालांकि, %1$s पर हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने "
+"वाले जवाब कभी नहीं दिखाता।"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20709,7 +20848,9 @@ msgstr "यह वीडियो अब तक यहां देखे जा
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता है।"
+msgstr ""
+"यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता "
+"है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20719,8 +20860,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup डिस्कनेक्ट "
-"हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी चैट एक्सेस कर पाएंगे।"
+"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup "
+"डिस्कनेक्ट हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी "
+"चैट एक्सेस कर पाएंगे।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20729,15 +20871,16 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे पहले जैसा "
-"नहीं किया जा सकता है।"
+"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे "
+"पहले जैसा नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
 msgstr ""
-"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा सकता है।"
+"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा "
+"सकता है।"
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20860,8 +21003,7 @@ msgstr "जारी रखने के लिए, आपको Duck.ai की 
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
+msgstr "जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20870,8 +21012,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप प्रिंट करना "
-"चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
+"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप "
+"प्रिंट करना चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20881,9 +21023,10 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत होगी जिसे "
-"आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर PDF के रूप में सेव "
-"किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync सेटअप करने के लिए किया था।"
+"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत "
+"होगी जिसे आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर "
+"PDF के रूप में सेव किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync "
+"सेटअप करने के लिए किया था।"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20892,8 +21035,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo ब्राउज़र को "
-"नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
+"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo "
+"ब्राउज़र को नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20901,8 +21044,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को माइक्रोफ़ोन का "
-"एक्सेस दें।"
+"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को "
+"माइक्रोफ़ोन का एक्सेस दें।"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20925,6 +21068,8 @@ msgstr "आज"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल "
+"करें।%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21098,8 +21243,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ करते रहें और देखें "
-"हम कितनों को ब्लॉक करते हैं।"
+"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ "
+"करते रहें और देखें हम कितनों को ब्लॉक करते हैं।"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21146,7 +21291,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में कैसे पहुंचूं?\""
+msgstr ""
+"फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में "
+"कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21155,7 +21302,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी सिनेमा हॉल तक कैसे पहुंचूं?\""
+"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी "
+"सिनेमा हॉल तक कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21338,7 +21486,7 @@ msgstr "इन्हें आज़माएं"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "कोई दूसरा मॉडल आज़माएं"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21349,7 +21497,7 @@ msgstr "खोज करने का प्रयास करें।"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "कोई सुझाव आज़माएं"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21385,7 +21533,8 @@ msgstr "अलग कीवर्ड आज़माएं।"
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी अक्षम करें।"
+"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी "
+"अक्षम करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21418,7 +21567,7 @@ msgstr "मुफ़्त में आज़माएं"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "मुफ़्त में आज़माएं"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21438,7 +21587,7 @@ msgstr "मुफ़्त में आज़माएं! एक सुरक�
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "7 दिनों के लिए मुफ़्त में आज़माएं"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21471,7 +21620,7 @@ msgstr "हमारा होमपेज आज़माएं जो कभ�
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "रीज़निंग को आज़माएं"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21547,7 +21696,8 @@ msgstr "हाल ही में जोड़े गए ओपन-सोर्
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
 msgstr ""
-"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को आजमाएं"
+"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को "
+"आजमाएं"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -21587,8 +21737,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
-"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
+"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21597,8 +21747,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
-"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
+"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21723,7 +21873,7 @@ msgstr "YouTube को बिना लक्षित विज्ञापन�
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Duck.ai टॉगल चालू करें"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21787,8 +21937,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और दिखाई देने वाले "
-"उत्तर के बीच थोड़ा समय लग सकता है।"
+"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और "
+"दिखाई देने वाले उत्तर के बीच थोड़ा समय लग सकता है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21918,8 +22068,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर %5$sसेट "
-"पेज%6$s पर क्लिक करें।"
+"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर "
+"%5$sसेट पेज%6$s पर क्लिक करें।"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -21927,8 +22077,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: https://duckduckgo."
-"com"
+"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21960,7 +22110,9 @@ msgstr "%1$sसर्च%2$s सेक्शन के नीचे, %3$sसर�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s चुनें"
+msgstr ""
+"स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s "
+"चुनें"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22044,8 +22196,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 गुना ज़्यादा "
-"उपयोग सीमाएं अनलॉक करें।"
+"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 "
+"गुना ज़्यादा उपयोग सीमाएं अनलॉक करें।"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22091,7 +22243,7 @@ msgstr "अपने सब्सक्रिप्शन के जरिए �
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "एडवांस्ड मॉडल्स अनलॉक करें"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22185,8 +22337,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने के लिए "
-"DuckDuckGo ब्राउज़र को अपडेट करें"
+"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने "
+"के लिए DuckDuckGo ब्राउज़र को अपडेट करें"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22311,14 +22463,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज बनाने के लिए "
-"बाद में वापस आएं।"
+"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज "
+"बनाने के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में अपग्रेड करें"
+msgstr ""
+"Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में "
+"अपग्रेड करें"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22414,9 +22568,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को हैकर्स, "
-"स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। मुफ़्त। किसी खाते की ज़रूरत "
-"नहीं है।"
+"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को "
+"हैकर्स, स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। "
+"मुफ़्त। किसी खाते की ज़रूरत नहीं है।"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22456,7 +22610,7 @@ msgstr "Safari में इस्तेमाल करें"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "हिस्ट्री से किसी चैट को डिलीट करने के लिए Fire Button का इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22465,8 +22619,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस कोड का "
-"इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस "
+"कोड का इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22474,8 +22628,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने के लिए इस "
-"कोड का इस्तेमाल करें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने "
+"के लिए इस कोड का इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -22625,8 +22779,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को Microsoft के "
-"विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को "
+"Microsoft के विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22635,8 +22789,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक TripAdvisor के "
-"विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक "
+"TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22648,8 +22802,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist सेटिंग%2$s "
-"पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22658,8 +22812,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sDuckAssist "
-"सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए "
+"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22668,7 +22822,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का पालन करें।"
+"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का "
+"पालन करें।"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22684,8 +22839,8 @@ msgid ""
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
 "अपने दूसरे ब्राउज़र में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > %3$sSync & "
-"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के साथ सिंक "
-"करें%8$s को चुनें।"
+"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के "
+"साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22695,9 +22850,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & Backup के "
-"अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी "
-"रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & "
+"Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक "
+"करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22707,9 +22862,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > "
-"%3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस "
-"के साथ सिंक करें%8$s को चुनें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai "
+"सेटिंग%2$s > %3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद "
+"%7$sकिसी दूसरे डिवाइस के साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22719,9 +22874,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। "
-"Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" "
-"को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की "
+"सेटिंग खोलें। Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी "
+"दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड "
+"स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22774,8 +22930,8 @@ msgstr "वॉयस चैट समाप्त हो गई"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए "
-"नहीं किया जाता है।"
+"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
+"के लिए नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22919,8 +23075,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को YouTube "
-"अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
+"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को "
+"YouTube अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22940,9 +23096,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है क्योंकि हमें वहाँ "
-"से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र कंपनी है और इसका YouTube से कोई "
-"संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए जाते हैं।"
+"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है "
+"क्योंकि हमें वहाँ से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र "
+"कंपनी है और इसका YouTube से कोई संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए "
+"जाते हैं।"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22955,8 +23112,8 @@ msgstr "हम गुमनाम करते हैं"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को गुमनाम रख "
-"सकते हैं।"
+"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को "
+"गुमनाम रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22968,9 +23125,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की रिपोर्ट करने "
-"के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम जांच कर सकें और समस्या "
-"का समाधान कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की "
+"रिपोर्ट करने के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम "
+"जांच कर सकें और समस्या का समाधान कर सकें।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22982,16 +23139,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की रिपोर्ट "
-"करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस मामले की जांच करके उसे "
-"ठीक कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की "
+"रिपोर्ट करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस "
+"मामले की जांच करके उसे ठीक कर सकें।"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल कर सकते हैं।"
+"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -22999,7 +23157,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक एन्क्रिप्टेड है।"
+"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक "
+"एन्क्रिप्टेड है।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23011,7 +23170,8 @@ msgstr "हम विज्ञापनों के साथ आपको फ�
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
 msgstr ""
-"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं करते हैं।"
+"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं "
+"करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23028,8 +23188,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं करते हैं। "
-"हम आपको ट्रैक नहीं करते हैं। कभी भी।"
+"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं "
+"करते हैं। हम आपको ट्रैक नहीं करते हैं। कभी भी।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23043,8 +23203,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां वापस क्यों आए "
-"हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां "
+"वापस क्यों आए हैं:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23053,8 +23213,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस वजह से हमें "
-"आज़माना चाहते हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस "
+"वजह से हमें आज़माना चाहते हैं:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23094,8 +23254,9 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे विज्ञापनकर्ताओं को बेचने "
-"के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते हैं।"
+"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे "
+"विज्ञापनकर्ताओं को बेचने के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23121,8 +23282,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके कि आपकी चैट्स "
-"का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
+"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके "
+"कि आपकी चैट्स का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23147,8 +23308,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, आपके डेटा का "
-"फायदा उठाकर नहीं।"
+"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, "
+"आपके डेटा का फायदा उठाकर नहीं।"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23157,19 +23318,23 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते हैं। आप अक्‍सर "
-"बाद में अपना विचार बदल सकते हैं।"
+"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते "
+"हैं। आप अक्‍सर बाद में अपना विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते हैं।"
+msgstr ""
+"हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल हैं।"
+msgstr ""
+"हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23185,15 +23350,16 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा सके। "
-"%1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार तुरंत परिणामों में "
-"दिखाई ना दें।"
+"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा "
+"सके। %1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार "
+"तुरंत परिणामों में दिखाई ना दें।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले ट्रैकर्स को ब्लॉक कर देंगे।"
+"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले "
+"ट्रैकर्स को ब्लॉक कर देंगे।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23202,8 +23368,9 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। अगर आपको "
-"यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क करें।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
+"हैं। अगर आपको यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23212,8 +23379,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। कभी-कभी "
-"अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
+"हैं। कभी-कभी अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23228,7 +23395,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार मेहनत कर रहे हैं।"
+"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार "
+"मेहनत कर रहे हैं।"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23237,8 +23405,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज फिर से लोड "
-"करना होगा।"
+"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज "
+"फिर से लोड करना होगा।"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23338,7 +23506,9 @@ msgstr "साप्ताहिक उपयोग सीमा पूरी �
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
+msgstr ""
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23347,8 +23517,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट करना "
-"जारी रख सकते हैं।"
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट "
+"करना जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23362,8 +23532,9 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं "
-"और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
+"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं "
+"किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23372,8 +23543,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
-"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम "
+"उन्हें अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए "
+"नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23383,16 +23555,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित करता है। "
-"यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं करता है या उनका "
-"उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
+"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित "
+"करता है। यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं "
+"करता है या उनका उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर सकते हैं।"
+"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23460,8 +23633,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई है। पेज को "
-"रीलोड करने की कोशिश करें।"
+"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई "
+"है। पेज को रीलोड करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23496,7 +23669,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए कुछ विकल्प बताएं।"
+"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए "
+"कुछ विकल्प बताएं।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23515,11 +23689,12 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र डाउनलोड करने के "
-"क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही संदर्भ लें। जवाब को स्पष्ट हिस्सों में "
-"बांटें और हर हिस्से के लिए शीर्षक दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर "
-"विशेष ध्यान दिया गया हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी "
-"अनुभव रखने वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
+"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र "
+"डाउनलोड करने के क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही "
+"संदर्भ लें। जवाब को स्पष्ट हिस्सों में बांटें और हर हिस्से के लिए शीर्षक "
+"दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर विशेष ध्यान दिया गया "
+"हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी अनुभव रखने "
+"वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23634,7 +23809,7 @@ msgstr "आप किस वजह से वापस आए हैं?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "आप क्या कर सकते हैं?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23755,7 +23930,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग होता है?"
+"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग "
+"होता है?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23831,8 +24007,8 @@ msgstr "आप किस पर फीडबैक देना चाहें�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को प्रभावित नहीं "
-"करेगा।"
+"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
+"प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23858,8 +24034,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद ब्रांडों पर "
-"विचार करना चाहिए?"
+"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद "
+"ब्रांडों पर विचार करना चाहिए?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24060,6 +24236,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए "
+"चैट का इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24314,8 +24493,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे दोबारा प्राप्त "
-"नहीं किया जा सकता है।"
+"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे "
+"दोबारा प्राप्त नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24335,7 +24514,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
+"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24344,8 +24524,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके DuckDuckGo "
-"से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
+"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके "
+"DuckDuckGo से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24359,8 +24539,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या इसे कभी भी "
-"बंद कर सकते हैं।"
+"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या "
+"इसे कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24369,22 +24549,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते हैं या इसे "
-"कभी भी बंद कर सकते हैं।"
+"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते "
+"हैं या इसे कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का भी इस्तेमाल "
-"कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का "
+"भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI Chat%2$s "
-"का भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI "
+"Chat%2$s का भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24398,8 +24578,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में जाकर बदल "
-"सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
+"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में "
+"जाकर बदल सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24420,8 +24600,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है और चाहे तो पहली "
-"सेटिंग को डिलीट भी कर सकते हैं।"
+"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है "
+"और चाहे तो पहली सेटिंग को डिलीट भी कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24493,7 +24673,7 @@ msgstr "प्रति बातचीत अधिकतम %1$s इमेज 
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "आप एक बार में सिर्फ़ %1$s टैब ही अटैच कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24514,8 +24694,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको पहले किसी "
-"अन्य साइट को अनब्लॉक करना होगा।"
+"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको "
+"पहले किसी अन्य साइट को अनब्लॉक करना होगा।"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24572,8 +24752,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में 2 गुना "
-"ज़्यादा उपयोग सीमाएं।"
+"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में "
+"2 गुना ज़्यादा उपयोग सीमाएं।"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24582,8 +24762,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN और अन्य "
-"DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
+"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN "
+"और अन्य DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24605,8 +24785,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
-"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
+"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
+"चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24616,8 +24797,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
-"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
+"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
+"चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24636,7 +24818,7 @@ msgstr "नया वर्ज़न डाउनलोड करने के �
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "आप पूरी तरह तैयार हैं!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24645,8 +24827,9 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए भी Chrome की "
-"बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह कर सकता है:"
+"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए "
+"भी Chrome की बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह "
+"कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24659,8 +24842,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम करने के लिए "
-"सुझाव पाएं।"
+"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम "
+"करने के लिए सुझाव पाएं।"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24689,7 +24872,7 @@ msgstr "आपने 1 साइट को ब्लॉक कर दिया �
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "आपने Duck.ai की बुनियादी बातें सीख ली हैं"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24709,7 +24892,9 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से कोशिश करें।"
+msgstr ""
+"आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24728,7 +24913,8 @@ msgstr "आज की वॉयस चैट सीमा पूरी हो �
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
 msgstr ""
-"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से कोशिश करें।"
+"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24737,9 +24923,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। "
-"सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन की गई चैट डिलीट नहीं की "
-"जाएंगी।"
+"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त "
+"हो गई है। सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन "
+"की गई चैट डिलीट नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24749,9 +24935,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। सिंक फिर "
-"से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट कर दें। पिन की गई चैट डिलीट "
-"नहीं की जाएंगी।"
+"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई "
+"है। सिंक फिर से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट "
+"कर दें। पिन की गई चैट डिलीट नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24765,8 +24951,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस वजह से "
-"YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
+"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस "
+"वजह से YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24810,8 +24996,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
-"जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल "
+"स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24821,8 +25008,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
-"जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज "
+"में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24847,8 +25035,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता है।DuckDuckGo के "
-"पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
+"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता "
+"है।DuckDuckGo के पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -24856,8 +25044,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo के पास इस "
-"डेटा का कभी भी एक्सेस नहीं रहा है।"
+"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo "
+"के पास इस डेटा का कभी भी एक्सेस नहीं रहा है।"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24866,8 +25054,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी "
+"दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24880,8 +25068,8 @@ msgstr "आपकी चैट अब सेव की जा रही है�
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता"
+"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24895,8 +25083,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24904,8 +25092,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24913,8 +25101,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
+"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24922,8 +25110,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
+"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24938,9 +25126,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI मॉडल्स को "
-"प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री सुरक्षित रखने के लिए इन चरणों "
-"का पालन करें।"
+"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI "
+"मॉडल्स को प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री "
+"सुरक्षित रखने के लिए इन चरणों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24949,7 +25137,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें जहां आपने छोड़ा था।"
+"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें "
+"जहां आपने छोड़ा था।"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24981,8 +25170,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध नहीं है। "
-"[%2$sउदाहरण संदेश%3$s]"
+"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध "
+"नहीं है। [%2$sउदाहरण संदेश%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24997,8 +25186,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए नहीं किया "
-"जाता।"
+"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए "
+"नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25027,10 +25216,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का उपयोग करके '512-"
-"बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल आपके ब्राउज़र को छोड़ देती है। "
-"हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी "
-"आपके पासफ़्रेज़ को नहीं जानता है।"
+"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का "
+"उपयोग करके '512-बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल "
+"आपके ब्राउज़र को छोड़ देती है। हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स "
+"फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी आपके पासफ़्रेज़ को नहीं जानता है।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25045,8 +25234,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान बताने वाला "
-"मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे जोड़ न सकें।"
+"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान "
+"बताने वाला मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे "
+"जोड़ न सकें।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25060,7 +25250,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा सकते हैं।"
+"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25092,6 +25283,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
+"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25100,8 +25293,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
-"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
+"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर "
+"जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25121,8 +25315,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए Chrome के बजाय "
-"हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और यहां दिए गए काम कर सकता है:"
+"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए "
+"Chrome के बजाय हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और "
+"यहां दिए गए काम कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25131,8 +25326,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके फिर से "
-"कोशिश करें।"
+"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके "
+"फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25141,8 +25336,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire Button की मदद "
-"से इस बातचीत को मिटाएं।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire "
+"Button की मदद से इस बातचीत को मिटाएं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25151,7 +25346,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट शुरू करें।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट "
+"शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25166,8 +25362,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया इस चैट को अब कल "
-"जारी रखें।"
+"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया "
+"इस चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25470,7 +25666,8 @@ msgstr "ऑफ़िशियल वेबसाइट"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s अक्षर है)"
+"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s "
+"अक्षर है)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25686,4 +25883,4 @@ msgstr "वर्ष"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr "%1$s पाया गया"
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -176,9 +182,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
-"स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
+"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -188,9 +193,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
-"स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
+"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -206,9 +210,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस "
-"ब्राउज़र में अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
-"पर स्विच करें।"
+"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -217,8 +220,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में "
-"फिर से कोशिश करें।"
+"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में फिर से कोशिश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -309,9 +312,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल "
-"प्रोवाइडर भी आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस "
-"चैट को अपने सर्वर पर सेव कर सकता है।"
+"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल प्रोवाइडर भी "
+"आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस चैट को अपने सर्वर पर सेव "
+"कर सकता है।"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -355,6 +358,12 @@ msgid "%s used"
 msgstr "%1$s उपयोग किया गया"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s व्यू"
@@ -391,8 +400,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी "
-"रखने के लिए मॉडल बदल सकते हैं।"
+"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी रखने "
+"के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -403,8 +412,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को "
-"जारी रखने के लिए मॉडल बदल सकते हैं।"
+"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को जारी रखने के "
+"लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -417,8 +426,8 @@ msgstr "%1$s शब्द"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, "
-"फिर %6$sठीक हैं%7$s पर क्लिक करें"
+"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, फिर %6$sठीक "
+"हैं%7$s पर क्लिक करें"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -426,8 +435,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
-"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति दें%7$s पर "
+"निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -437,8 +446,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें "
-"%6$sअनुमति दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
+"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -472,16 +481,14 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर "
-"किया जाता है।"
+"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर "
-"जानें।%2$s"
+"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर जानें।%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -493,9 +500,7 @@ msgstr "होम स्क्रीन पर DuckDuckGo ऐप आइकन �
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से "
-"कोशिश करें।"
+msgstr "%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -602,6 +607,12 @@ msgstr "पिछले 24 घंटे में DuckDuckGo ने 1 कोश�
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 दिन पहले"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -822,9 +833,7 @@ msgstr "6 घंटे की उपयोग सीमा पूरी हो �
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
-"हैं।"
+msgstr "6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -832,8 +841,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके "
-"चैटिंग जारी रख सकते हैं।"
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके चैटिंग जारी रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -887,26 +896,22 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना "
-"कनेक्शन जांचें और फिर से कोशिश करें।"
+"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना कनेक्शन "
+"जांचें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
-"करें।"
+msgstr "AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
-"करें।"
+msgstr "Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -950,10 +955,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
-"सुविधा देता है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप "
-"जाएगा। जब यह सेटिंग बंद हो तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI "
-"Chat का उपयोग कर सकते हैं।"
+"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा देता "
+"है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप जाएगा। जब यह सेटिंग बंद हो "
+"तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI Chat का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1014,10 +1018,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते "
-"हैं। हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और "
-"अक्सर उससे लिंक करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और "
-"Anthropic, और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते हैं। "
+"हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और अक्सर उससे लिंक "
+"करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और Anthropic, और अन्य के चैट "
+"मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1202,8 +1206,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या "
-"किसी मुफ़्त मॉडल पर स्विच करें।"
+"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
+"पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1239,8 +1243,8 @@ msgstr "विज्ञापन"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका "
-"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग आपकी "
+"व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1248,8 +1252,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और "
-"इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग "
+"आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1300,8 +1304,7 @@ msgstr "DuckDuckGo एक्सटेंशन जोड़ें"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials "
-"जोड़ें:"
+"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials जोड़ें:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1516,6 +1519,14 @@ msgid "Advanced Models"
 msgstr "एडवांस्ड मॉडल"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "खोज में विज्ञापन दें"
@@ -1555,9 +1566,7 @@ msgstr "जैसे ही वह डाउनलोड होकर खुल�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल "
-"क्लिक करें"
+msgstr "डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1694,8 +1703,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "सभी चैट DuckDuckGo द्वारा अनाम कर दी जाती हैं, और आपकी बातचीत का इस्तेमाल "
-"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं "
-"किया जाता है"
+"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं किया "
+"जाता है"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1728,8 +1737,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से "
-"रोका गया है।"
+"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से रोका गया "
+"है।"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1744,8 +1753,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) "
-"हटा दिया जाता है।"
+"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) हटा दिया "
+"जाता है।"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1777,8 +1786,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन "
-"एक्सेस की अनुमति दें।"
+"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन एक्सेस की अनुमति "
+"दें।"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1801,8 +1810,7 @@ msgstr "इस चैट के लिए गुमनाम फ़ाइल र
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
 msgstr ""
-"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को "
-"अनुमति दें"
+"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को अनुमति दें"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1812,10 +1820,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स "
-"के जवाबों को बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही "
-"भेजता है, जिनमें डेटा रिटेंशन की लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स "
-"और जवाबों पर अभी भी %3$sप्रोवाइडर की विज़िबिलिटी शून्य%4$s रहती है।"
+"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स के जवाबों को "
+"बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही भेजता है, जिनमें डेटा रिटेंशन की "
+"लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स और जवाबों पर अभी भी %3$sप्रोवाइडर की "
+"विज़िबिलिटी शून्य%4$s रहती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1823,8 +1831,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता "
-"है (Cloud Save का उपयोग करने के लिए आवश्यक है)"
+"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता है (Cloud "
+"Save का उपयोग करने के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1962,8 +1970,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
-"%3$s और %4$s शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1972,8 +1980,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
-"%3$s और %4$s शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1987,8 +1995,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। "
-"चुनें कि इसे कितनी बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
+"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। चुनें कि इसे कितनी "
+"बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2035,8 +2043,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे "
-"बतख संबंधी तथ्य बताएं"
+"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे बतख संबंधी "
+"तथ्य बताएं"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2136,8 +2144,8 @@ msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
 msgstr ""
-"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा "
-"नहीं किया जा सकता।"
+"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा नहीं किया "
+"जा सकता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2158,8 +2166,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, "
-"जिनमें पिन की गई चैट्स भी शामिल हैं।"
+"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, जिनमें पिन "
+"की गई चैट्स भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2168,8 +2176,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी "
-"चैट को भी डिलीट कर देगा।"
+"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी चैट को भी "
+"डिलीट कर देगा।"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2207,8 +2215,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा "
-"नहीं करते हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
+"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा नहीं करते "
+"हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2306,6 +2314,12 @@ msgid "Ask privately"
 msgstr "गोपनीय रूप से पूछें"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2338,13 +2352,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ "
-"खोजों के लिए गुमनाम रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन "
-"सकते हैं कि Assist को कितनी बार दिखाना है: कभी नहीं (यह खोज परिणामों से "
-"Assist के UI को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप "
-"'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे "
-"बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फिलहाल, AI "
-"की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
+"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ खोजों के लिए गुमनाम "
+"रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन सकते हैं कि Assist को कितनी बार "
+"दिखाना है: कभी नहीं (यह खोज परिणामों से Assist के UI को पूरी तरह हटा देता है), ऑन-"
+"डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ "
+"तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता "
+"है)। फिलहाल, AI की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2356,12 +2369,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, "
-"खोज संबंधी क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, "
-"यह वेब को स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री "
-"से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित "
-"नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद रखना ज़रूरी है कि "
-"जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
+"क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके "
+"क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम "
+"शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद "
+"रखना ज़रूरी है कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
 "आधारित होते हैं।"
 
 # smartling.placeholder_format=C
@@ -2454,8 +2466,8 @@ msgstr "चैट खत्म होने के बाद ऑडियो ह
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
 msgstr ""
-"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर "
-"नहीं किया जाता है।"
+"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर नहीं किया जाता "
+"है।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2497,16 +2509,14 @@ msgstr "स्वत: उत्तर"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां "
-"हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में "
-"अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2531,9 +2541,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, "
-"जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता "
-"है। फिलहाल, Assist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, जानकारी को "
+"गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता है। फिलहाल, Assist केवल "
+"अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2542,17 +2552,15 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए "
-"DuckAssist जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल "
-"DuckAssist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए DuckAssist "
+"जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल DuckAssist केवल अंग्रेज़ी "
+"क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू "
-"ऑटोप्ले करें।"
+msgstr "वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू ऑटोप्ले करें।"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2752,9 +2760,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस "
-"और पहचान बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर "
-"उसे अनाम बना देगा।"
+"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस और पहचान "
+"बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर उसे अनाम बना देगा।"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3135,18 +3142,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने "
-"खोज इंजन, ट्रैकर ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s "
-"एक्सटेंशन%3$s में बंडल किया है।"
+"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने खोज इंजन, ट्रैकर "
+"ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल किया है।"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज "
-"इंजन, ट्रैकर ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s "
-"में बंडल कर दिया है।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज इंजन, ट्रैकर "
+"ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल कर दिया है।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3154,9 +3159,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख "
-"ब्राउज़र्स%2$s के लिए गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, "
-"सब कुछ एक ही डाउनलोड में।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख ब्राउज़र्स%2$s के लिए "
+"गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, सब कुछ एक ही डाउनलोड में।"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3263,11 +3267,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र "
-"में) में संग्रहित किया जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से "
-"(क्लाउड में रिमोट सर्वर पर) संग्रहित करने के लिए अनाम क्लाउड सेव का उपयोग कर "
-"सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी क्लाउड में संग्रहित "
-"नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं होगा।"
+"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र में) में संग्रहित किया "
+"जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से (क्लाउड में रिमोट सर्वर पर) संग्रहित "
+"करने के लिए अनाम क्लाउड सेव का उपयोग कर सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी "
+"जानकारी क्लाउड में संग्रहित नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं "
+"होगा।"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3275,8 +3279,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
-"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
+"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3285,8 +3289,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
-"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
+"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3622,9 +3626,7 @@ msgstr "यूआरएल के दिखाई देने का तरी�
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर "
-"देता है"
+msgstr "जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर देता है"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3772,11 +3774,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के "
-"साथ गुमनाम ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि "
-"मॉडलों को सपोर्ट करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat "
-"बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर भी आप "
-"%1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Chat का इस्तेमाल कर सकते हैं।"
+"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम "
+"ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि मॉडलों को सपोर्ट "
+"करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat बटन और लिंक छिप जाएंगे। "
+"हालांकि, यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
+"Chat का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3832,8 +3834,7 @@ msgstr "गोपनीय ढंग से चैट करें"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय "
-"ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3841,8 +3842,7 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय "
-"ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3855,6 +3855,12 @@ msgstr "%1$s के साथ गोपनीय ढंग से चैट क�
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "AI के साथ गोपनीय ढंग से चैट करें"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3905,8 +3911,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर "
-"स्टोर की जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
+"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर स्टोर की "
+"जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3918,11 +3924,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
-"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते "
-"हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट "
-"हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और "
-"रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए "
+"जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
+"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई "
+"चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3945,9 +3950,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर "
-"अपलोड की गई सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर "
-"द्वारा गुमनाम रूप से किया जाता है।"
+"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर अपलोड की गई "
+"सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर द्वारा गुमनाम रूप से किया "
+"जाता है।"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -3955,8 +3960,7 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए "
-"स्टोरेज खाली करें।"
+"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए स्टोरेज खाली करें।"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4121,8 +4125,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस "
-"ऐप का इस्तेमाल करना है"
+"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस ऐप का "
+"इस्तेमाल करना है"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4303,9 +4307,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को "
-"लंबे समय तक रख सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर "
-"उन्हें ऑटो-डिलीट कर सकते हैं।"
+"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को लंबे समय तक रख "
+"सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर उन्हें ऑटो-डिलीट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4315,9 +4318,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए "
-"बिना, हाल की चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के "
-"बाद अपने-आप हटाया जा सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
+"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए बिना, हाल की "
+"चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के बाद अपने-आप हटाया जा "
+"सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4326,8 +4329,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी "
-"ब्लॉक लिस्ट को हमेशा के लिए सेव करें"
+"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी ब्लॉक लिस्ट को "
+"हमेशा के लिए सेव करें"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4336,9 +4339,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप "
-"प्रश्न %1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो "
-"OpenAI, Anthropic और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप प्रश्न "
+"%1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो OpenAI, Anthropic "
+"और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4380,8 +4383,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > "
-"प्राथमिकताएं%4$s (Mac पर) क्लिक करें"
+"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > प्राथमिकताएं%4$s "
+"(Mac पर) क्लिक करें"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4397,9 +4400,7 @@ msgstr "DuckDuckGo एकस्टेंशन को डाउनलोड क�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक "
-"करें"
+msgstr "DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक करें"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4414,8 +4415,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर "
-"%3$sगियर आइकन%4$s पर क्लिक करें)"
+"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर %3$sगियर "
+"आइकन%4$s पर क्लिक करें)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4432,9 +4433,7 @@ msgstr "ड्रॉपडाउन में %1$sसेटिंग्स%2$s �
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s "
-"करें।"
+msgstr "%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s करें।"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4447,8 +4446,7 @@ msgstr "%1$sहां%2$s पर क्लिक करें"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक "
-"करें"
+"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक करें"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4510,9 +4508,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा "
-"हटा देता है, लेकिन यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी "
-"खोज सेटिंग रीसेट करें%4$s पर क्लिक/टैप नहीं कर देते।"
+"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटा देता है, लेकिन "
+"यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी खोज सेटिंग रीसेट करें%4$s पर "
+"क्लिक/टैप नहीं कर देते।"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4523,9 +4521,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता "
-"है, लेकिन यह आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स "
-"रीसेट%4$s पर क्लिक/टैप नहीं करते।"
+"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता है, लेकिन यह "
+"आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स रीसेट%4$s पर क्लिक/टैप नहीं करते।"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4594,8 +4591,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर "
-"क्लिक करें और %3$sDuckDuckGo%4$s चुनें।"
+"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर क्लिक करें और "
+"%3$sDuckDuckGo%4$s चुनें।"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4603,8 +4600,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र "
-"के ऊपरी दाएं कोने में होता है।"
+"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र के ऊपरी दाएं "
+"कोने में होता है।"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4645,6 +4642,12 @@ msgstr "क्लिपआर्ट"
 #. An accessible label for a button that closes a modal dialog
 msgid "Close"
 msgstr "बंद करें"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4689,6 +4692,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "सर्च बंद करें"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4793,8 +4802,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा "
-"सुरक्षित रख सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
+"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा सुरक्षित रख "
+"सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5062,6 +5071,12 @@ msgid "Continue Blocking Ads"
 msgstr "विज्ञापनों को ब्लॉक करना जारी रखें"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5127,6 +5142,12 @@ msgid "Cookie data:"
 msgstr "कूकी का डेटा:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5172,6 +5193,12 @@ msgstr "%1$sabout:preferences#search%2$s कॉपी करें और एड
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "कोड कॉपी करें"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5287,6 +5314,12 @@ msgid "Create Image"
 msgstr "इमेज बनाएं"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5328,6 +5361,14 @@ msgstr "क्रिएटर"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "%1$s द्वारा निर्मित"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5483,6 +5524,12 @@ msgid "Customize responses"
 msgstr "जवाबों को अपनी आवश्यकता अनुसार कस्टमाइज़ करें"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "इस पेज को कस्टमाइज़ करें"
@@ -5555,8 +5602,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट "
-"करना जारी रख सकते हैं।"
+"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट करना "
+"जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5767,10 +5814,22 @@ msgid "Delete Server Data?"
 msgstr "सर्वर डेटा डिलीट करें?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "ट्रांसक्रिप्ट डिलीट करें"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5803,6 +5862,12 @@ msgstr "इमेज डिलीट करें"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "इमेज डिलीट करें?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5929,8 +5994,8 @@ msgstr "Duck.ai में डिक्टेशन"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
-"के लिए नहीं किया जाता है।"
+"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए नहीं "
+"किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5948,8 +6013,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता "
-"है, ताकि आप बिना टाइप किए भी Duck.ai में चैट कर सकें।"
+"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता है, ताकि आप "
+"बिना टाइप किए भी Duck.ai में चैट कर सकें।"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6113,6 +6178,12 @@ msgid "Dismiss promotion"
 msgstr "प्रमोशन हटाएं"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6255,8 +6326,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा "
-"नहीं है और AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा नहीं है और "
+"AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6265,8 +6336,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI "
-"फ़ीचर्स और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI फ़ीचर्स "
+"और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6323,6 +6394,12 @@ msgid "Download DuckDuckGo"
 msgstr "DuckDuckGo डाउनलोड करें"
 
 # smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo Browser"
@@ -6376,8 +6453,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
-"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
+"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
+"जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6386,8 +6463,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
-"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
+"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
+"जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6408,8 +6485,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी "
-"में लोगों को आमंत्रित करने के लिए है।"
+"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी में लोगों को "
+"आमंत्रित करने के लिए है।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6418,8 +6495,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग "
-"बढ़ाने की मेरी रणनीतियों के बारे में लिखना है।"
+"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग बढ़ाने की मेरी "
+"रणनीतियों के बारे में लिखना है।"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6538,6 +6615,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai by DuckDuckGo. प्राइवेट AI चैट। मुफ़्त।"
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6545,9 +6628,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। "
-"पेज का कंटेंट तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग "
-"में पेजों को ऑटोमैटिकली अटैच करने का विकल्प न चुना हो।"
+"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। पेज का कंटेंट "
+"तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग में पेजों को ऑटोमैटिकली अटैच "
+"करने का विकल्प न चुना हो।"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6557,9 +6640,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। "
-"कृपया अपनी ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) "
-"करें और फिर से कोशिश करें।"
+"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। कृपया अपनी "
+"ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6568,8 +6650,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस "
-"चैट को अब कल जारी रखें।"
+"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस चैट को अब "
+"कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6585,9 +6667,8 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन "
-"कंपनी हैं, जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने "
-"हाथ में लेना चाहते हैं।"
+"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन कंपनी हैं, "
+"जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने हाथ में लेना चाहते हैं।"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6602,8 +6683,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी "
-"आसान होगा: https://duck.ai"
+"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी आसान "
+"होगा: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6618,8 +6699,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम "
-"कोड %1$s को %2$s पर ईमेल करें"
+"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम कोड "
+"%1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6640,9 +6721,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता "
-"है। इसे बंद करने से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी "
-"%1$sduck.ai%2$s पर जा सकते हैं सीधे ही।"
+"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता है। इसे बंद करने "
+"से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी %1$sduck.ai%2$s पर जा सकते हैं "
+"सीधे ही।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6653,11 +6734,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
-"सुविधा मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग "
-"को बंद करने से DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, "
-"यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
-"Duck.ai का इस्तेमाल कर सकते हैं।"
+"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा "
+"मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग को बंद करने से "
+"DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर "
+"भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Duck.ai का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6672,8 +6752,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी "
-"रख सकते हैं।"
+"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6687,8 +6767,14 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता "
-"संबंधी कोई जांच नहीं होती है।"
+"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता संबंधी कोई जांच "
+"नहीं होती है।"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6716,9 +6802,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, "
-"बिना साइन अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, "
-"गोपनीयता केंद्रित AI, बिना खाता AI चैट"
+"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, बिना साइन "
+"अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, गोपनीयता "
+"केंद्रित AI, बिना खाता AI चैट"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6746,13 +6832,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके "
-"बारे में खास जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार "
-"दिखाना है: कभी नहीं (यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा "
-"देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते "
-"हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई "
-"तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, DuckAssist सिर्फ़ अमेरिका "
-"(अंग्रेज़ी) में उपलब्ध है।"
+"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास "
+"जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार दिखाना है: कभी नहीं "
+"(यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी "
+"दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब "
+"नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, "
+"DuckAssist सिर्फ़ अमेरिका (अंग्रेज़ी) में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6762,8 +6847,8 @@ msgid ""
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा "
-"है जो OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
+"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा है जो "
+"OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6773,8 +6858,8 @@ msgid ""
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा "
-"है जो OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
+"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा है जो "
+"OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6786,12 +6871,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज "
-"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और "
-"संबंधित साइटों को स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे "
-"जुड़ी खास जानकारी को जनरेट करने के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी "
-"का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल इसके जवाब Wikipedia और "
-"संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं की जाती है।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
+"क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और संबंधित साइटों को "
+"स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे जुड़ी खास जानकारी को जनरेट करने "
+"के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल "
+"इसके जवाब Wikipedia और संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं "
+"की जाती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6805,15 +6890,13 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम "
-"रहकर, खोज संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को "
-"स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी "
-"जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल "
-"लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा एक या दो "
-"स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, "
-"ताकि आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है "
-"कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
-"आधारित होते हैं।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज "
+"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके क्वेरी से जुड़ी "
+"सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने "
+"के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा "
+"एक या दो स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, ताकि "
+"आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है कि जवाब, दूसरे "
+"स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर आधारित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6821,8 +6904,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते "
-"हैं और इनकी सटीकता की जांच नहीं की जाती है।"
+"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते हैं और इनकी "
+"सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6831,8 +6914,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। "
-"कृपया इस चैट को अब कल जारी रखें।"
+"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। कृपया इस चैट को "
+"अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6841,8 +6924,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
-"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
+"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6851,8 +6934,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
-"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
+"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6861,8 +6944,7 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6871,8 +6953,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो "
-"कृपया इस अनाम कोड %1$s को %2$s पर ईमेल करें"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस "
+"अनाम कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6881,8 +6963,7 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से "
-"कोशिश करें।"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7007,9 +7088,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी "
-"मेटाडेटा जैसी व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को "
-"एनोनिमाइज़ कर देता है।"
+"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी मेटाडेटा जैसी "
+"व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को एनोनिमाइज़ कर देता है।"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7017,8 +7097,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की "
-"%2$s से सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की %2$s से "
+"सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7027,8 +7107,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से "
-"सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से सहमत "
+"होते हैं।"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7037,9 +7117,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता "
-"है, जिसमें Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर "
-"आपको अन्य वेबसाइटों पर ट्रैक करने की कोशिश करते हैं।"
+"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता है, जिसमें "
+"Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर आपको अन्य वेबसाइटों पर "
+"ट्रैक करने की कोशिश करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7051,12 +7131,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो "
-"यह केवल आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो "
-"आपकी डिवाइस उसे हमें भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर "
-"बनाने के लिए करते हैं और फिर हम तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही "
-"रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने इस तकनीक को कैसे डिज़ाइन "
-"किया है, इसके बारे में और जानें%2$s।"
+"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो यह केवल "
+"आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो आपकी डिवाइस उसे हमें "
+"भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर बनाने के लिए करते हैं और फिर हम "
+"तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने "
+"इस तकनीक को कैसे डिज़ाइन किया है, इसके बारे में और जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7076,8 +7155,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक "
-"के बेहतर परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
+"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक के बेहतर "
+"परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7163,10 +7242,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक "
-"शब्दों की लंबी सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों "
-"का चयन करते हैं, यह सुनिश्चित करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर "
-"लंबा है।"
+"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक शब्दों की लंबी "
+"सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों का चयन करते हैं, यह सुनिश्चित "
+"करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर लंबा है।"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7237,8 +7315,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब "
-"तैयार होगा।"
+"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब तैयार "
+"होगा।"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7335,6 +7413,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "सबसे ज़्यादा देखी गई साइटें सक्षम करें"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7370,8 +7454,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना "
-"विचार बदल सकते हैं।"
+"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना विचार बदल सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7414,9 +7498,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते "
-"हैं, लेकिन फिर भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते "
-"हैं।"
+"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते हैं, लेकिन फिर "
+"भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7578,8 +7661,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह "
-"आपके नए पासफ्रेज़ के तहत आपके डेटा को बचाएगा।"
+"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह आपके नए पासफ्रेज़ के "
+"तहत आपके डेटा को बचाएगा।"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7605,8 +7688,8 @@ msgstr "टेक्स्ट डालें"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s "
-"उपनाम %6$s: d%7$s"
+"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s उपनाम "
+"%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7631,6 +7714,12 @@ msgstr "अपनी सेटिंग लोड करने के लिए 
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "मनोरंजन गाइड"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7701,8 +7790,8 @@ msgstr "मैप का विस्तार करें"
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
-"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी "
-"की सचमुच परवाह है।"
+"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी की सचमुच "
+"परवाह है।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7794,6 +7883,18 @@ msgstr "अश्लील सामग्री"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "आपत्तिजनक बोल"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7897,6 +7998,12 @@ msgid "FREE"
 msgstr "मुफ़्त"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7953,8 +8060,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार "
-"संंबंधी कार्यों में मदद मिलती है।"
+"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार संंबंधी कार्यों में मदद "
+"मिलती है।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7963,9 +8070,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की "
-"कोशिश में मदद मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे "
-"आपने शेयर किया है।"
+"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की कोशिश में मदद "
+"मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे आपने शेयर किया है।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7973,8 +8079,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी "
-"वेबसाइट में कॉपी पेस्ट करें।"
+"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी वेबसाइट में कॉपी "
+"पेस्ट करें।"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8063,9 +8169,7 @@ msgstr "इमेज खोज परिणामों से AI-जनरे�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
-"इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर "
-"जानें%2$s"
+msgstr "इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर जानें%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8143,9 +8247,7 @@ msgstr "अपने नज़दीक के परिणामों को �
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती "
-"है।"
+msgstr "अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती है।"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8209,8 +8311,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई "
-"मेन्यू विकल्प चुनें या कोई बटन क्लिक करें।"
+"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई मेन्यू विकल्प चुनें "
+"या कोई बटन क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8312,6 +8414,12 @@ msgid "Free Up Storage"
 msgstr "स्टोरेज खाली करें"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8352,8 +8460,8 @@ msgstr "व्यावसायिक रूप से शेयर और उ�
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
 msgstr ""
-"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट "
-"नहीं की जाएंगी।"
+"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट नहीं की "
+"जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8434,8 +8542,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट "
-"देखें...</strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
+"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट देखें...</"
+"strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8786,9 +8894,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस "
-"प्राप्त करें, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल "
-"हैं।"
+"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस प्राप्त करें, जिसमें "
+"हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8799,9 +8906,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo "
-"सब्सक्रिप्शन के साथ, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी "
-"शामिल हैं।"
+"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo सब्सक्रिप्शन के साथ, "
+"जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8825,6 +8931,12 @@ msgstr "DuckDuckGo सहायता पर अपने सवालों क
 msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr "कंप्यूटर सहायता प्राप्त करें"
+
+# smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8862,6 +8974,18 @@ msgid "Get the Latest Version"
 msgstr "नया वर्ज़न पाएं"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8881,9 +9005,13 @@ msgstr "यह गाना यहां पाएंः"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr "आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद करें!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
-"आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद "
-"करें!"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8914,9 +9042,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में "
-"जाएं और %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › "
-"टेक्स्ट कोड कॉपी करें%4$sपर जाएं"
+"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › टेक्स्ट कोड कॉपी "
+"करें%4$sपर जाएं"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8925,8 +9053,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
+"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8936,9 +9064,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और "
-"इस कोड को स्कैन करें:"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
+"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8948,9 +9075,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या "
-"अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
+"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या अपनी रिकवरी PDF "
+"पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8965,8 +9092,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि "
-"\"स्थान सेवाएं\" चालू है।"
+"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि \"स्थान "
+"सेवाएं\" चालू है।"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8975,8 +9102,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे "
-"स्क्रॉल करके %3$sDuckDuckGo%4$s पर जाएं।"
+"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे स्क्रॉल करके "
+"%3$sDuckDuckGo%4$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9569,6 +9696,12 @@ msgid "Hide Tips"
 msgstr "टिप्स छिपाएं"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9653,8 +9786,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist "
-"उत्तरों में मुख्य तथ्यों को हाइलाइट करता है।"
+"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist उत्तरों में मुख्य "
+"तथ्यों को हाइलाइट करता है।"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9681,8 +9814,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s "
-"दबाएं%3$s। %4$sफिर %5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
+"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s दबाएं%3$s। %4$sफिर "
+"%5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9696,8 +9829,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा "
-"गोपनीयता संरक्षण खो देंगे।"
+"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा गोपनीयता "
+"संरक्षण खो देंगे।"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9747,8 +9880,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते "
-"हैं और इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं और इनका "
+"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9890,8 +10023,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह "
-"व्यवहारकुशलता से बात करनी चाहिए और क्या कहना चाहिए?"
+"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह व्यवहारकुशलता से "
+"बात करनी चाहिए और क्या कहना चाहिए?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10013,8 +10146,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ "
-"कौन-सी हैं और क्यों?"
+"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ कौन-सी हैं और "
+"क्यों?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10049,8 +10182,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट "
-"> 'स्थान और गोपनीयता रीसेट करें' पर जाएं%2$s।"
+"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट > 'स्थान और "
+"गोपनीयता रीसेट करें' पर जाएं%2$s।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10060,9 +10193,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > "
-"सेटिंग्‍स > साइट सेटिंग्स > स्थान%2$s पर जाएं, और सुनिश्चित करें कि "
-"DuckDuckGo को स्थान एक्सेस की अनुमति है।"
+"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > सेटिंग्‍स > साइट सेटिंग्स "
+"> स्थान%2$s पर जाएं, और सुनिश्चित करें कि DuckDuckGo को स्थान एक्सेस की अनुमति है।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10077,8 +10209,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज "
-"इंजन%4$s की सूची में जोड़ना होगा"
+"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज इंजन%4$s "
+"की सूची में जोड़ना होगा"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10087,8 +10219,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, "
-"तो आप सीधे %1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
+"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, तो आप सीधे "
+"%1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10097,17 +10229,15 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर "
-"करने के लिए आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के "
-"रूप में अपने डिवाइस पर सेव कर सकते हैं।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर करने के लिए "
+"आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के रूप में अपने डिवाइस पर सेव "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें "
-"%2$s"
+msgstr "अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें %2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10117,17 +10247,15 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे "
-"%1$s या %2$s संस्करणों का उपयोग करें।"
+"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे %1$s या "
+"%2$s संस्करणों का उपयोग करें।"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ "
-"खोलें)"
+msgstr "अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ खोलें)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10256,8 +10384,7 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में "
-"सुधार करता है"
+"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में सुधार करता है"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10270,8 +10397,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों "
-"को रीडायरेक्ट करना आवश्यक है। %1$sऔर जानें%2$s।"
+"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों को रीडायरेक्ट करना "
+"आवश्यक है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10282,8 +10409,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य "
-"डिवाइस के साथ सिंक करें” चुनें।"
+"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य डिवाइस के "
+"साथ सिंक करें” चुनें।"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10298,8 +10425,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते "
-"हैं कि हम क्या जानकारी संग्रहित करते हैं।"
+"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते हैं कि हम क्या "
+"जानकारी संग्रहित करते हैं।"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10635,9 +10762,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश "
-"बताएं।"
+msgstr "क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश बताएं।"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10688,8 +10813,7 @@ msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा "
-"बार) ठीक है"
+"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा बार) ठीक है"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10708,10 +10832,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और "
-"Microsoft के विज्ञापन नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे "
-"मर्चेंट लैंडिंग पेज पर ले जाते हैं और विज्ञापनों के विपरीत, DuckDuckGo को इन "
-"परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
+"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और Microsoft के विज्ञापन "
+"नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे मर्चेंट लैंडिंग पेज पर ले जाते हैं और "
+"विज्ञापनों के विपरीत, DuckDuckGo को इन परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10720,8 +10843,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और "
-"अधिक सुरक्षित भी है।"
+"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और अधिक सुरक्षित "
+"भी है।"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11188,6 +11311,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "आपको DuckDuckGo के साथ अनाम रूप से खोजने की अनुमति देता है"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "लाइबेरिया"
 
@@ -11258,6 +11388,12 @@ msgid "Lineouts Won"
 msgstr "लाइनआउट जीते"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "फ़ॉन्ट जोड़ें"
@@ -11271,9 +11407,7 @@ msgstr "लिंक्स:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी "
-"लिस्ट दें।"
+msgstr "इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी लिस्ट दें।"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11911,8 +12045,8 @@ msgstr "माइक्रोनेशिया"
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
 msgstr ""
-"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की "
-"अनुमति दें और फिर से प्रयास करें।"
+"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की अनुमति दें और फिर "
+"से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12352,6 +12486,12 @@ msgid "More than 20 minutes"
 msgstr "20 मिनट से ज़्यादा"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12672,11 +12812,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और "
-"अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
-"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से "
-"पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी "
-"स्टोरेज भी बंद हो जाएगा।"
+"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से "
+"DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को "
+"रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और "
+"नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12838,6 +12977,12 @@ msgstr "नहीं, धन्यवाद"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "नहीं, धन्यवाद"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13492,14 +13637,20 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s "
-"आइकन > सेटिंग्स%5$s पर क्लिक करें"
+"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s आइकन "
+"> सेटिंग्स%5$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "चालू लेकिन कोई संख्या नहीं"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13515,8 +13666,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया "
-"%1$s पेज या उससे कम वाली फ़ाइलें अपलोड करें।"
+"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया %1$s पेज या उससे "
+"कम वाली फ़ाइलें अपलोड करें।"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13543,8 +13694,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल "
-"पैरामीटर%2$s पेज पर है।"
+"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल पैरामीटर%2$s पेज "
+"पर है।"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13559,8 +13710,7 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में "
-"फिर से प्रयास करें।"
+"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13712,6 +13862,12 @@ msgstr "चैट सुझाव खोलें"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "इमेज बनाने और एडिट करने के सुझाव खोलें"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -13877,8 +14033,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में "
-"हो। हम आपको — अवधि में ट्रैक नहीं करते हैं।"
+"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में हो। हम आपको — "
+"अवधि में ट्रैक नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13891,8 +14047,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर "
-"नहीं करते हैं।"
+"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर नहीं "
+"करते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13900,8 +14056,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, "
-"एनक्रिप्शन एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
+"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, एनक्रिप्शन "
+"एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14154,8 +14310,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, "
-"ब्राउज़र फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
+"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, ब्राउज़र "
+"फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14355,10 +14511,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो AI की मदद से दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर "
-"जवाब अक्सर मिलते हैं। उन्हें बंद करने और Assist बटन छिपाने के लिए %1$sखोज "
-"सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो AI की मदद से "
+"दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। उन्हें बंद "
+"करने और Assist बटन छिपाने के लिए %1$sखोज सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14367,10 +14522,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो DuckAssist के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। "
-"इस फ़ीचर के काम करने के तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, "
-"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
+"के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इस फ़ीचर के काम करने के "
+"तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, %1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14380,10 +14534,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो DuckAssist अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते "
-"हैं। इसे बंद करने और Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist "
-"Settings%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
+"अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इसे बंद करने और "
+"Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist Settings%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14416,8 +14569,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, "
-"Mistral, वगैरह।"
+"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, Mistral, "
+"वगैरह।"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14436,8 +14589,7 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा "
-"उपलब्ध नहीं होगी।"
+"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा उपलब्ध नहीं होगी।"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14450,8 +14602,8 @@ msgstr "कोई विशिष्ट समस्या चुनें"
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए "
-"निर्देशों का पालन करें।"
+"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए निर्देशों का "
+"पालन करें।"
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14460,10 +14612,22 @@ msgid "Pin"
 msgstr "पिन"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "%1$s %2$s से चैट्स को यहां पिन करें"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14481,6 +14645,12 @@ msgstr "गुलाबी"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "पिन किया गया"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14522,8 +14692,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया "
-"निम्नलिखित चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया निम्नलिखित "
+"चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14532,8 +14702,8 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया "
-"निम्नलिखित चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया निम्नलिखित चुनौती "
+"को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14566,8 +14736,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट "
-"सेशन डिलीट हो जाएगा।"
+"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट सेशन डिलीट हो "
+"जाएगा।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14576,9 +14746,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
-"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या "
-"गैरकानूनी है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
+"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या गैरकानूनी है।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14587,9 +14756,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
-"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या "
-"नुकसानदेह है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
+"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या नुकसानदेह है।"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14742,8 +14910,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या "
-"सुझावों को प्रभावित नहीं करेगा।"
+"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
+"प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14800,6 +14968,12 @@ msgstr "पोलिश"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "खराब फॉर्मेटिंग"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15008,6 +15182,12 @@ msgstr "पिछली इमेज"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "पिछले टैब"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15303,8 +15483,8 @@ msgstr "मुझे प्रॉम्प्ट करें"
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
 msgstr ""
-"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के "
-"लिए प्रेरित करें।"
+"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के लिए प्रेरित "
+"करें।"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15323,8 +15503,7 @@ msgstr "खोजते और ब्राउज़ करते समय अ�
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
 msgstr ""
-"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को "
-"सुरक्षित रखें।"
+"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15349,8 +15528,7 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का "
-"टेक्स्ट यहां डालें।]"
+"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का टेक्स्ट यहां डालें।]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15552,6 +15730,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "मॉडल में मौजूद मीडियम मॉडरेशन लेवल वाला तार्किक AI"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15587,14 +15777,20 @@ msgid "Recent chat storage can be adjusted in %s."
 msgstr "हालिया चैट स्टोरेज को %1$s में एडजस्ट किया जा सकता है।"
 
 # smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
 msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
-"स्थानीय स्तर पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
+"पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15603,8 +15799,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
-"स्थानीय स्तर पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
+"पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15614,10 +15810,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स "
-"भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर "
-"पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया "
-"जा सके।"
+"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
+"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि "
+"आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके।"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15742,13 +15937,19 @@ msgid "Reduce Usage"
 msgstr "उपयोग कम करें"
 
 # smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट "
-"के आकार को घटाता है"
+"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट के आकार को "
+"घटाता है"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15889,8 +16090,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने "
-"ब्राउज़र के &quot;रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
+"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने ब्राउज़र के &quot;"
+"रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15980,8 +16181,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप "
-"से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई देते "
+"हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15989,9 +16190,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर "
-"स्वचालित रूप से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित "
-"होते हैं।"
+"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई "
+"देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16049,9 +16249,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए "
-"DuckDuckGo को भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए "
-"आपकी अनाम प्रतिक्रिया भी %1$s के साथ शेयर की जाती है।"
+"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए DuckDuckGo को "
+"भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए आपकी अनाम प्रतिक्रिया भी "
+"%1$s के साथ शेयर की जाती है।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16059,8 +16259,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई "
-"भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
+"पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16069,9 +16269,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें "
-"आपने इस पेज लोड के दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने "
-"फ़ीडबैक में कोई भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें आपने इस पेज लोड के "
+"दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
+"पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16118,6 +16318,12 @@ msgid "Reset All Settings"
 msgstr "सभी सेटिंग्स को रीसेट करें"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16128,6 +16334,12 @@ msgstr "%1$s में रीसेट होता है"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "रिज़ॉल्यूशन"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16151,10 +16363,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। AI की मदद से दिए गए जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन "
-"हैं।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। AI की मदद से दिए गए "
+"जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन हैं।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16163,9 +16374,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। DuckAssist हमारी %1$sसेवा की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। DuckAssist हमारी "
+"%1$sसेवा की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16175,11 +16386,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। ये वेब सामग्री के आधार पर तैयार किए जाते हैं और इनमें कुछ "
-"गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा की शर्तों%2$s के अधीन "
-"है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। ये वेब सामग्री के आधार "
+"पर तैयार किए जाते हैं और इनमें कुछ गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा "
+"की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16256,8 +16466,7 @@ msgstr "परिणामों में ब्लॉक की गई सा�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में "
-"मैनेज कर सकते हैं।"
+"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में मैनेज कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16606,8 +16815,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और "
-"एन्क्रिप्टेड स्टोरेज के साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
+"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और एन्क्रिप्टेड स्टोरेज के "
+"साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16620,9 +16829,7 @@ msgstr "अपनी सबसे हाल की 30 चैट तक को �
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच "
-"सुरक्षित रखें।"
+msgstr "एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16770,8 +16977,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या "
-"%5$sनया जोड़ें%6$s) क्लिक करें"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या %5$sनया जोड़ें%6$s) "
+"क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16780,8 +16987,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर "
-"क्लिक करें (या %5$sनया जोड़ें%6$s)।"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर क्लिक करें (या %5$sनया "
+"जोड़ें%6$s)।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16800,8 +17007,8 @@ msgstr "नीचे स्क्रॉल करें और सूची म�
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह "
-"आपकी लोकेशन यानी स्थान का इस्तेमाल कर सके।"
+"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह आपकी लोकेशन "
+"यानी स्थान का इस्तेमाल कर सके।"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16832,6 +17039,12 @@ msgid "Search %s to find results closer to you?"
 msgstr "आपके नज़दीक के परिणामों को ढूंढने के लिए %1$s को खोजें?"
 
 # smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Search Anonymously"
 msgstr "अनाम रूप से खोजें"
 
@@ -16855,12 +17068,11 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा "
-"करने के लिए यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक "
-"संक्षिप्त जवाब तैयार करता है। आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी "
-"नहीं, केवल मांग पर (जब आप 'Assist' पर क्लिक करें), कभी-कभी (जब यह बहुत "
-"प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू हो)। फिलहाल, Search Assist "
-"केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
+"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा करने के लिए "
+"यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक संक्षिप्त जवाब तैयार करता है। "
+"आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी नहीं, केवल मांग पर (जब आप 'Assist' पर "
+"क्लिक करें), कभी-कभी (जब यह बहुत प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू "
+"हो)। फिलहाल, Search Assist केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16868,8 +17080,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय "
-"जानकारी नहीं मिली। कुछ और सर्च करके देखें।"
+"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय जानकारी नहीं "
+"मिली। कुछ और सर्च करके देखें।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16878,10 +17090,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब "
-"तैयार करता है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि "
-"संबंधित सामग्री मिल सके, और फिर मिली जानकारी के आधार पर AI की मदद से एक "
-"संक्षिप्त उत्तर तैयार करता है।"
+"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब तैयार करता "
+"है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि संबंधित सामग्री मिल सके, "
+"और फिर मिली जानकारी के आधार पर AI की मदद से एक संक्षिप्त उत्तर तैयार करता है।"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17002,8 +17213,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे "
-"Wikipedia पर “ducks” को खोजा जाएगा।"
+"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे Wikipedia पर "
+"“ducks” को खोजा जाएगा।"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17022,8 +17233,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र "
-"में गोपनीय वेब खोज जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
+"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र में गोपनीय वेब खोज "
+"जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17031,8 +17242,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट "
-"अनुरोध का उपयोग होगा)"
+"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट अनुरोध का उपयोग "
+"होगा)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17044,11 +17255,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल "
-"स्टोरेज में रखा जाता है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके "
-"अपनी सेटिंग को क्लाउड में किसी रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते "
-"हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान योग्य जानकारी स्टोर नहीं की "
-"जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं जाएगा।"
+"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल स्टोरेज में रखा जाता "
+"है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके अपनी सेटिंग को क्लाउड में किसी "
+"रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान "
+"योग्य जानकारी स्टोर नहीं की जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं "
+"जाएगा।"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17151,8 +17362,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17161,8 +17372,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17171,8 +17382,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17181,8 +17392,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप "
-"से स्टोर करें, और उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप से स्टोर करें, और "
+"उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17197,8 +17408,14 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर "
-"किया गया। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर किया गया। आपके "
+"अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17342,9 +17559,7 @@ msgstr "Safari मेनू से %1$s'इस वेबसाइट के ल�
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज "
-"करें"
+msgstr "%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज करें"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17354,17 +17569,13 @@ msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट �
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
-"करें"
+msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
-"करें।"
+msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें।"
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17413,8 +17624,7 @@ msgstr "ड्रॉपडाउन मेनू से %1$sएड-ऑन प्
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) "
-"चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) चुनें"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17422,8 +17632,7 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) "
-"चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) चुनें"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17488,8 +17697,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी "
-"पसंद का कोई एक विकल्प) चुनें"
+"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी पसंद का कोई "
+"एक विकल्प) चुनें"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17611,8 +17820,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब "
-"देना है। ये निर्देश आगे चलकर आपके सभी वार्तालापों पर लागू होंगे।"
+"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब देना है। ये निर्देश आगे "
+"चलकर आपके सभी वार्तालापों पर लागू होंगे।"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17710,6 +17919,12 @@ msgid "Set as Homepage"
 msgstr "होमपेज के रूप में बनाएं"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17722,8 +17937,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी "
-"डिवाइसों पर सिंक रख सकें।"
+"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी डिवाइसों पर "
+"सिंक रख सकें।"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17775,6 +17990,18 @@ msgid "Seychelles"
 msgstr "सेशल्स"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17810,9 +18037,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की "
-"सटीकता बेहतर हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं "
-"बताता है।"
+"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की सटीकता बेहतर "
+"हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं बताता है।"
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17873,6 +18106,12 @@ msgid "Share positive feedback"
 msgstr "सकारात्मक फ़ीडबैक शेयर करें"
 
 # smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17895,8 +18134,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और "
-"हानिकारक रिपोर्ट के लिए आवश्यक है)"
+"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और हानिकारक "
+"रिपोर्ट के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18008,6 +18247,12 @@ msgid "Show Detail"
 msgstr "विवरण दिखाएं"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "DuckAssist <sup>बीटा</sup> दिखाएं"
@@ -18017,8 +18262,7 @@ msgstr "DuckAssist <sup>बीटा</sup> दिखाएं"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर "
-"सकते हैं।)"
+"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर सकते हैं।)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18157,6 +18401,12 @@ msgid "Show more"
 msgstr "ज़्यादा दिखाएं"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18190,6 +18440,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "साइडबार दिखाएं"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18244,9 +18500,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
-"खोज गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की "
-"गोपनीयता प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
+"गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की गोपनीयता "
+"प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18254,9 +18510,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
-"खोज हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे "
-"खोज सुरक्षा प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
+"हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज सुरक्षा "
+"प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18294,8 +18550,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर "
-"दिखाता है"
+"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर दिखाता है"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18562,6 +18817,12 @@ msgid "Something went wrong, please try again later."
 msgstr "कुछ गड़बड़ हुई है, कृपया बाद में फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18577,9 +18838,7 @@ msgstr "कभी-कभी"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों "
-"में बताएं।"
+msgstr "माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों में बताएं।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18618,8 +18877,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी "
-"इमेज या फ़ॉर्मेट आज़माएं।"
+"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी इमेज या फ़ॉर्मेट "
+"आज़माएं।"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18628,8 +18887,7 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन "
-"किया गया है।"
+"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन किया गया है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18644,16 +18902,14 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने "
-"के लिए, %1$sयहाँ क्लिक करें%2$s।"
+"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने के लिए, %1$sयहाँ "
+"क्लिक करें%2$s।"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास "
-"करें।"
+msgstr "क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18708,8 +18964,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा "
-"हिस्सा चुनकर फिर से प्रयास करें।"
+"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा हिस्सा चुनकर फिर से "
+"प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18856,6 +19112,12 @@ msgstr "मासिक सीमा का इस्तेमाल शुर�
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "साप्ताहिक सीमा का इस्तेमाल शुरू करें"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19053,8 +19315,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक "
-"इमेज बनाने के लिए बाद में वापस आएं।"
+"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक इमेज बनाने "
+"के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19123,8 +19385,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' "
-"वाले कार्ड पर लिखने के लिए वाक्य सुझाएं?"
+"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' वाले कार्ड पर "
+"लिखने के लिए वाक्य सुझाएं?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19436,6 +19698,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "ऐसे खोज इंजन पर स्विच करें जो आपको ट्रैक न करता हो। कभी भी।"
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19447,8 +19717,8 @@ msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
 msgstr ""
-"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर "
-"विज़िबिलिटी ज़ीरो होगी"
+"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर विज़िबिलिटी ज़ीरो "
+"होगी"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19503,8 +19773,7 @@ msgstr "Sync & Backup चालू है!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा "
-"सकता।"
+"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19553,26 +19822,25 @@ msgid ""
 msgstr ""
 "सिंक रिकवरी कोड\n"
 "\n"
-" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai "
-"चैट को सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक "
-"किया हुआ डेटा रिकवर कर सकते हैं।\n"
+" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai चैट को "
+"सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक किया हुआ डेटा "
+"रिकवर कर सकते हैं।\n"
 "\n"
 "इस जानकारी को सुरक्षित और गोपनीय रखें।\n"
-"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस "
-"कर सकता है।\n"
+"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस कर सकता "
+"है।\n"
 "\n"
 "%1$s\n"
 "\n"
 "यह कोड कैसे काम करता है?\n"
 "1. अपने ब्राउज़र में Duck.ai पर जाएं और Duck.ai सेटिंग खोलें।\n"
-"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" "
-"चुनें\n"
-"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड "
-"यहां पेस्ट करें\" कहा गया है\n"
+"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" चुनें\n"
+"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड यहां पेस्ट "
+"करें\" कहा गया है\n"
 "\n"
-"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक "
-"DuckDuckGo ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट "
-"कर दिया जाएगा और उसे रीस्टोर नहीं किया जा सकेगा।"
+"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक DuckDuckGo "
+"ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट कर दिया जाएगा और उसे "
+"रीस्टोर नहीं किया जा सकेगा।"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19591,6 +19859,12 @@ msgstr "किसी दूसरे डिवाइस के साथ सि�
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "सिंक और बैकअप की सुविधा अभी उपलब्ध नहीं है"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19678,6 +19952,22 @@ msgstr "तजाकिस्तान"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "अपनी गोपनीयता वापस लें!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19915,9 +20205,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई "
-"जानकारी को किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम "
-"मामलों में इसमें पासवर्ड, या भुगतान विवरण शामिल होते हैं।"
+"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई जानकारी को "
+"किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम मामलों में इसमें पासवर्ड, "
+"या भुगतान विवरण शामिल होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19926,8 +20216,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी "
-"सेटिंग्स में कोई भी बदलाव करने की अनुमति देता है।"
+"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी सेटिंग्स में कोई भी "
+"बदलाव करने की अनुमति देता है।"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19957,8 +20247,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और "
-"सिर्फ़ आप ही इसे एक्सेस कर सकते हैं।"
+"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और सिर्फ़ आप ही इसे एक्सेस "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20038,8 +20328,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी "
-"ब्राउज़र सेटिंग जांचें और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
+"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी ब्राउज़र सेटिंग जांचें "
+"और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20054,8 +20344,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से "
-"पहले कुछ मिनट इंतज़ार करें।"
+"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से पहले कुछ "
+"मिनट इंतज़ार करें।"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20074,9 +20364,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर "
-"ब्लॉक करके, संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका "
-"डिफ़ॉल्ट खोज इंजन बनाकर गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
+"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर ब्लॉक करके, "
+"संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका डिफ़ॉल्ट खोज इंजन बनाकर "
+"गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20114,8 +20404,7 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की "
-"कोशिश करें।"
+"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20124,8 +20413,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए "
-"वर्ज़न के साथ नई चैट शुरू करें।"
+"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए वर्ज़न के साथ नई "
+"चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20140,10 +20429,22 @@ msgid "This Month"
 msgstr "इस माह"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "इस सप्ताह"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20152,9 +20453,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की "
-"गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
-"लिए %4$s देखें)।"
+"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की गई। "
+"AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20164,9 +20464,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई "
-"चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए "
-"%2$s देखें)."
+"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई चैट में गलत "
+"या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %2$s देखें)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20175,8 +20474,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक "
-"जानकारी भी प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
+"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक जानकारी भी "
+"प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20186,9 +20485,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के "
-"जरिए जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है "
-"(ज़्यादा जानकारी के लिए %4$s देखें)।"
+"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के जरिए "
+"जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
+"लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20260,8 +20559,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
-"करें"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20269,13 +20567,28 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
-"करें।"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें।"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "यह जानकारी उपयोगी नहीं है"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20296,8 +20609,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य "
-"मॉडल प्रदाता 'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य मॉडल प्रदाता "
+"'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20306,8 +20619,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल "
-"प्रदाता 'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल प्रदाता "
+"'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20344,8 +20657,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के "
-"साथ सेव करता है, जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
+"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के साथ सेव करता है, "
+"जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20354,9 +20667,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
-"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
-"सकते हैं।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
+"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20366,10 +20678,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
-"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
-"सकते हैं। हालांकि, %1$s पर हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने "
-"वाले जवाब कभी नहीं दिखाता।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
+"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं। हालांकि, %1$s पर "
+"हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने वाले जवाब कभी नहीं दिखाता।"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20398,9 +20709,7 @@ msgstr "यह वीडियो अब तक यहां देखे जा
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता "
-"है।"
+msgstr "यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20410,9 +20719,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup "
-"डिस्कनेक्ट हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी "
-"चैट एक्सेस कर पाएंगे।"
+"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup डिस्कनेक्ट "
+"हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी चैट एक्सेस कर पाएंगे।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20421,16 +20729,15 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे "
-"पहले जैसा नहीं किया जा सकता है।"
+"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे पहले जैसा "
+"नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
 msgstr ""
-"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा "
-"सकता है।"
+"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20553,7 +20860,8 @@ msgstr "जारी रखने के लिए, आपको Duck.ai की 
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
+msgstr ""
+"जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20562,8 +20870,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप "
-"प्रिंट करना चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
+"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप प्रिंट करना "
+"चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20573,10 +20881,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत "
-"होगी जिसे आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर "
-"PDF के रूप में सेव किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync "
-"सेटअप करने के लिए किया था।"
+"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत होगी जिसे "
+"आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर PDF के रूप में सेव "
+"किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync सेटअप करने के लिए किया था।"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20585,8 +20892,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo "
-"ब्राउज़र को नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
+"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo ब्राउज़र को "
+"नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20594,8 +20901,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को "
-"माइक्रोफ़ोन का एक्सेस दें।"
+"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को माइक्रोफ़ोन का "
+"एक्सेस दें।"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20612,6 +20919,12 @@ msgstr "आज"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "आज"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20785,8 +21098,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ "
-"करते रहें और देखें हम कितनों को ब्लॉक करते हैं।"
+"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ करते रहें और देखें "
+"हम कितनों को ब्लॉक करते हैं।"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20833,9 +21146,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में "
-"कैसे पहुंचूं?\""
+msgstr "फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20844,8 +21155,7 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी "
-"सिनेमा हॉल तक कैसे पहुंचूं?\""
+"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी सिनेमा हॉल तक कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21025,9 +21335,21 @@ msgid "Try Them Out"
 msgstr "इन्हें आज़माएं"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "खोज करने का प्रयास करें।"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21063,8 +21385,7 @@ msgstr "अलग कीवर्ड आज़माएं।"
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी "
-"अक्षम करें।"
+"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी अक्षम करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21094,6 +21415,12 @@ msgid "Try for free"
 msgstr "मुफ़्त में आज़माएं"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21106,6 +21433,12 @@ msgstr "मुफ़्त में आज़माएं"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "मुफ़्त में आज़माएं! एक सुरक्षित VPN, एडवांस्ड और प्राइवेट AI, और भी बहुत कुछ।"
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21133,6 +21466,12 @@ msgstr "हमारा ब्राउज़र इस्तेमाल कर
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "हमारा होमपेज आज़माएं जो कभी ये संदेश नहीं दिखाता है:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21208,8 +21547,7 @@ msgstr "हाल ही में जोड़े गए ओपन-सोर्
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
 msgstr ""
-"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को "
-"आजमाएं"
+"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को आजमाएं"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -21249,8 +21587,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
-"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
+"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21259,8 +21597,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
-"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
+"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21382,6 +21720,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "YouTube को बिना लक्षित विज्ञापनों के देखने के लिए Duck Player चालू करें"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21443,8 +21787,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और "
-"दिखाई देने वाले उत्तर के बीच थोड़ा समय लग सकता है।"
+"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और दिखाई देने वाले "
+"उत्तर के बीच थोड़ा समय लग सकता है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21574,8 +21918,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर "
-"%5$sसेट पेज%6$s पर क्लिक करें।"
+"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर %5$sसेट "
+"पेज%6$s पर क्लिक करें।"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -21583,8 +21927,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: "
-"https://duckduckgo.com"
+"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21616,9 +21960,7 @@ msgstr "%1$sसर्च%2$s सेक्शन के नीचे, %3$sसर�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s "
-"चुनें"
+msgstr "स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s चुनें"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21702,8 +22044,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 "
-"गुना ज़्यादा उपयोग सीमाएं अनलॉक करें।"
+"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 गुना ज़्यादा "
+"उपयोग सीमाएं अनलॉक करें।"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21744,6 +22086,12 @@ msgstr "DuckDuckGo सब्सक्रिप्शन के जरिए ए�
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "अपने सब्सक्रिप्शन के जरिए एडवांस्ड AI अनलॉक करें!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -21837,8 +22185,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने "
-"के लिए DuckDuckGo ब्राउज़र को अपडेट करें"
+"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने के लिए "
+"DuckDuckGo ब्राउज़र को अपडेट करें"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21963,16 +22311,14 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज "
-"बनाने के लिए बाद में वापस आएं।"
+"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज बनाने के लिए "
+"बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में "
-"अपग्रेड करें"
+msgstr "Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में अपग्रेड करें"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22068,9 +22414,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को "
-"हैकर्स, स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। "
-"मुफ़्त। किसी खाते की ज़रूरत नहीं है।"
+"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को हैकर्स, "
+"स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। मुफ़्त। किसी खाते की ज़रूरत "
+"नहीं है।"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22107,14 +22453,20 @@ msgid "Use in Safari"
 msgstr "Safari में इस्तेमाल करें"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस "
-"कोड का इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस कोड का "
+"इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22122,8 +22474,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने "
-"के लिए इस कोड का इस्तेमाल करें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने के लिए इस "
+"कोड का इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -22273,8 +22625,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को "
-"Microsoft के विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को Microsoft के "
+"विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22283,8 +22635,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक "
-"TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक TripAdvisor के "
+"विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22296,8 +22648,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist "
-"सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist सेटिंग%2$s "
+"पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22306,8 +22658,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए "
-"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sDuckAssist "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22316,8 +22668,7 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का "
-"पालन करें।"
+"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22333,8 +22684,8 @@ msgid ""
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
 "अपने दूसरे ब्राउज़र में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > %3$sSync & "
-"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के "
-"साथ सिंक करें%8$s को चुनें।"
+"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के साथ सिंक "
+"करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22344,9 +22695,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & "
-"Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक "
-"करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & Backup के "
+"अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी "
+"रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22356,9 +22707,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai "
-"सेटिंग%2$s > %3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद "
-"%7$sकिसी दूसरे डिवाइस के साथ सिंक करें%8$s को चुनें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > "
+"%3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस "
+"के साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22368,10 +22719,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की "
-"सेटिंग खोलें। Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी "
-"दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड "
-"स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। "
+"Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" "
+"को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22424,8 +22774,8 @@ msgstr "वॉयस चैट समाप्त हो गई"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
-"के लिए नहीं किया जाता है।"
+"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए "
+"नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22569,8 +22919,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को "
-"YouTube अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
+"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को YouTube "
+"अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22590,10 +22940,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है "
-"क्योंकि हमें वहाँ से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र "
-"कंपनी है और इसका YouTube से कोई संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए "
-"जाते हैं।"
+"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है क्योंकि हमें वहाँ "
+"से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र कंपनी है और इसका YouTube से कोई "
+"संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए जाते हैं।"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22606,8 +22955,8 @@ msgstr "हम गुमनाम करते हैं"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को "
-"गुमनाम रख सकते हैं।"
+"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को गुमनाम रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22619,9 +22968,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की "
-"रिपोर्ट करने के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम "
-"जांच कर सकें और समस्या का समाधान कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की रिपोर्ट करने "
+"के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम जांच कर सकें और समस्या "
+"का समाधान कर सकें।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22633,17 +22982,16 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की "
-"रिपोर्ट करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस "
-"मामले की जांच करके उसे ठीक कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की रिपोर्ट "
+"करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस मामले की जांच करके उसे "
+"ठीक कर सकें।"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल "
-"कर सकते हैं।"
+"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -22651,8 +22999,7 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक "
-"एन्क्रिप्टेड है।"
+"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक एन्क्रिप्टेड है।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22664,8 +23011,7 @@ msgstr "हम विज्ञापनों के साथ आपको फ�
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
 msgstr ""
-"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं "
-"करते हैं।"
+"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22682,8 +23028,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं "
-"करते हैं। हम आपको ट्रैक नहीं करते हैं। कभी भी।"
+"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं करते हैं। "
+"हम आपको ट्रैक नहीं करते हैं। कभी भी।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22697,8 +23043,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां "
-"वापस क्यों आए हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां वापस क्यों आए "
+"हैं:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22707,8 +23053,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस "
-"वजह से हमें आज़माना चाहते हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस वजह से हमें "
+"आज़माना चाहते हैं:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22748,9 +23094,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे "
-"विज्ञापनकर्ताओं को बेचने के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते "
-"हैं।"
+"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे विज्ञापनकर्ताओं को बेचने "
+"के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22776,8 +23121,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके "
-"कि आपकी चैट्स का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
+"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके कि आपकी चैट्स "
+"का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22802,8 +23147,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, "
-"आपके डेटा का फायदा उठाकर नहीं।"
+"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, आपके डेटा का "
+"फायदा उठाकर नहीं।"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22812,23 +23157,19 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते "
-"हैं। आप अक्‍सर बाद में अपना विचार बदल सकते हैं।"
+"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते हैं। आप अक्‍सर "
+"बाद में अपना विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते "
-"हैं।"
+msgstr "हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल "
-"हैं।"
+msgstr "हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22844,16 +23185,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा "
-"सके। %1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार "
-"तुरंत परिणामों में दिखाई ना दें।"
+"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा सके। "
+"%1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार तुरंत परिणामों में "
+"दिखाई ना दें।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले "
-"ट्रैकर्स को ब्लॉक कर देंगे।"
+"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले ट्रैकर्स को ब्लॉक कर देंगे।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22862,9 +23202,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
-"हैं। अगर आपको यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क "
-"करें।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। अगर आपको "
+"यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क करें।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22873,8 +23212,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
-"हैं। कभी-कभी अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। कभी-कभी "
+"अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22889,8 +23228,7 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार "
-"मेहनत कर रहे हैं।"
+"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार मेहनत कर रहे हैं।"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22899,8 +23237,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज "
-"फिर से लोड करना होगा।"
+"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज फिर से लोड "
+"करना होगा।"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23000,9 +23338,7 @@ msgstr "साप्ताहिक उपयोग सीमा पूरी �
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
-"हैं।"
+msgstr "साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23011,8 +23347,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट "
-"करना जारी रख सकते हैं।"
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट करना "
+"जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23026,9 +23362,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
-"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं "
-"किया जाता।"
+"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं "
+"और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23037,9 +23372,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम "
-"उन्हें अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए "
-"नहीं किया जाता।"
+"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
+"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23049,17 +23383,16 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित "
-"करता है। यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं "
-"करता है या उनका उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
+"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित करता है। "
+"यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं करता है या उनका "
+"उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर "
-"सकते हैं।"
+"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23127,8 +23460,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई "
-"है। पेज को रीलोड करने की कोशिश करें।"
+"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई है। पेज को "
+"रीलोड करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23163,8 +23496,7 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए "
-"कुछ विकल्प बताएं।"
+"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए कुछ विकल्प बताएं।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23183,12 +23515,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र "
-"डाउनलोड करने के क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही "
-"संदर्भ लें। जवाब को स्पष्ट हिस्सों में बांटें और हर हिस्से के लिए शीर्षक "
-"दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर विशेष ध्यान दिया गया "
-"हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी अनुभव रखने "
-"वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
+"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र डाउनलोड करने के "
+"क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही संदर्भ लें। जवाब को स्पष्ट हिस्सों में "
+"बांटें और हर हिस्से के लिए शीर्षक दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर "
+"विशेष ध्यान दिया गया हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी "
+"अनुभव रखने वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23298,6 +23629,12 @@ msgstr "आपको सबसे खराब क्या लगा?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "आप किस वजह से वापस आए हैं?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23418,8 +23755,7 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग "
-"होता है?"
+"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग होता है?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23495,8 +23831,8 @@ msgstr "आप किस पर फीडबैक देना चाहें�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
-"प्रभावित नहीं करेगा।"
+"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को प्रभावित नहीं "
+"करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23522,8 +23858,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद "
-"ब्रांडों पर विचार करना चाहिए?"
+"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद ब्रांडों पर "
+"विचार करना चाहिए?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23716,6 +24052,14 @@ msgstr "जीत"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "विंट्री मिक्स"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -23970,8 +24314,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे "
-"दोबारा प्राप्त नहीं किया जा सकता है।"
+"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे दोबारा प्राप्त "
+"नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23991,8 +24335,7 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24001,8 +24344,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके "
-"DuckDuckGo से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
+"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके DuckDuckGo "
+"से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24016,8 +24359,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या "
-"इसे कभी भी बंद कर सकते हैं।"
+"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या इसे कभी भी "
+"बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24026,22 +24369,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते "
-"हैं या इसे कभी भी बंद कर सकते हैं।"
+"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते हैं या इसे "
+"कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का "
-"भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का भी इस्तेमाल "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI "
-"Chat%2$s का भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI Chat%2$s "
+"का भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24055,8 +24398,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में "
-"जाकर बदल सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
+"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में जाकर बदल "
+"सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24077,8 +24420,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है "
-"और चाहे तो पहली सेटिंग को डिलीट भी कर सकते हैं।"
+"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है और चाहे तो पहली "
+"सेटिंग को डिलीट भी कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24146,6 +24489,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "प्रति बातचीत अधिकतम %1$s इमेज अटैच करने की अनुमति है।"
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24164,8 +24514,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको "
-"पहले किसी अन्य साइट को अनब्लॉक करना होगा।"
+"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको पहले किसी "
+"अन्य साइट को अनब्लॉक करना होगा।"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24222,8 +24572,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में "
-"2 गुना ज़्यादा उपयोग सीमाएं।"
+"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में 2 गुना "
+"ज़्यादा उपयोग सीमाएं।"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24232,8 +24582,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN "
-"और अन्य DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
+"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN और अन्य "
+"DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24255,9 +24605,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
-"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
-"चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
+"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24267,9 +24616,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
-"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
-"चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
+"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24285,15 +24633,20 @@ msgid ""
 msgstr "नया वर्ज़न डाउनलोड करने के बाद आपको अपने आप DuckDuckGo ऐप के अपडेट मिलेंगे।"
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए "
-"भी Chrome की बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह "
-"कर सकता है:"
+"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए भी Chrome की "
+"बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24306,8 +24659,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम "
-"करने के लिए सुझाव पाएं।"
+"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम करने के लिए "
+"सुझाव पाएं।"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24333,6 +24686,12 @@ msgid "You've blocked 1 site"
 msgstr "आपने 1 साइट को ब्लॉक कर दिया है"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24350,9 +24709,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से "
-"कोशिश करें।"
+msgstr "आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24371,8 +24728,7 @@ msgstr "आज की वॉयस चैट सीमा पूरी हो �
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
 msgstr ""
-"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से "
-"कोशिश करें।"
+"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24381,9 +24737,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त "
-"हो गई है। सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन "
-"की गई चैट डिलीट नहीं की जाएंगी।"
+"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। "
+"सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन की गई चैट डिलीट नहीं की "
+"जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24393,9 +24749,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई "
-"है। सिंक फिर से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट "
-"कर दें। पिन की गई चैट डिलीट नहीं की जाएंगी।"
+"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। सिंक फिर "
+"से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट कर दें। पिन की गई चैट डिलीट "
+"नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24409,8 +24765,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस "
-"वजह से YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
+"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस वजह से "
+"YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24454,9 +24810,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
-"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल "
-"स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
+"जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24466,9 +24821,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
-"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज "
-"में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
+"जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24493,8 +24847,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता "
-"है।DuckDuckGo के पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
+"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता है।DuckDuckGo के "
+"पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -24502,8 +24856,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo "
-"के पास इस डेटा का कभी भी एक्सेस नहीं रहा है।"
+"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo के पास इस "
+"डेटा का कभी भी एक्सेस नहीं रहा है।"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24512,8 +24866,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी "
-"दिखाई दे सकती है।"
+"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24526,8 +24880,8 @@ msgstr "आपकी चैट अब सेव की जा रही है�
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता"
+"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24541,8 +24895,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24550,8 +24904,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24559,8 +24913,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
-"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24568,8 +24922,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
-"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24584,9 +24938,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI "
-"मॉडल्स को प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री "
-"सुरक्षित रखने के लिए इन चरणों का पालन करें।"
+"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI मॉडल्स को "
+"प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री सुरक्षित रखने के लिए इन चरणों "
+"का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24595,8 +24949,7 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें "
-"जहां आपने छोड़ा था।"
+"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें जहां आपने छोड़ा था।"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24628,8 +24981,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध "
-"नहीं है। [%2$sउदाहरण संदेश%3$s]"
+"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध नहीं है। "
+"[%2$sउदाहरण संदेश%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24644,8 +24997,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए "
-"नहीं किया जाता।"
+"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए नहीं किया "
+"जाता।"
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24674,10 +25027,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का "
-"उपयोग करके '512-बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल "
-"आपके ब्राउज़र को छोड़ देती है। हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स "
-"फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी आपके पासफ़्रेज़ को नहीं जानता है।"
+"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का उपयोग करके '512-"
+"बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल आपके ब्राउज़र को छोड़ देती है। "
+"हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी "
+"आपके पासफ़्रेज़ को नहीं जानता है।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24692,9 +25045,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान "
-"बताने वाला मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे "
-"जोड़ न सकें।"
+"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान बताने वाला "
+"मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे जोड़ न सकें।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24708,8 +25060,7 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा "
-"सकते हैं।"
+"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -24735,15 +25086,22 @@ msgid "Your searches can’t be tied back to you"
 msgstr "आपकी खोजों (सर्च) की पहचान गुप्त रहती है"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
-"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर "
-"जानें%4$s"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
+"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -24763,9 +25121,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए "
-"Chrome के बजाय हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और "
-"यहां दिए गए काम कर सकता है:"
+"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए Chrome के बजाय "
+"हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और यहां दिए गए काम कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24774,8 +25131,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके "
-"फिर से कोशिश करें।"
+"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24784,8 +25141,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire "
-"Button की मदद से इस बातचीत को मिटाएं।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire Button की मदद "
+"से इस बातचीत को मिटाएं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24794,8 +25151,7 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट "
-"शुरू करें।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24810,8 +25166,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया "
-"इस चैट को अब कल जारी रखें।"
+"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया इस चैट को अब कल "
+"जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25114,8 +25470,7 @@ msgstr "ऑफ़िशियल वेबसाइट"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s "
-"अक्षर है)"
+"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s अक्षर है)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25326,3 +25681,9 @@ msgstr "वर्ष"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "वर्ष"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -88,8 +87,7 @@ msgstr "AI modeli %1$s i %2$s"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
+msgstr "%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -129,7 +127,7 @@ msgstr "Otkriven %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Korištenih datoteka: %1$s"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -367,7 +365,7 @@ msgstr "%1$s rabljeno"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -504,8 +502,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
+msgstr "%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -625,7 +622,7 @@ msgstr "Prije jednog dana"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "Korištena 1 datoteka"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -926,8 +923,7 @@ msgstr "Dostupna je nova verzija AI Chata! Osvježi ovu stranicu za nastavak."
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
+msgstr "Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1544,6 +1540,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Napredni modeli mogu brže trošiti uporabna ograničenja, 2 do 5 puta više od "
+"ostalih modela. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2336,7 +2334,7 @@ msgstr "Pitaj privatno"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Pitaj privatno"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2487,8 +2485,7 @@ msgstr "Nakon završetka čavrljanja, zvuk ne pohranjujemo ni mi ni OpenAI."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
+msgstr "Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2929,8 +2926,7 @@ msgstr "Blokiraj ovu stranicu iz svih rezultata"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
+msgstr "Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3658,8 +3654,7 @@ msgstr "Promjena načina prikaza URL-ova rezultata"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
+msgstr "Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3898,7 +3893,7 @@ msgstr "Privatno čavrljaj s AI-om"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Privatno čavrljaj s popularnim AI-jevima"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4478,8 +4473,7 @@ msgstr "Klikni %1$sPostavke%2$s u padajućem izborniku."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
+msgstr "Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4695,7 +4689,7 @@ msgstr "Zatvori"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Zatvori"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4745,7 +4739,7 @@ msgstr "Zatvori pretraživanje"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Zatvori drugo mišljenje"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5124,7 +5118,7 @@ msgstr "Nastavi blokirati oglase"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5195,7 +5189,7 @@ msgstr "Sadržaj kolačića:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Kopirano"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5248,7 +5242,7 @@ msgstr "Kopiraj šifru"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopiraj poveznicu"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5318,8 +5312,7 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
+msgstr "Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5368,7 +5361,7 @@ msgstr "Izradi sliku"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Stvori poveznicu za dijeljenje"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5420,6 +5413,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Stvaranjem poveznice izrađuje se kopija razgovora koju može vidjeti svatko "
+"tko je otvori."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5578,7 +5573,7 @@ msgstr "Prilagodi odgovore"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Prilagodi odgovore"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5870,7 +5865,7 @@ msgstr "Izbrisati podatke poslužitelja?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Izbriši podijeljenu poveznicu"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5882,7 +5877,7 @@ msgstr "Izbriši transkript"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Izbriši čavrljanje"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5920,7 +5915,7 @@ msgstr "Izbrisati sliku?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Izbriši me"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6149,8 +6144,7 @@ msgstr "Onemogući i isključi"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
+msgstr "Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6237,7 +6231,7 @@ msgstr "Odbaci promociju"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Odbaci obilazak"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6453,7 +6447,7 @@ msgstr "Preuzmi DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Preuzmi DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6674,7 +6668,7 @@ msgstr "Duck.ai by DuckDuckGo. Privatno AI čavrljanje. Besplatno."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai sada može analizirati PDF-ove. Isprobaj ga!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6713,8 +6707,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
+msgstr "Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6833,7 +6826,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai podržava modele Anthropica, OpenAI-ja i drugih."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7038,8 +7031,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
+msgstr "DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7168,8 +7160,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš Duck.ai-"
-"jeve %2$s."
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš "
+"Duck.ai-jeve %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7177,8 +7169,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
+msgstr "DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7385,8 +7376,7 @@ msgstr "Slika se uređuje..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
+msgstr "Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7486,7 +7476,7 @@ msgstr "Omogući najposjećenije web lokacije"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Omogući"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7789,7 +7779,7 @@ msgstr "Vodič za zabavu"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Cijelo čavrljanje"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7799,8 +7789,7 @@ msgstr "Ekvatorska Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
+msgstr "Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7959,13 +7948,13 @@ msgstr "Eksplicitni stihovi"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Istraži Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Istraži Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8072,7 +8061,7 @@ msgstr "Besplatno"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "BESPLATNO I NEOBAVEZNO"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8150,8 +8139,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje web-"
-"mjesto."
+"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje "
+"web-mjesto."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8287,8 +8276,7 @@ msgstr "Pronađi <b>%1$s</b> u mapi za preuzimanje"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
+msgstr "Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8497,7 +8485,7 @@ msgstr "Oslobodi prostor za pohranu"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Besplatno i uvijek privatno"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8509,8 +8497,7 @@ msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
+msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9018,7 +9005,7 @@ msgstr "Zatraži pomoć za računalo"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Ostvari veće količine korištenja uz pretplatu na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9061,13 +9048,13 @@ msgstr "Preuzmi najnoviju verziju"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Preuzmi aplikaciju"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
+msgstr "Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9095,7 +9082,7 @@ msgstr "Preporuči nas prijateljima i pomozi nam da rastemo!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Kontrolni popis za početak"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9639,8 +9626,7 @@ msgstr "Pomozi nam poboljšati DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
+msgstr "Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9786,7 +9772,7 @@ msgstr "Sakrij savjete"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Sakrij vodič"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10077,8 +10063,7 @@ msgstr "Kako funkcionira"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
+msgstr "Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10337,8 +10322,7 @@ msgstr "Ako nas ipak želiš podržati, %1$spomozi proširiti DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
+msgstr "Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10646,8 +10630,7 @@ msgstr "Lako pregledavanje rezultata pretraživanja za slike i videozapise"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Infinite Scroll for Images, Videos, and Shopping"
-msgstr ""
-"Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
+msgstr "Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is accurate
@@ -11413,6 +11396,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Omogućuje ti prebacivanje između slanja upita za pretraživanje i upita za "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11488,7 +11473,7 @@ msgstr "Osvojeni lineouti"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Poveznica istječe za 7 dana."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12143,8 +12128,7 @@ msgstr "Mikronezija"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
+msgstr "Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12589,7 +12573,7 @@ msgstr "Duže od 20 minuta"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Više savjeta"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13083,7 +13067,7 @@ msgstr "Ne, hvala"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Ne, hvala"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13751,7 +13735,7 @@ msgstr "Uključeno, ali bez brojeva"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Uvođenje je dovršeno"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13969,7 +13953,7 @@ msgstr "Otvori prijedloge za izradu i uređivanje slika"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Otvori popis za početak"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14722,7 +14706,7 @@ msgstr "Pribadača"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Prikvači čavrljanje"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14734,7 +14718,7 @@ msgstr "Prikvači čavrljanja ovdje iz %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Prikvači me"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14757,7 +14741,7 @@ msgstr "Prikvačeno"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14812,8 +14796,7 @@ msgstr "Ispuni sljedeći upit i potvrdi da je ovo pretraživanje izvršio čovje
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
+msgstr "Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15078,6 +15061,8 @@ msgstr "Loše formatiranje"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Dostupni su popularni AI modeli. Nije potreban račun. Razgovore "
+"anonimiziramo mi."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15291,7 +15276,7 @@ msgstr "Prethodne kartice"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Prethodni savjeti"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15839,13 +15824,15 @@ msgstr "AI za rasuđivanje s ugrađenom srednjom razinom moderacije"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Rasuđivanje može pružiti bolje odgovore na složena pitanja."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Razmišljanje je temeljitije, ali 2 do 5 puta brže troši uporabna "
+"ograničenja. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15886,7 +15873,7 @@ msgstr "Nedavna pohrana čavrljanja može se prilagoditi u %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Nedavna čavrljanja"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16047,7 +16034,7 @@ msgstr "Smanji uporabu"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Smanji uporabu s učinkovitijim modelom"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16197,8 +16184,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb &quot;"
-"Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
+"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb "
+"&quot;Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
 "pregledniku."
 
 # smartling.placeholder_format=C
@@ -16209,8 +16196,7 @@ msgstr "Zapamti moj izbor"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
+msgstr "Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16432,7 +16418,7 @@ msgstr "Resetiraj sve postavke"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Resetiraj vodič"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16450,7 +16436,7 @@ msgstr "Razlučivost"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Odgovor"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16942,8 +16928,7 @@ msgstr "Spremi do 30 svojih najnovijih čavrljanja lokalno na svom uređaju."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
+msgstr "Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17128,8 +17113,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
+msgstr "Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17157,7 +17141,7 @@ msgstr "Potražiti %1$s kako bi pronašao rezultate bliže tebi?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Prekidač za pretraživanje i Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17422,8 +17406,7 @@ msgstr "Pretraži putem DuckDuckGoa"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
+msgstr "Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17473,8 +17456,7 @@ msgstr "Drugo mišljenje"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+msgstr "Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17523,8 +17505,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
+msgstr "Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17540,7 +17521,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Sigurno pohranjeno na našem šifriranom poslužitelju."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17716,8 +17697,7 @@ msgstr "Odaberi %1$sDuckDuckGo%2$s u padajućem izborniku zadanih tražilica"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr "Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17836,8 +17816,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr "Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18055,7 +18034,7 @@ msgstr "Postavi kao početnu stranicu"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Postavi ton i stil odgovora usluge Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18077,8 +18056,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
+msgstr "Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18127,13 +18105,13 @@ msgstr "Sejšeli"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Podijeli"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Podijeli"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18144,8 +18122,7 @@ msgstr "Podijeli"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
+msgstr "Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18181,7 +18158,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Podijeli čavrljanje"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18245,7 +18222,7 @@ msgstr "Podijeli pozitivne povratne informacije"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Opseg dijeljenja"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18386,7 +18363,7 @@ msgstr "Prikaži detalje"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Prikaži Duck.ai vodič"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18397,8 +18374,7 @@ msgstr "Prikaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
+msgstr "Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18540,7 +18516,7 @@ msgstr "Prikaži više"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Prikaži više modela"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18581,7 +18557,7 @@ msgstr "Prikaži bočnu traku"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Prikaži savjete korak po korak kako najbolje iskoristiti Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18725,8 +18701,7 @@ msgstr "Prikazuje poruku dobrodošlice na vrhu stranice rezultata pretraživanja
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
+msgstr "Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18798,14 +18773,12 @@ msgstr "Nazivi web-mjesta"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
+msgstr "Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
+msgstr "Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18964,7 +18937,7 @@ msgstr "Nešto nije bilo kako treba, pokušaj ponovno malo kasnije."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Nešto nije bilo kako treba. Pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18982,8 +18955,7 @@ msgstr "Ponekad"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
+msgstr "Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19031,8 +19003,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
+msgstr "Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19112,8 +19083,7 @@ msgstr "Izvorni tekst je izbrisan"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
+msgstr "Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19265,7 +19235,7 @@ msgstr "Počni koristiti tjedno ograničenje"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Započni novo čavrljanje"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19318,22 +19288,19 @@ msgstr "Ostani na DuckDuckGou"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19371,15 +19338,14 @@ msgstr "Zaustavi generiranje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
+msgstr "Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
 msgstr ""
-"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim web-"
-"mjestima."
+"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim "
+"web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19857,7 +19823,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Prebaci se na ovo drugo mišljenje"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20018,7 +19984,7 @@ msgstr "Sinkronizacija i sigurnosno kopiranje privremeno su nedostupni"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sinkroniziraj čavrljanja na različitim uređajima"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20114,6 +20080,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Ponesi Duck.ai sa sobom posvuda. Nabavi ga ugrađenog u našu besplatnu "
+"aplikaciju za brži pristup, gdje god se nalaziš."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20122,6 +20090,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Ponesi Duck.ai sa sobom posvuda. Nabavi ga ugrađenog u naš besplatni "
+"preglednik za brži pristup, gdje god pregledavaš."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20392,8 +20362,7 @@ msgstr "Priložene datoteke prelaze ukupno ograničenje veličine od %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
+msgstr "Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20594,7 +20563,7 @@ msgstr "Ovaj mjesec"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Ovaj odgovor"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20606,7 +20575,7 @@ msgstr "Ovaj tjedan"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Ovaj razgovor ostaje u Duck.ai-ju i tebi ostaje privatan."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20744,6 +20713,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Ovo je samo primjer čavrljanja. Otvori njegov izbornik (tri točke), a zatim "
+"odaberi Prikvači kako bi ostao na vrhu tvojih čavrljanja!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20752,6 +20723,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Ovo je samo primjer čavrljanja. Upotrijebi Fire Button u bočnom izborniku da "
+"ga izbrišeš!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20800,8 +20773,7 @@ msgstr "Za pravilno funkcioniranje ove stranice potreban je Javascript."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
+msgstr "Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20872,8 +20844,7 @@ msgstr "Ovaj je prijevod pogrešan"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
+msgstr "Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21043,8 +21014,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš ispisati."
-"%3$sKlikni na ikonu za ispis.%4$s"
+"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš "
+"ispisati.%3$sKlikni na ikonu za ispis.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21098,7 +21069,7 @@ msgstr "Danas"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
+msgstr "Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21146,8 +21117,7 @@ msgstr "Previše oglasa"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr ""
-"Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
+msgstr "Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21516,7 +21486,7 @@ msgstr "Isprobaj ih"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Pokušaj s drugim modelom"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21527,7 +21497,7 @@ msgstr "Isprobaj pretragu!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Isprobaj prijedlog"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21577,8 +21547,7 @@ msgstr "Pokušaj omogućiti anonimnu lokaciju za točnije rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
+msgstr "Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21598,7 +21567,7 @@ msgstr "Probaj besplatno"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Isprobaj besplatno"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21620,7 +21589,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Probaj besplatno 7 dana"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21653,7 +21622,7 @@ msgstr "Isprobaj našu početnu stranicu koja nikad ne prikazuje ove poruke:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Isprobaj rasuđivanje"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21900,14 +21869,13 @@ msgstr "Uključi %1$sPreciznu lokaciju%2$s za preciznije rezultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
+msgstr "Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Uključi Duck.ai preklopnik"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22071,8 +22039,7 @@ msgstr "Nije moguće poslati povratne informacije"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
+msgstr "Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22124,8 +22091,7 @@ msgstr "Pod %1$sOtvori s%2$s odaberi %3$sOdređenu stranicu ili stranice%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
+msgstr "Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22147,15 +22113,13 @@ msgstr "Pod %1$sTraži%2$s, klikni %3$sUpravljaj tražilicama...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
+msgstr "Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
+msgstr "Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22255,8 +22219,7 @@ msgstr "Otključaj uz pretplatu na DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
+msgstr "Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22281,7 +22244,7 @@ msgstr "Otključaj naprednu umjetnu inteligenciju uz svoju pretplatu!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Otključaj napredne modele"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22490,8 +22453,7 @@ msgctxt ""
 "Description prompting Plus subscribers to upgrade to Pro for higher image "
 "generation limits"
 msgid "Upgrade to Pro to unlock 2x higher limits"
-msgstr ""
-"Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
+msgstr "Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
 
 # smartling.placeholder_format=C
 #. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
@@ -22651,7 +22613,7 @@ msgstr "Koristi u Safariju"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Pomoću Fire Buttona izbriši čavrljanje iz povijesti."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22917,8 +22879,8 @@ msgid ""
 msgstr ""
 "Posjeti Duck.ai u svom drugom pregledniku ili u aplikaciji DuckDuckGo i "
 "otvori Postavke Duck.ai. Odaberi „Uključi“ pod Sync & Backup i odaberi "
-"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery PDF-"
-"u."
+"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery "
+"PDF-u."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23197,8 +23159,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
+msgstr "Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23665,8 +23626,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem Duck."
-"ai. Pokušaj ponovo učitati stranicu."
+"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem "
+"Duck.ai. Pokušaj ponovo učitati stranicu."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23680,8 +23641,7 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr ""
-"Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
+msgstr "Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -23844,7 +23804,7 @@ msgstr "Što te danas dovelo natrag?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Što možeš učiniti?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23965,8 +23925,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra URL-"
-"a označenog apleta?"
+"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra "
+"URL-a označenog apleta?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24041,8 +24001,7 @@ msgstr "O čemu želiš pružiti povratne informacije?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
+msgstr "Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24074,8 +24033,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
+msgstr "Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24093,8 +24051,7 @@ msgstr "Gdje gledati <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
+msgstr "Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24272,6 +24229,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Uz Duck.ai, tvoja su čavrljanja anonimizirana i nikada se ne koriste za "
+"obuku umjetne inteligencije. Uključi ili isključi u bilo kojem trenutku u "
+"izborniku '%1$s'."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24525,8 +24485,7 @@ msgstr "Da, novi korisnik!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
+msgstr "Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24617,15 +24576,13 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
+msgstr "Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
+msgstr "Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24664,8 +24621,7 @@ msgstr "Možeš nastaviti razgovarati koristeći svoje mjesečno ograničenje."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
+msgstr "Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24708,7 +24664,7 @@ msgstr "Možeš priložiti samo %1$s slike/a po razgovoru."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Možeš priložiti samo %1$s kartica odjednom."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24839,8 +24795,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
+msgstr "Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24856,7 +24811,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Sve je spremno!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24910,7 +24865,7 @@ msgstr "Blokirao si 1 stranicu"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Savladao si osnove Duck.ai-ja"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24945,14 +24900,12 @@ msgstr "Dosegao si maksimalno trajanje glasovnog čavrljanja za jednu sesiju."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
+msgstr "Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
+msgstr "Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25113,8 +25066,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
+msgstr "Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25175,8 +25127,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u Duck."
-"ai."
+"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25321,6 +25273,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Tvoje su postavke spremljene, ali brisanje kolačića će ih resetirati. "
+"Omogući proširenje %1$sDuckDuckGo No AI%2$s kako bi to postalo trajno."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25360,8 +25314,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
+msgstr "Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25701,8 +25654,7 @@ msgstr "službenu web lokaciju"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
+msgstr "ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25918,4 +25870,4 @@ msgstr "god."
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -87,7 +88,8 @@ msgstr "AI modeli %1$s i %2$s"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
+msgstr ""
+"%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -122,6 +124,12 @@ msgstr "Prije %1$s dana"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Otkriven %1$s"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -356,6 +364,12 @@ msgid "%s used"
 msgstr "%1$s rabljeno"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s prikaz"
@@ -490,7 +504,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
+msgstr ""
+"%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -605,6 +620,12 @@ msgstr "DuckDuckGo je blokirao 1 pokušaj u zadnja 24 sata"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Prije jednog dana"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -905,7 +926,8 @@ msgstr "Dostupna je nova verzija AI Chata! Osvježi ovu stranicu za nastavak."
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
+msgstr ""
+"Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1514,6 +1536,14 @@ msgctxt ""
 "app variant)"
 msgid "Advanced Models"
 msgstr "Napredni modeli"
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2303,6 +2333,12 @@ msgid "Ask privately"
 msgstr "Pitaj privatno"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2451,7 +2487,8 @@ msgstr "Nakon završetka čavrljanja, zvuk ne pohranjujemo ni mi ni OpenAI."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
+msgstr ""
+"Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2892,7 +2929,8 @@ msgstr "Blokiraj ovu stranicu iz svih rezultata"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
+msgstr ""
+"Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3620,7 +3658,8 @@ msgstr "Promjena načina prikaza URL-ova rezultata"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
+msgstr ""
+"Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3854,6 +3893,12 @@ msgstr "Privatno čavrljaj s %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Privatno čavrljaj s AI-om"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4433,7 +4478,8 @@ msgstr "Klikni %1$sPostavke%2$s u padajućem izborniku."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
+msgstr ""
+"Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4646,6 +4692,12 @@ msgid "Close"
 msgstr "Zatvori"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4688,6 +4740,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Zatvori pretraživanje"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5063,6 +5121,12 @@ msgid "Continue Blocking Ads"
 msgstr "Nastavi blokirati oglase"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5128,6 +5192,12 @@ msgid "Cookie data:"
 msgstr "Sadržaj kolačića:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5173,6 +5243,12 @@ msgstr "Kopiraj i zalijepi %1$sabout:preferences#search%2$s u adresnu traku"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopiraj šifru"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5242,7 +5318,8 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
+msgstr ""
+"Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5288,6 +5365,12 @@ msgid "Create Image"
 msgstr "Izradi sliku"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5329,6 +5412,14 @@ msgstr "Izradio"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Kreirao %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5482,6 +5573,12 @@ msgstr "Prilagodi odgovore"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Prilagodi odgovore"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5770,10 +5867,22 @@ msgid "Delete Server Data?"
 msgstr "Izbrisati podatke poslužitelja?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Izbriši transkript"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5806,6 +5915,12 @@ msgstr "Izbriši sliku"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Izbrisati sliku?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6034,7 +6149,8 @@ msgstr "Onemogući i isključi"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
+msgstr ""
+"Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6116,6 +6232,12 @@ msgstr "Zauvijek odbaci"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Odbaci promociju"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6326,6 +6448,12 @@ msgstr "Preuzimanje dovršeno"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Preuzmi DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6543,6 +6671,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai by DuckDuckGo. Privatno AI čavrljanje. Besplatno."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6579,7 +6713,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
+msgstr ""
+"Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6693,6 +6828,12 @@ msgid ""
 msgstr ""
 "Odgovori Duck.ai ne temelje se na specifičnim izvorima niti su provjereni za "
 "točnost."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6897,7 +7038,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
+msgstr ""
+"DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7026,8 +7168,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš "
-"Duck.ai-jeve %2$s."
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš Duck.ai-"
+"jeve %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7035,7 +7177,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
+msgstr ""
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7242,7 +7385,8 @@ msgstr "Slika se uređuje..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
+msgstr ""
+"Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7337,6 +7481,12 @@ msgstr "Omogući najposjećenija web-mjesta"
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Omogući najposjećenije web lokacije"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7636,6 +7786,12 @@ msgid "Entertainment guide"
 msgstr "Vodič za zabavu"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Ekvatorska Gvineja"
 
@@ -7643,7 +7799,8 @@ msgstr "Ekvatorska Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
+msgstr ""
+"Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7799,6 +7956,18 @@ msgid "Explicit lyrics"
 msgstr "Eksplicitni stihovi"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7900,6 +8069,12 @@ msgid "FREE"
 msgstr "Besplatno"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7975,8 +8150,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje "
-"web-mjesto."
+"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje web-"
+"mjesto."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8112,7 +8287,8 @@ msgstr "Pronađi <b>%1$s</b> u mapi za preuzimanje"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
+msgstr ""
+"Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8318,6 +8494,12 @@ msgid "Free Up Storage"
 msgstr "Oslobodi prostor za pohranu"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8327,7 +8509,8 @@ msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
+msgstr ""
+"Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8832,6 +9015,12 @@ msgid "Get computer help"
 msgstr "Zatraži pomoć za računalo"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8869,6 +9058,18 @@ msgid "Get the Latest Version"
 msgstr "Preuzmi najnoviju verziju"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8889,6 +9090,12 @@ msgstr "Preuzmi ovu pjesmu na:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Preporuči nas prijateljima i pomozi nam da rastemo!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9432,7 +9639,8 @@ msgstr "Pomozi nam poboljšati DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
+msgstr ""
+"Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9573,6 +9781,12 @@ msgstr "Sakrij korake"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Sakrij savjete"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9863,7 +10077,8 @@ msgstr "Kako funkcionira"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
+msgstr ""
+"Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10122,7 +10337,8 @@ msgstr "Ako nas ipak želiš podržati, %1$spomozi proširiti DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
+msgstr ""
+"Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10430,7 +10646,8 @@ msgstr "Lako pregledavanje rezultata pretraživanja za slike i videozapise"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Infinite Scroll for Images, Videos, and Shopping"
-msgstr "Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
+msgstr ""
+"Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is accurate
@@ -11191,6 +11408,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Omogućuje anonimno pretraživanje pomoću DuckDuckGoa"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberija"
 
@@ -11259,6 +11483,12 @@ msgstr "Linijski crtež"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Osvojeni lineouti"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11913,7 +12143,8 @@ msgstr "Mikronezija"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
+msgstr ""
+"Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12353,6 +12584,12 @@ msgstr "Više statistika o %1$s"
 msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Duže od 20 minuta"
+
+# smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12841,6 +13078,12 @@ msgstr "Ne, hvala"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Ne, hvala"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13505,6 +13748,12 @@ msgid "On but no numbers"
 msgstr "Uključeno, ali bez brojeva"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13715,6 +13964,12 @@ msgstr "Otvori prijedloge za čavrljanje"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Otvori prijedloge za izradu i uređivanje slika"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14464,10 +14719,22 @@ msgid "Pin"
 msgstr "Pribadača"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Prikvači čavrljanja ovdje iz %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14485,6 +14752,12 @@ msgstr "Ružičasta"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Prikvačeno"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14539,7 +14812,8 @@ msgstr "Ispuni sljedeći upit i potvrdi da je ovo pretraživanje izvršio čovje
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
+msgstr ""
+"Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14800,6 +15074,12 @@ msgid "Poor formatting"
 msgstr "Loše formatiranje"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15006,6 +15286,12 @@ msgstr "Prethodna slika"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Prethodne kartice"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15550,6 +15836,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "AI za rasuđivanje s ugrađenom srednjom razinom moderacije"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15583,6 +15881,12 @@ msgstr "Nedavne kartice"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Nedavna pohrana čavrljanja može se prilagoditi u %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15740,6 +16044,12 @@ msgid "Reduce Usage"
 msgstr "Smanji uporabu"
 
 # smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
@@ -15887,8 +16197,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb "
-"&quot;Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
+"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb &quot;"
+"Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
 "pregledniku."
 
 # smartling.placeholder_format=C
@@ -15899,7 +16209,8 @@ msgstr "Zapamti moj izbor"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
+msgstr ""
+"Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16118,6 +16429,12 @@ msgid "Reset All Settings"
 msgstr "Resetiraj sve postavke"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16128,6 +16445,12 @@ msgstr "Resetira se za %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Razlučivost"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16619,7 +16942,8 @@ msgstr "Spremi do 30 svojih najnovijih čavrljanja lokalno na svom uređaju."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
+msgstr ""
+"Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16804,7 +17128,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
+msgstr ""
+"Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16827,6 +17152,12 @@ msgstr "Traži"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Potražiti %1$s kako bi pronašao rezultate bliže tebi?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17091,7 +17422,8 @@ msgstr "Pretraži putem DuckDuckGoa"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
+msgstr ""
+"Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17141,7 +17473,8 @@ msgstr "Drugo mišljenje"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+msgstr ""
+"Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17190,7 +17523,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
+msgstr ""
+"Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17201,6 +17535,12 @@ msgid ""
 msgstr ""
 "Sigurno pohranjeno na poslužitelju DuckDuckGoa s end-to-end šifriranjem. "
 "Nitko osim tebe ne može vidjeti tvoje podatke, čak ni mi."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17376,7 +17716,8 @@ msgstr "Odaberi %1$sDuckDuckGo%2$s u padajućem izborniku zadanih tražilica"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr ""
+"Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17495,7 +17836,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr ""
+"Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17710,6 +18052,12 @@ msgid "Set as Homepage"
 msgstr "Postavi kao početnu stranicu"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17729,7 +18077,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
+msgstr ""
+"Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17775,6 +18124,18 @@ msgid "Seychelles"
 msgstr "Sejšeli"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17783,7 +18144,8 @@ msgstr "Podijeli"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
+msgstr ""
+"Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17813,6 +18175,13 @@ msgstr ""
 "Podijeli lokaciju na razini grada s AI modelima u svrhu poboljšanja "
 "relevantnosti. Duck.ai nikada ne otkriva tvoju točnu lokaciju nama ili AI "
 "modelima."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17871,6 +18240,12 @@ msgstr "Podijeli URL stranice"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Podijeli pozitivne povratne informacije"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18008,6 +18383,12 @@ msgid "Show Detail"
 msgstr "Prikaži detalje"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "Prikaži DuckAssist <sup>BETA</sup>"
@@ -18016,7 +18397,8 @@ msgstr "Prikaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
+msgstr ""
+"Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18155,6 +18537,12 @@ msgid "Show more"
 msgstr "Prikaži više"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18188,6 +18576,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Prikaži bočnu traku"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18331,7 +18725,8 @@ msgstr "Prikazuje poruku dobrodošlice na vrhu stranice rezultata pretraživanja
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
+msgstr ""
+"Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18403,12 +18798,14 @@ msgstr "Nazivi web-mjesta"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
+msgstr ""
+"Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
+msgstr ""
+"Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18564,6 +18961,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Nešto nije bilo kako treba, pokušaj ponovno malo kasnije."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18579,7 +18982,8 @@ msgstr "Ponekad"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
+msgstr ""
+"Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18627,7 +19031,8 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
+msgstr ""
+"Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18707,7 +19112,8 @@ msgstr "Izvorni tekst je izbrisan"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
+msgstr ""
+"Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18856,6 +19262,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Počni koristiti tjedno ograničenje"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Počni pretraživati!"
@@ -18906,19 +19318,22 @@ msgstr "Ostani na DuckDuckGou"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18956,14 +19371,15 @@ msgstr "Zaustavi generiranje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
+msgstr ""
+"Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
 msgstr ""
-"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim "
-"web-mjestima."
+"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim web-"
+"mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19436,6 +19852,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Prijeđi na tražilicu koja te ne prati. Nikad."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19591,6 +20015,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sinkronizacija i sigurnosno kopiranje privremeno su nedostupni"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19676,6 +20106,22 @@ msgstr "Tadžikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Vrati svoju privatnost!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19946,7 +20392,8 @@ msgstr "Priložene datoteke prelaze ukupno ograničenje veličine od %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
+msgstr ""
+"Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20144,10 +20591,22 @@ msgid "This Month"
 msgstr "Ovaj mjesec"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Ovaj tjedan"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20279,6 +20738,22 @@ msgid "This information isn’t useful"
 msgstr "Ove informacije nisu korisne"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20325,7 +20800,8 @@ msgstr "Za pravilno funkcioniranje ove stranice potreban je Javascript."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
+msgstr ""
+"Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20396,7 +20872,8 @@ msgstr "Ovaj je prijevod pogrešan"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
+msgstr ""
+"Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20566,8 +21043,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš "
-"ispisati.%3$sKlikni na ikonu za ispis.%4$s"
+"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš ispisati."
+"%3$sKlikni na ikonu za ispis.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20618,6 +21095,12 @@ msgid "Today"
 msgstr "Danas"
 
 # smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Togo"
 msgstr "Togo"
 
@@ -20663,7 +21146,8 @@ msgstr "Previše oglasa"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr "Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
+msgstr ""
+"Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21029,9 +21513,21 @@ msgid "Try Them Out"
 msgstr "Isprobaj ih"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Isprobaj pretragu!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21081,7 +21577,8 @@ msgstr "Pokušaj omogućiti anonimnu lokaciju za točnije rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
+msgstr ""
+"Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21098,6 +21595,12 @@ msgid "Try for free"
 msgstr "Probaj besplatno"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21112,6 +21615,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Isprobaj besplatno! Siguran VPN, napredna i privatna umjetna inteligencija i "
 "još mnogo toga."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21139,6 +21648,12 @@ msgstr "Probaj naš preglednik"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Isprobaj našu početnu stranicu koja nikad ne prikazuje ove poruke:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21385,7 +21900,14 @@ msgstr "Uključi %1$sPreciznu lokaciju%2$s za preciznije rezultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
+msgstr ""
+"Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21549,7 +22071,8 @@ msgstr "Nije moguće poslati povratne informacije"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
+msgstr ""
+"Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -21601,7 +22124,8 @@ msgstr "Pod %1$sOtvori s%2$s odaberi %3$sOdređenu stranicu ili stranice%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
+msgstr ""
+"Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21623,13 +22147,15 @@ msgstr "Pod %1$sTraži%2$s, klikni %3$sUpravljaj tražilicama...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
+msgstr ""
+"Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
+msgstr ""
+"Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21729,7 +22255,8 @@ msgstr "Otključaj uz pretplatu na DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
+msgstr ""
+"Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21749,6 +22276,12 @@ msgstr "Otključaj napredne AI modele uz pretplatu na DuckDuckGo"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Otključaj naprednu umjetnu inteligenciju uz svoju pretplatu!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -21957,7 +22490,8 @@ msgctxt ""
 "Description prompting Plus subscribers to upgrade to Pro for higher image "
 "generation limits"
 msgid "Upgrade to Pro to unlock 2x higher limits"
-msgstr "Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
+msgstr ""
+"Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
 
 # smartling.placeholder_format=C
 #. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
@@ -22112,6 +22646,12 @@ msgstr "Koristi u Firefoxu"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Koristi u Safariju"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22377,8 +22917,8 @@ msgid ""
 msgstr ""
 "Posjeti Duck.ai u svom drugom pregledniku ili u aplikaciji DuckDuckGo i "
 "otvori Postavke Duck.ai. Odaberi „Uključi“ pod Sync & Backup i odaberi "
-"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery "
-"PDF-u."
+"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery PDF-"
+"u."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22657,7 +23197,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
+msgstr ""
+"Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23124,8 +23665,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem "
-"Duck.ai. Pokušaj ponovo učitati stranicu."
+"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem Duck."
+"ai. Pokušaj ponovo učitati stranicu."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23139,7 +23680,8 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr "Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
+msgstr ""
+"Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -23299,6 +23841,12 @@ msgid "What brought you back today?"
 msgstr "Što te danas dovelo natrag?"
 
 # smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -23417,8 +23965,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra "
-"URL-a označenog apleta?"
+"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra URL-"
+"a označenog apleta?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23493,7 +24041,8 @@ msgstr "O čemu želiš pružiti povratne informacije?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
+msgstr ""
+"Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23525,7 +24074,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
+msgstr ""
+"Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23543,7 +24093,8 @@ msgstr "Gdje gledati <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
+msgstr ""
+"Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23713,6 +24264,14 @@ msgstr "Pobjeda"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Razne zimske nepogode"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -23966,7 +24525,8 @@ msgstr "Da, novi korisnik!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
+msgstr ""
+"Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24057,13 +24617,15 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
+msgstr ""
+"Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
+msgstr ""
+"Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24102,7 +24664,8 @@ msgstr "Možeš nastaviti razgovarati koristeći svoje mjesečno ograničenje."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
+msgstr ""
+"Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24139,6 +24702,13 @@ msgstr "Možeš priložiti samo %1$s slike/a po razgovoru"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Možeš priložiti samo %1$s slike/a po razgovoru."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24269,7 +24839,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
+msgstr ""
+"Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24280,6 +24851,12 @@ msgid ""
 msgstr ""
 "Primit ćeš automatska ažuriranja aplikacije DuckDuckGo kada nabaviš "
 "najnoviju verziju."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24330,6 +24907,12 @@ msgid "You've blocked 1 site"
 msgstr "Blokirao si 1 stranicu"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24362,12 +24945,14 @@ msgstr "Dosegao si maksimalno trajanje glasovnog čavrljanja za jednu sesiju."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
+msgstr ""
+"Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
+msgstr ""
+"Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24528,7 +25113,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
+msgstr ""
+"Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24589,8 +25175,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u "
-"Duck.ai."
+"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24729,6 +25315,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Tvoja se pretraživanja ne mogu povezati s tobom"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24766,7 +25360,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
+msgstr ""
+"Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25106,7 +25701,8 @@ msgstr "službenu web lokaciju"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
+msgstr ""
+"ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25317,3 +25913,9 @@ msgstr "godine"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "god."
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s nyelv észlelve"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s felhasznált fájl"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -182,9 +182,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
-"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
-"Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
+"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
+"válts a Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -194,9 +194,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
-"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
-"Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
+"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
+"válts a Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -365,6 +365,8 @@ msgstr "%1$s felhasználva"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
+"%1$s akár 2–5-ször gyorsabban használja fel a limiteket, mint az alapvető "
+"modellek %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -480,8 +482,7 @@ msgstr "%1$sTudj meg többet%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
+msgstr "%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -496,15 +497,13 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
+msgstr "%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
+msgstr "%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -622,7 +621,7 @@ msgstr "1 nappal ezelőtt"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 fájl felhasználva"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -843,8 +842,7 @@ msgstr "Elérted a 6 órás használati limitet."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
+msgstr "Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -969,8 +967,9 @@ msgstr ""
 "Az AI Chat segítségével névtelen beszélgetéseket folytathatsz harmadik felek "
 "mesterséges intelligencián alapuló csevegési modelljeivel. Ennek "
 "kikapcsolása elrejti az AI Chat funkciót a DuckDuckGo Search "
-"szolgáltatásban. Ha a beállítás ki van kapcsolva, a %1$sduckduckgo.com/"
-"aichat%2$s oldalra látogatva továbbra is elérheted az AI Chatet."
+"szolgáltatásban. Ha a beállítás ki van kapcsolva, a "
+"%1$sduckduckgo.com/aichat%2$s oldalra látogatva továbbra is elérheted az AI "
+"Chatet."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1034,8 +1033,9 @@ msgstr ""
 "Az AI-alapú válaszokra jelenleg nem tehetők fel közvetlenül további "
 "kérdések. Azonban ha újabb kérdést szeretnél feltenni, az OpenAI, az "
 "Anthropic, valamint más szolgáltatók csevegési modelljeit is támogató "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a %1$sDuck."
-"ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak linkjét."
+"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a "
+"%1$sDuck.ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak "
+"linkjét."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1544,6 +1544,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"A fejlett modellek 2–5-ször gyorsabban használhatják fel a limiteket, mint "
+"más modellek. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1825,8 +1827,7 @@ msgstr "Adatvédelmet tiszteletben tartó hirdetések engedélyezése"
 #. Title of the upload consent prompt shown before the first image/file upload in a chat with a zero-provider-visibility model, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow anonymous file review for this chat?"
-msgstr ""
-"Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
+msgstr "Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
 
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
@@ -2340,7 +2341,7 @@ msgstr "Kérdezz privátban"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Kérdezz privátban"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2381,9 +2382,9 @@ msgstr ""
 "felhasználói felületét a keresési eredményekből), Igény szerint (csak az "
 "Asszisztens gombra kattintás esetén jelennek meg az AI-alapú válaszok), Néha "
 "(csak akkor jelenik meg AI-alapú válasz, ha nagyon releváns), illetve "
-"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az AI-"
-"alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában érhetők "
-"el."
+"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az "
+"AI-alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában "
+"érhetők el."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2480,21 +2481,18 @@ msgstr "Hang"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2743,8 +2741,7 @@ msgstr "Vonalkód"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
+msgstr "Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2937,8 +2934,7 @@ msgstr "Webhely blokkolása minden találatból"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
+msgstr "Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3672,8 +3668,7 @@ msgstr "Módosítja az eredmények URL-jeinek megjelenítési módját"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
+msgstr "Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3885,8 +3880,8 @@ msgstr "Privát csevegés"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített Duck."
-"ai segítségével."
+"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített "
+"Duck.ai segítségével."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3913,7 +3908,7 @@ msgstr "Privát csevegés a mesterséges intelligenciával"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Privát csevegés népszerű AI-modellekkel"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4404,8 +4399,8 @@ msgid ""
 msgstr ""
 "Kattints a „Több” lehetőségre, ha többet meg szeretnél tudni egy témáról, és "
 "tegyél fel kapcsolódó kérdéseket az OpenAI, az Anthropic és további "
-"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a %1$sDuck."
-"ai%2$s használatával."
+"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a "
+"%1$sDuck.ai%2$s használatával."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4432,15 +4427,13 @@ msgstr "Kattints a %1$sHozzáadás%2$s lehetőségre"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr ""
-"Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
+msgstr "Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr ""
-"Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
+msgstr "Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4474,8 +4467,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
+msgstr "Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4556,8 +4548,7 @@ msgstr "Kattints a %1$sBeállítás alapértelmezettként%2$s lehetőségre lent
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
+msgstr "Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4724,7 +4715,7 @@ msgstr "Bezárás"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Bezárás"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4774,7 +4765,7 @@ msgstr "Keresés bezárása"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Második vélemény bezárása"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5153,6 +5144,8 @@ msgstr "Folytasd a hirdetések blokkolását"
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
+"Itt folytathatod a legutóbbi csevegéseket. Vagy törölheted őket a Fire "
+"Button segítségével."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5223,7 +5216,7 @@ msgstr "Cookie-adatok:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Másolva"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5264,8 +5257,7 @@ msgstr "Másolás"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
+msgstr "Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5277,7 +5269,7 @@ msgstr "Kód másolása"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Hivatkozás másolása"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5398,7 +5390,7 @@ msgstr "Kép létrehozása"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Megosztási link létrehozása"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5452,6 +5444,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"A link létrehozásával készül egy másolat a csevegésről, amelyet bárki "
+"megtekinthet, aki megnyitja."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5610,7 +5604,7 @@ msgstr "Válaszok testreszabása"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Válaszok testreszabása"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5900,7 +5894,7 @@ msgstr "Törlöd a szerveradatokat?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Megosztott link törlése"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5912,7 +5906,7 @@ msgstr "Leirat törlése"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Egy csevegés törlése"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5950,7 +5944,7 @@ msgstr "Törlöd a képet?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Törölj le"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6268,7 +6262,7 @@ msgstr "Promóció bezárása"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Bemutató bezárása"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6485,7 +6479,7 @@ msgstr "DuckDuckGo letöltése"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "DuckDuckGo letöltése"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6654,8 +6648,7 @@ msgstr "Dobd ide a fotókat vagy PDF-fájlokat"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
+msgstr "A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6707,7 +6700,7 @@ msgstr "Duck.ai a DuckDuckGo kínálatában. Privát AI-csevegés. Ingyenes."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "A Duck.ai mostantól tud PDF-eket elemezni. Próbáld ki!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6748,8 +6741,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
+msgstr "A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6792,8 +6784,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el e-"
-"mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
+"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el "
+"e-mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
 "%2$s"
 
 # smartling.placeholder_format=C
@@ -6801,8 +6793,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
+msgstr "A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6816,9 +6807,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű MI-"
-"modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, de "
-"továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
+"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű "
+"MI-modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, "
+"de továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6872,7 +6863,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "A Duck.ai az Anthropic, az OpenAI és mások modelljeit támogatja."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6902,8 +6893,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes AI-"
-"csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
+"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes "
+"AI-csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
 "Anthropic, Llama, Mistral, nyílt forráskódú AI modellek, adatvédelemre "
 "összpontosító AI, fiók nélküli AI-csevegés"
 
@@ -6951,8 +6942,8 @@ msgid ""
 msgstr ""
 "A DuckAssist nem tud utólagos kérdésekre válaszolni, viszont kínálatunkban "
 "többek között az OpenAI és az Anthropic csevegési modelljeit támogató "
-"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy mesterségesintelligencia-"
-"alapú privát csevegési szolgáltatás."
+"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy "
+"mesterségesintelligencia-alapú privát csevegési szolgáltatás."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7080,8 +7071,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
+msgstr "A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7201,8 +7191,8 @@ msgid ""
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
 "A DuckDuckGo automatikusan anonimizálja ezeket a jelentéseket az olyan "
-"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az e-mail-"
-"címek, a telefonszámok és az azonosításra alkalmas metaadatok."
+"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
+"e-mail-címek, a telefonszámok és az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7481,8 +7471,7 @@ msgstr "Emeld ki a fontos információkat a válaszokban"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr ""
-"Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
+msgstr "Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7533,7 +7522,7 @@ msgstr "Legtöbbször meglátogatott webhelyek engedélyezése"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Engedélyezés"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7583,8 +7572,7 @@ msgstr "Diktálás engedélyezése a Duck.ai felületén"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
+msgstr "Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7702,15 +7690,13 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
+msgstr "Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
+msgstr "Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7724,8 +7710,7 @@ msgstr ""
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
+msgstr "Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7761,15 +7746,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
+msgstr "Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
+msgstr "Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7853,7 +7836,7 @@ msgstr "Programajánló"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Teljes csevegés"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -8022,13 +8005,13 @@ msgstr "Szókimondó dalszövegek"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "A Duck.ai felfedezése"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "A Duck.ai felfedezése"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8135,7 +8118,7 @@ msgstr "Ingyenes"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "INGYENES ÉS OPCIONÁLIS"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8465,8 +8448,8 @@ msgstr ""
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
 msgstr ""
-"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új Duck."
-"ai felületre"
+"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új "
+"Duck.ai felületre"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8565,7 +8548,7 @@ msgstr "Tárhely felszabadítása"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Ingyenes és mindig privát"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8577,8 +8560,7 @@ msgstr "Ingyenes és privát csevegések, általunk anonimizálva"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
+msgstr "Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8830,15 +8812,13 @@ msgstr "Általános célú mesterséges intelligencia, beépített erős moderá
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Általános célú mesterséges intelligencia, beépített gyenge moderálással"
+msgstr "Általános célú mesterséges intelligencia, beépített gyenge moderálással"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Általános célú mesterséges intelligencia, beépített közepes moderálással"
+msgstr "Általános célú mesterséges intelligencia, beépített közepes moderálással"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9061,9 +9041,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez DuckDuckGo-"
-"előfizetéssel, amely a VPN-megoldásunk mellett további prémium adatvédelmi "
-"szolgáltatásokat is tartalmaz."
+"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez "
+"DuckDuckGo-előfizetéssel, amely a VPN-megoldásunk mellett további prémium "
+"adatvédelmi szolgáltatásokat is tartalmaz."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9092,7 +9072,7 @@ msgstr "Kérj számítógépes segítséget"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9135,13 +9115,15 @@ msgstr "A legújabb verzió beszerzése"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Alkalmazás letöltése"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Töltsd le az ingyenes DuckDuckGo böngészőt, a %1$sYouTube-hirdetések "
+"blokkolásához.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9169,7 +9151,7 @@ msgstr "Hozd el a barátaidat, hogy még nagyobbak lehessünk!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Első lépések ellenőrzőlistája"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9244,8 +9226,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
+msgstr "Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9716,8 +9697,7 @@ msgstr "Segíts nekünk a DuckDuckGo fejlesztésében"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
+msgstr "A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9863,7 +9843,7 @@ msgstr "Tippek elrejtése"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Útmutató elrejtése"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10413,8 +10393,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
+msgstr "Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10615,8 +10594,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr ""
-"A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
+msgstr "A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11509,6 +11487,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Lehetővé teszi a keresési lekérdezések és a Duck.ai-nak küldött utasítások "
+"közötti váltást"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11584,7 +11564,7 @@ msgstr "Megnyert bedobások"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "A link 7 nap múlva lejár."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11895,8 +11875,7 @@ msgstr "Ügyelj rá, hogy minden szó helyesen legyen írva."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
+msgstr "Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12689,7 +12668,7 @@ msgstr "Több, mint 20 perces"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "További tippek"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13183,7 +13162,7 @@ msgstr "Nem, köszönöm"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nem, köszönöm"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13851,7 +13830,7 @@ msgstr "Be, de számok nélkül"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Bevezetés kész"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13910,8 +13889,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
+msgstr "Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14072,7 +14050,7 @@ msgstr "Képjavaslatok megnyitása, létrehozása és szerkesztése"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Első lépések ellenőrzőlistájának megnyitása"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14263,9 +14241,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, titkosítás-"
-"végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS és "
-"Android%2$s rendszerhez is elérhető."
+"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, "
+"titkosítás-végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS "
+"és Android%2$s rendszerhez is elérhető."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14827,7 +14805,7 @@ msgstr "Kitűzés"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Csevegés kitűzése"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14839,7 +14817,7 @@ msgstr "Csevegések rögzítése innen: %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Tűzz ki"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14862,7 +14840,7 @@ msgstr "Kitűzött"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14903,8 +14881,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
+msgstr "A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14912,8 +14889,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
+msgstr "A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15124,8 +15100,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a YouTube-"
-"javaslataidat."
+"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a "
+"YouTube-javaslataidat."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15188,6 +15164,8 @@ msgstr "Rossz formázás"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Elérhetők a népszerű AI-modellek. Nincs szükség fiókra. Általunk anonimizált "
+"csevegések."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15401,7 +15379,7 @@ msgstr "Előző lapok"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Előző tippek"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15935,27 +15913,25 @@ msgstr "Érvelő mesterséges intelligencia, magas szintű beépített moderáci
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr ""
-"Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
+msgstr "Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr ""
-"Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
+msgstr "Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Érveléssel jobb válaszok kaphatók az összetett kérdésekre."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15996,7 +15972,7 @@ msgstr "A legutóbbi csevegések tárhelye a %1$sban állítható be."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Legutóbbi csevegések"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16157,7 +16133,7 @@ msgstr "Használat csökkentése"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Limitfelhasználás csökkentése hatékonyabb modellel"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16318,8 +16294,7 @@ msgstr "Választott beállítás megjegyzése"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
+msgstr "Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16542,7 +16517,7 @@ msgstr "Alapértelmezett beállítások használata"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Útmutató visszaállítása"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16560,7 +16535,7 @@ msgstr "Felbontás"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Válasz"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16585,8 +16560,8 @@ msgid ""
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
 "A válaszok kizárólag tájékoztatási célokat szolgálnak, és nem minősülnek "
-"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az AI-"
-"alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
+"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az "
+"AI-alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16681,8 +16656,7 @@ msgstr "A találatok nem tartalmazzák a blokkolt webhelyeket."
 #. Informational banner shown at the top of the Maps search results panel when the user has blocked Yelp or TripAdvisor in their settings. Explains why ratings, reviews, and other details may be missing from place listings.
 msgctxt "Exclusion message at top of maps vertical"
 msgid "Results exclude information from blocked sites."
-msgstr ""
-"A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
+msgstr "A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
 
 # smartling.placeholder_format=C
 #. Message that appears when results exclude blocked sites
@@ -17269,14 +17243,13 @@ msgstr "Keresés"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr ""
-"A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
+msgstr "A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Keresés és Duck.ai átkapcsolója"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17655,7 +17628,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Biztonságosan tárolva a titkosított szerverünkön."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17682,8 +17655,7 @@ msgstr "Fényképek megtekintése"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "See Privacy Policy and Terms of Service"
-msgstr ""
-"Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
+msgstr "Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
 
 # smartling.placeholder_format=C
 #. Text of the secondary button in the modal that allows the user to open the terms and privacy policy page.
@@ -17749,8 +17721,7 @@ msgstr "További információ: %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr ""
-"További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
+msgstr "További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -17806,8 +17777,8 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a %3$shttps://duckduckgo."
-"com%4$s címet a beviteli mezőbe"
+"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a "
+"%3$shttps://duckduckgo.com%4$s címet a beviteli mezőbe"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17855,8 +17826,7 @@ msgstr "Válaszd a %1$sDuckDuckGót%2$s a keresőszolgáltatók listáján"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
+msgstr "Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17867,8 +17837,7 @@ msgstr "Válaszd a %1$sDuckDuckGo%2$s lehetőséget."
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
+msgstr "Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17911,8 +17880,7 @@ msgstr "Válaszd ki a %1$sKeresőmotor%2$s lehetőséget"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
+msgstr "Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17937,8 +17905,7 @@ msgstr "Válaszd ki a %1$sBeállítások%2$s opciót a legördülő menüből."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
+msgstr "Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18193,7 +18160,7 @@ msgstr "Beállítás kezdőlapként"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Állítsd be a Duck.ai válaszainak hangvételét és stílusát."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18266,13 +18233,13 @@ msgstr "Seychelle-szigetek"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Megosztás"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Megosztás"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18283,8 +18250,7 @@ msgstr "Megosztás"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
+msgstr "Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18311,8 +18277,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az AI-"
-"modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
+"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az "
+"AI-modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
 "pontos tartózkodási helyedet."
 
 # smartling.placeholder_format=C
@@ -18320,7 +18286,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Csevegés megosztása"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18384,7 +18350,7 @@ msgstr "Pozitív visszajelzés megosztása"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Megosztás hatóköre"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18398,8 +18364,7 @@ msgstr "Beszélgetés megosztása a DuckDuckGóval"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr ""
-"Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
+msgstr "Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -18526,7 +18491,7 @@ msgstr "Részletek megjelenítése"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Duck.ai-útmutató megjelenítése"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18656,8 +18621,7 @@ msgstr "Minden találat megjelenítése"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
+msgstr "Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18682,7 +18646,7 @@ msgstr "Mutass többet"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "További modellek megjelenítése"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18724,6 +18688,8 @@ msgstr "Oldalsáv megjelenítése"
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
+"Lépésről lépésre követhető tippek megjelenítése a Duck.ai maximális "
+"kihasználásához."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18818,14 +18784,12 @@ msgstr "A legtöbbször meglátogatott hivatkozások megjelenítése új lapon"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
+msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
+msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18843,8 +18807,7 @@ msgstr "Oldalszám megjelenítése a találati oldalak töréseinél"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
+msgstr "A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18872,8 +18835,7 @@ msgstr "Üdvözlőüzenet megjelenítése a keresési találati oldal tetején"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
+msgstr "Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18950,8 +18912,7 @@ msgstr "Az oldalkeresés átmenetileg nem érhető el. Dolgozunk a megoldáson."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
+msgstr "Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19108,7 +19069,7 @@ msgstr "Hiba történt, próbálkozz újra később."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Hiba történt. Próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19408,7 +19369,7 @@ msgstr "Heti limit felhasználásának megkezdése"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Új csevegés indítása"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19996,7 +19957,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Váltás erre a második véleményre"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20160,7 +20121,7 @@ msgstr "A szinkronizálás és biztonsági mentés átmenetileg nem érhető el"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Csevegések eszközök közötti szinkronizálása"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20256,6 +20217,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Bárhová magaddal viheted a Duck.ai-t. Bárhol igénybe veheted az ingyenes "
+"alkalmazásunkba épített gyorsabb hozzáférést."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20264,6 +20227,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Bárhová magaddal viheted a Duck.ai-t. Bárhol böngészve igénybe veheted az "
+"ingyenes böngészőnkbe épített gyorsabb hozzáférést."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20357,8 +20322,7 @@ msgstr "Koppints a címsorban található %1$sengedélyek ikonra%2$s"
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Tap the vertical dots in the DuckDuckGo app."
-msgstr ""
-"Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
+msgstr "Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a teacher in its responses.
@@ -20527,21 +20491,18 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
+msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
+msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
+msgstr "A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20741,7 +20702,7 @@ msgstr "Ebben a hónapban"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Ez a válasz"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20753,7 +20714,7 @@ msgstr "Ezen a héten"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20871,8 +20832,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
-"fájlt"
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
+"GIF-fájlt"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20880,8 +20841,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
-"fájlt."
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
+"GIF-fájlt."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20895,6 +20856,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Ez csak egy mintacsevegés. Nyisd meg a menüjét (három pont), majd válaszd a "
+"Kitűzés lehetőséget, hogy a csevegéseid felső részében maradjon!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20903,6 +20866,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Ez csak egy mintacsevegés. Töröld az oldalsó menüben található Fire Button "
+"segítségével!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20981,9 +20946,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
-"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
-"intelligencia segítségével generált válaszok."
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
+"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
+"mesterséges intelligencia segítségével generált válaszok."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20993,9 +20958,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
-"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
-"intelligencia segítségével generált válaszok. Ugyanakkor van egy "
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
+"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
+"mesterséges intelligencia segítségével generált válaszok. Ugyanakkor van egy "
 "kezdőoldalunk, amely soha nem jelenít meg AI-alapú válaszokat: %1$s."
 
 # smartling.placeholder_format=C
@@ -21025,8 +20990,7 @@ msgstr "Ez a videó még nem tekinthető meg itt. Megnézheted itt: %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
+msgstr "Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21204,8 +21168,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "A szinkronizált adatok visszaállításához szükség lesz a szinkronizálás első "
-"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód PDF-"
-"fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
+"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód "
+"PDF-fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
 "eszközre."
 
 # smartling.placeholder_format=C
@@ -21248,6 +21212,8 @@ msgstr "Ma"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Válts át a privát AI-csevegés kipróbálásához, vagy %1$stiltsd le a(z) %2$s "
+"menüben.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21589,8 +21555,7 @@ msgstr "Próbálkozz ezzel: %1$s"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr ""
-"Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
+msgstr "Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -21669,7 +21634,7 @@ msgstr "Próbáld ki őket!"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Próbálj ki egy másik modellt"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21680,7 +21645,7 @@ msgstr "Keress rá!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Próbálj ki egy javaslatot"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21723,16 +21688,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
+msgstr "A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
+msgstr "Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21752,7 +21715,7 @@ msgstr "Ingyenes próba"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Próbáld ki ingyen"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21766,14 +21729,13 @@ msgstr "Próbáld ki ingyen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
+msgstr "Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Próbáld ki ingyen 7 napig"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21800,14 +21762,13 @@ msgstr "Próbáld ki a böngészőnket,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
+msgstr "Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Próbáld ki az érvelést"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -22060,14 +22021,13 @@ msgstr "A pontosabb találatokhoz kapcsold be a %1$sPontos hely%2$s funkciót"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
+msgstr "Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Duck.ai átváltás bekapcsolása"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22294,8 +22254,7 @@ msgstr "Az %1$sÁltalános > Kezdőlap%2$s alatt írd be: https://duckduckgo.com
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr ""
-"A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
+msgstr "A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22404,8 +22363,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb MI-"
-"érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
+"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb "
+"MI-érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22427,8 +22386,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el DuckDuckGo-"
-"előfizetéssel"
+"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el "
+"DuckDuckGo-előfizetéssel"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22453,7 +22412,7 @@ msgstr "Használj fejlett AI funkciókat az előfizetéseddel!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Fejlett modellek használata"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22820,7 +22779,7 @@ msgstr "Használat a Safariban"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "A Fire Button segítségével törölhetsz egy csevegést az előzményekből."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23048,9 +23007,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: %1$sDuck.ai-"
-"beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd válaszd a "
-"%7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
+"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: "
+"%1$sDuck.ai-beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd "
+"válaszd a %7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23089,8 +23048,8 @@ msgstr ""
 "Látogass el a Duck.ai oldalra a másik böngésződben vagy a DuckDuckGo "
 "alkalmazásban, és nyisd meg a Duck.ai beállításait. Válaszd a „Bekapcsolás” "
 "lehetőséget a Sync & Backup alatt, és válaszd a „Szinkronizálás másik "
-"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található QR-"
-"kódot."
+"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található "
+"QR-kódot."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23143,8 +23102,8 @@ msgstr "A hangcsevegés véget ért"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel MI-"
-"modellek betanítására."
+"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel "
+"MI-modellek betanítására."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23288,8 +23247,9 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott YouTube-"
-"hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube ajánlásait."
+"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott "
+"YouTube-hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube "
+"ajánlásait."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23358,16 +23318,14 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
+msgstr "Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
+msgstr "Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23409,8 +23367,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
+msgstr "Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23562,8 +23519,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
+msgstr "Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23744,8 +23700,8 @@ msgid ""
 "anonymized by us and not used to train AI models."
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! Minden itt folytatott beszélgetésed privát, "
-"anonimizáljuk azokat, és nem használjuk fel mesterségesintelligencia-"
-"modellek tanítására."
+"anonimizáljuk azokat, és nem használjuk fel "
+"mesterségesintelligencia-modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23757,15 +23713,14 @@ msgid ""
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! A csevegést a(z) %1$s %2$s technológiája "
 "szolgáltatja. Minden itt folytatott beszélgetésed privát, melyeket a "
-"DuckDuckGo soha nem tárol, és nem használ fel a mesterségesintelligencia-"
-"modellek tanítására."
+"DuckDuckGo soha nem tárol, és nem használ fel a "
+"mesterségesintelligencia-modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
+msgstr "Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23864,8 +23819,7 @@ msgstr ""
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
+msgstr "Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24015,7 +23969,7 @@ msgstr "Mi járatban vagy ma?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Mit tehetsz?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24246,8 +24200,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
+msgstr "Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24265,8 +24218,7 @@ msgstr "Hol nézhető meg a(z) <strong>%1$s</strong>?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
+msgstr "A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24444,6 +24396,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"A Duck.ai segítségével a beszélgetéseidet anonimizáljuk, és soha nem "
+"használjuk fel őket az AI betanítására. Bármikor be- vagy kikapcsolhatod "
+"a(z) „%1$s” menüben."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24736,8 +24691,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
+msgstr "A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -24797,8 +24751,7 @@ msgstr "Ezt a %1$sKeresési beállítások%2$s oldalon bármikor módosíthatod"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
+msgstr "A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24837,8 +24790,7 @@ msgstr "A havi limit felhasználásával folytathatod a csevegést."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
+msgstr "Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24881,7 +24833,7 @@ msgstr "Beszélgetésenként csak %1$s képet csatolhatsz."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Egyszerre csak %1$s lapot csatolhatsz."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -25031,7 +24983,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Minden készen áll!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -25084,7 +25036,7 @@ msgstr "1 webhelyet blokkoltál"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Elsajátítottad a Duck.ai alapjait"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25104,8 +25056,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
+msgstr "Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25347,22 +25298,19 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
+msgstr "A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
 msgctxt "Description for the joiner-device success screen"
 msgid "Your chats will now sync between these devices."
-msgstr ""
-"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the success screen after a successful pairing.
 msgctxt "Description for the success screen"
 msgid "Your chats will now sync between these devices."
-msgstr ""
-"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Description explaining why delegation is needed for image generation.
@@ -25494,6 +25442,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"A beállítások mentve lettek, de a sütik törlésekor visszaállításra kerülnek. "
+"A %1$sDuckDuckGo No AI%2$s bővítmény engedélyezésével állandóvá teheted őket."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25510,8 +25460,7 @@ msgstr ""
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
+msgstr "A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -25571,8 +25520,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
+msgstr "Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25875,8 +25823,8 @@ msgstr "hivatalos webhely"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt %3$s-"
-"karakter)."
+"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt "
+"%3$s-karakter)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -26092,4 +26040,4 @@ msgstr "év"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr "%1$s nyelv észlelve"
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -176,9 +182,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
-"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
-"válts a Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
+"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
+"Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -188,9 +194,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
-"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
-"válts a Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
+"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
+"Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -355,6 +361,12 @@ msgid "%s used"
 msgstr "%1$s felhasználva"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s megtekintés"
@@ -468,7 +480,8 @@ msgstr "%1$sTudj meg többet%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
+msgstr ""
+"%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -483,13 +496,15 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
+msgstr ""
+"%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
+msgstr ""
+"%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -602,6 +617,12 @@ msgstr "A DuckDuckGo az elmúlt 24 órában 1 kísérletet blokkolt"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 nappal ezelőtt"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -822,7 +843,8 @@ msgstr "Elérted a 6 órás használati limitet."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
+msgstr ""
+"Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -947,9 +969,8 @@ msgstr ""
 "Az AI Chat segítségével névtelen beszélgetéseket folytathatsz harmadik felek "
 "mesterséges intelligencián alapuló csevegési modelljeivel. Ennek "
 "kikapcsolása elrejti az AI Chat funkciót a DuckDuckGo Search "
-"szolgáltatásban. Ha a beállítás ki van kapcsolva, a "
-"%1$sduckduckgo.com/aichat%2$s oldalra látogatva továbbra is elérheted az AI "
-"Chatet."
+"szolgáltatásban. Ha a beállítás ki van kapcsolva, a %1$sduckduckgo.com/"
+"aichat%2$s oldalra látogatva továbbra is elérheted az AI Chatet."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1013,9 +1034,8 @@ msgstr ""
 "Az AI-alapú válaszokra jelenleg nem tehetők fel közvetlenül további "
 "kérdések. Azonban ha újabb kérdést szeretnél feltenni, az OpenAI, az "
 "Anthropic, valamint más szolgáltatók csevegési modelljeit is támogató "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a "
-"%1$sDuck.ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak "
-"linkjét."
+"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a %1$sDuck."
+"ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak linkjét."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1518,6 +1538,14 @@ msgid "Advanced Models"
 msgstr "Fejlett modellek"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Hirdess a keresésben"
@@ -1797,7 +1825,8 @@ msgstr "Adatvédelmet tiszteletben tartó hirdetések engedélyezése"
 #. Title of the upload consent prompt shown before the first image/file upload in a chat with a zero-provider-visibility model, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow anonymous file review for this chat?"
-msgstr "Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
+msgstr ""
+"Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
 
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
@@ -2308,6 +2337,12 @@ msgid "Ask privately"
 msgstr "Kérdezz privátban"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2346,9 +2381,9 @@ msgstr ""
 "felhasználói felületét a keresési eredményekből), Igény szerint (csak az "
 "Asszisztens gombra kattintás esetén jelennek meg az AI-alapú válaszok), Néha "
 "(csak akkor jelenik meg AI-alapú válasz, ha nagyon releváns), illetve "
-"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az "
-"AI-alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában "
-"érhetők el."
+"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az AI-"
+"alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában érhetők "
+"el."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2445,18 +2480,21 @@ msgstr "Hang"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2705,7 +2743,8 @@ msgstr "Vonalkód"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr "Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
+msgstr ""
+"Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2898,7 +2937,8 @@ msgstr "Webhely blokkolása minden találatból"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
+msgstr ""
+"Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3632,7 +3672,8 @@ msgstr "Módosítja az eredmények URL-jeinek megjelenítési módját"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
+msgstr ""
+"Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3844,8 +3885,8 @@ msgstr "Privát csevegés"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített "
-"Duck.ai segítségével."
+"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített Duck."
+"ai segítségével."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3867,6 +3908,12 @@ msgstr "Privát csevegés a következővel: %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Privát csevegés a mesterséges intelligenciával"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4357,8 +4404,8 @@ msgid ""
 msgstr ""
 "Kattints a „Több” lehetőségre, ha többet meg szeretnél tudni egy témáról, és "
 "tegyél fel kapcsolódó kérdéseket az OpenAI, az Anthropic és további "
-"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a "
-"%1$sDuck.ai%2$s használatával."
+"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a %1$sDuck."
+"ai%2$s használatával."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4385,13 +4432,15 @@ msgstr "Kattints a %1$sHozzáadás%2$s lehetőségre"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr "Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
+msgstr ""
+"Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr "Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
+msgstr ""
+"Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4425,7 +4474,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
+msgstr ""
+"Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4506,7 +4556,8 @@ msgstr "Kattints a %1$sBeállítás alapértelmezettként%2$s lehetőségre lent
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
+msgstr ""
+"Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4670,6 +4721,12 @@ msgid "Close"
 msgstr "Bezárás"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4712,6 +4769,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Keresés bezárása"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5086,6 +5149,12 @@ msgid "Continue Blocking Ads"
 msgstr "Folytasd a hirdetések blokkolását"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5151,6 +5220,12 @@ msgid "Cookie data:"
 msgstr "Cookie-adatok:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5189,13 +5264,20 @@ msgstr "Másolás"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
+msgstr ""
+"Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kód másolása"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5313,6 +5395,12 @@ msgid "Create Image"
 msgstr "Kép létrehozása"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5356,6 +5444,14 @@ msgstr "Készítette:"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Készítette: %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5509,6 +5605,12 @@ msgstr "Válaszok testreszabása"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Válaszok testreszabása"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5795,10 +5897,22 @@ msgid "Delete Server Data?"
 msgstr "Törlöd a szerveradatokat?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Leirat törlése"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5831,6 +5945,12 @@ msgstr "Kép törlése"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Törlöd a képet?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6145,6 +6265,12 @@ msgid "Dismiss promotion"
 msgstr "Promóció bezárása"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6356,6 +6482,12 @@ msgid "Download DuckDuckGo"
 msgstr "DuckDuckGo letöltése"
 
 # smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo Browser"
@@ -6522,7 +6654,8 @@ msgstr "Dobd ide a fotókat vagy PDF-fájlokat"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
+msgstr ""
+"A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6571,6 +6704,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai a DuckDuckGo kínálatában. Privát AI-csevegés. Ingyenes."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6609,7 +6748,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
+msgstr ""
+"A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6652,8 +6792,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el "
-"e-mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
+"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el e-"
+"mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
 "%2$s"
 
 # smartling.placeholder_format=C
@@ -6661,7 +6801,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
+msgstr ""
+"A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6675,9 +6816,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű "
-"MI-modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, "
-"de továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
+"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű MI-"
+"modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, de "
+"továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6728,6 +6869,12 @@ msgstr ""
 "pontosságukat."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6755,8 +6902,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes "
-"AI-csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
+"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes AI-"
+"csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
 "Anthropic, Llama, Mistral, nyílt forráskódú AI modellek, adatvédelemre "
 "összpontosító AI, fiók nélküli AI-csevegés"
 
@@ -6804,8 +6951,8 @@ msgid ""
 msgstr ""
 "A DuckAssist nem tud utólagos kérdésekre válaszolni, viszont kínálatunkban "
 "többek között az OpenAI és az Anthropic csevegési modelljeit támogató "
-"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatás."
+"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy mesterségesintelligencia-"
+"alapú privát csevegési szolgáltatás."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6933,7 +7080,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
+msgstr ""
+"A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7053,8 +7201,8 @@ msgid ""
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
 "A DuckDuckGo automatikusan anonimizálja ezeket a jelentéseket az olyan "
-"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
-"e-mail-címek, a telefonszámok és az azonosításra alkalmas metaadatok."
+"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az e-mail-"
+"címek, a telefonszámok és az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7333,7 +7481,8 @@ msgstr "Emeld ki a fontos információkat a válaszokban"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr "Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
+msgstr ""
+"Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7379,6 +7528,12 @@ msgstr "A legtöbbször meglátogatott webhelyek engedélyezése"
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Legtöbbször meglátogatott webhelyek engedélyezése"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7428,7 +7583,8 @@ msgstr "Diktálás engedélyezése a Duck.ai felületén"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
+msgstr ""
+"Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7546,13 +7702,15 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
+msgstr ""
+"Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
+msgstr ""
+"Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7566,7 +7724,8 @@ msgstr ""
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
+msgstr ""
+"Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7602,13 +7761,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
+msgstr ""
+"Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
+msgstr ""
+"Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7687,6 +7848,12 @@ msgstr "Add meg a jelszavad a beállításaid betöltéséhez."
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "Programajánló"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7852,6 +8019,18 @@ msgid "Explicit lyrics"
 msgstr "Szókimondó dalszövegek"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7951,6 +8130,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Ingyenes"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8280,8 +8465,8 @@ msgstr ""
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
 msgstr ""
-"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új "
-"Duck.ai felületre"
+"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új Duck."
+"ai felületre"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8377,6 +8562,12 @@ msgid "Free Up Storage"
 msgstr "Tárhely felszabadítása"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8386,7 +8577,8 @@ msgstr "Ingyenes és privát csevegések, általunk anonimizálva"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
+msgstr ""
+"Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8638,13 +8830,15 @@ msgstr "Általános célú mesterséges intelligencia, beépített erős moderá
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Általános célú mesterséges intelligencia, beépített gyenge moderálással"
+msgstr ""
+"Általános célú mesterséges intelligencia, beépített gyenge moderálással"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Általános célú mesterséges intelligencia, beépített közepes moderálással"
+msgstr ""
+"Általános célú mesterséges intelligencia, beépített közepes moderálással"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8867,9 +9061,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez "
-"DuckDuckGo-előfizetéssel, amely a VPN-megoldásunk mellett további prémium "
-"adatvédelmi szolgáltatásokat is tartalmaz."
+"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez DuckDuckGo-"
+"előfizetéssel, amely a VPN-megoldásunk mellett további prémium adatvédelmi "
+"szolgáltatásokat is tartalmaz."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8893,6 +9087,12 @@ msgstr "A DuckDuckGo súgójában kaphatsz válaszokat."
 msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr "Kérj számítógépes segítséget"
+
+# smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8932,6 +9132,18 @@ msgid "Get the Latest Version"
 msgstr "A legújabb verzió beszerzése"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8952,6 +9164,12 @@ msgstr "Szerezd meg a dalt:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Hozd el a barátaidat, hogy még nagyobbak lehessünk!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9026,7 +9244,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
+msgstr ""
+"Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9497,7 +9716,8 @@ msgstr "Segíts nekünk a DuckDuckGo fejlesztésében"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
+msgstr ""
+"A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9638,6 +9858,12 @@ msgstr "Lépések elrejtése"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Tippek elrejtése"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10187,7 +10413,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
+msgstr ""
+"Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10388,7 +10615,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr "A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
+msgstr ""
+"A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11276,6 +11504,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "A DuckDuckGo segítségével névtelenül kereshetsz"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Libéria"
 
@@ -11344,6 +11579,12 @@ msgstr "Vonalas rajzolás"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Megnyert bedobások"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11654,7 +11895,8 @@ msgstr "Ügyelj rá, hogy minden szó helyesen legyen írva."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
+msgstr ""
+"Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12444,6 +12686,12 @@ msgid "More than 20 minutes"
 msgstr "Több, mint 20 perces"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12930,6 +13178,12 @@ msgstr "Nem, köszönöm"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Nem, köszönöm"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13594,6 +13848,12 @@ msgid "On but no numbers"
 msgstr "Be, de számok nélkül"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13650,7 +13910,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
+msgstr ""
+"Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13806,6 +14067,12 @@ msgstr "Csevegési javaslatokat megnyitása"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Képjavaslatok megnyitása, létrehozása és szerkesztése"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -13996,9 +14263,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, "
-"titkosítás-végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS "
-"és Android%2$s rendszerhez is elérhető."
+"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, titkosítás-"
+"végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS és "
+"Android%2$s rendszerhez is elérhető."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14557,10 +14824,22 @@ msgid "Pin"
 msgstr "Kitűzés"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Csevegések rögzítése innen: %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14578,6 +14857,12 @@ msgstr "Rózsaszín"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Kitűzött"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14618,7 +14903,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
+msgstr ""
+"A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14626,7 +14912,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
+msgstr ""
+"A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14837,8 +15124,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a "
-"YouTube-javaslataidat."
+"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a YouTube-"
+"javaslataidat."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14895,6 +15182,12 @@ msgstr "lengyel"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Rossz formázás"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15103,6 +15396,12 @@ msgstr "Előző kép"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Előző lapok"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15636,13 +15935,27 @@ msgstr "Érvelő mesterséges intelligencia, magas szintű beépített moderáci
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr "Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
+msgstr ""
+"Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr "Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
+msgstr ""
+"Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15678,6 +15991,12 @@ msgstr "Legutóbbi lapok"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "A legutóbbi csevegések tárhelye a %1$sban állítható be."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15833,6 +16152,12 @@ msgstr "Keresés újraindítása a webhely nélkül"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Használat csökkentése"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15993,7 +16318,8 @@ msgstr "Választott beállítás megjegyzése"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
+msgstr ""
+"Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16213,6 +16539,12 @@ msgid "Reset All Settings"
 msgstr "Alapértelmezett beállítások használata"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16223,6 +16555,12 @@ msgstr "Visszaállítás %1$s múlva"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Felbontás"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16247,8 +16585,8 @@ msgid ""
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
 "A válaszok kizárólag tájékoztatási célokat szolgálnak, és nem minősülnek "
-"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az "
-"AI-alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
+"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az AI-"
+"alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16343,7 +16681,8 @@ msgstr "A találatok nem tartalmazzák a blokkolt webhelyeket."
 #. Informational banner shown at the top of the Maps search results panel when the user has blocked Yelp or TripAdvisor in their settings. Explains why ratings, reviews, and other details may be missing from place listings.
 msgctxt "Exclusion message at top of maps vertical"
 msgid "Results exclude information from blocked sites."
-msgstr "A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
+msgstr ""
+"A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
 
 # smartling.placeholder_format=C
 #. Message that appears when results exclude blocked sites
@@ -16930,7 +17269,14 @@ msgstr "Keresés"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr "A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
+msgstr ""
+"A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17306,6 +17652,12 @@ msgstr ""
 "szerverén. Rajtad kívül senki sem láthatja az adataidat, még mi sem."
 
 # smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "Security issue"
 msgstr "Biztonsági probléma"
@@ -17330,7 +17682,8 @@ msgstr "Fényképek megtekintése"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "See Privacy Policy and Terms of Service"
-msgstr "Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
+msgstr ""
+"Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
 
 # smartling.placeholder_format=C
 #. Text of the secondary button in the modal that allows the user to open the terms and privacy policy page.
@@ -17396,7 +17749,8 @@ msgstr "További információ: %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr "További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
+msgstr ""
+"További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -17452,8 +17806,8 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a "
-"%3$shttps://duckduckgo.com%4$s címet a beviteli mezőbe"
+"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a %3$shttps://duckduckgo."
+"com%4$s címet a beviteli mezőbe"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17501,7 +17855,8 @@ msgstr "Válaszd a %1$sDuckDuckGót%2$s a keresőszolgáltatók listáján"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
+msgstr ""
+"Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17512,7 +17867,8 @@ msgstr "Válaszd a %1$sDuckDuckGo%2$s lehetőséget."
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
+msgstr ""
+"Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17555,7 +17911,8 @@ msgstr "Válaszd ki a %1$sKeresőmotor%2$s lehetőséget"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
+msgstr ""
+"Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17580,7 +17937,8 @@ msgstr "Válaszd ki a %1$sBeállítások%2$s opciót a legördülő menüből."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
+msgstr ""
+"Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17832,6 +18190,12 @@ msgid "Set as Homepage"
 msgstr "Beállítás kezdőlapként"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17899,6 +18263,18 @@ msgid "Seychelles"
 msgstr "Seychelle-szigetek"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17907,7 +18283,8 @@ msgstr "Megosztás"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
+msgstr ""
+"Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17934,9 +18311,16 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az "
-"AI-modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
+"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az AI-"
+"modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
 "pontos tartózkodási helyedet."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17997,6 +18381,12 @@ msgid "Share positive feedback"
 msgstr "Pozitív visszajelzés megosztása"
 
 # smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -18008,7 +18398,8 @@ msgstr "Beszélgetés megosztása a DuckDuckGóval"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr "Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
+msgstr ""
+"Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -18130,6 +18521,12 @@ msgstr "Könyvjegyzők és beállítások mutatása"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Részletek megjelenítése"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18259,7 +18656,8 @@ msgstr "Minden találat megjelenítése"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
+msgstr ""
+"Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18279,6 +18677,12 @@ msgstr "Térkép megjelenítése"
 msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr "Mutass többet"
+
+# smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18314,6 +18718,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Oldalsáv megjelenítése"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18408,12 +18818,14 @@ msgstr "A legtöbbször meglátogatott hivatkozások megjelenítése új lapon"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
+msgstr ""
+"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
+msgstr ""
+"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18431,7 +18843,8 @@ msgstr "Oldalszám megjelenítése a találati oldalak töréseinél"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
+msgstr ""
+"A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18459,7 +18872,8 @@ msgstr "Üdvözlőüzenet megjelenítése a keresési találati oldal tetején"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
+msgstr ""
+"Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18536,7 +18950,8 @@ msgstr "Az oldalkeresés átmenetileg nem érhető el. Dolgozunk a megoldáson."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
+msgstr ""
+"Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18688,6 +19103,12 @@ msgstr "Hiba történt a Sync & Backup bekapcsolásakor. Próbálkozz újra."
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Hiba történt, próbálkozz újra később."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18982,6 +19403,12 @@ msgstr "Havi limit felhasználásának megkezdése"
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "Heti limit felhasználásának megkezdése"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19564,6 +19991,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Válts a keresőeszközre, ami nem követ téged. Soha."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19722,6 +20157,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "A szinkronizálás és biztonsági mentés átmenetileg nem érhető el"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19807,6 +20248,22 @@ msgstr "Tádzsikisztán"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Szerezd vissza a magánéletedet!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19900,7 +20357,8 @@ msgstr "Koppints a címsorban található %1$sengedélyek ikonra%2$s"
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Tap the vertical dots in the DuckDuckGo app."
-msgstr "Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
+msgstr ""
+"Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a teacher in its responses.
@@ -20069,18 +20527,21 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
+msgstr ""
+"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
+msgstr ""
+"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
+msgstr ""
+"A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20277,10 +20738,22 @@ msgid "This Month"
 msgstr "Ebben a hónapban"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Ezen a héten"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20398,8 +20871,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
-"GIF-fájlt"
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
+"fájlt"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20407,13 +20880,29 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
-"GIF-fájlt."
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
+"fájlt."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Nem hasznos információ"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20492,9 +20981,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
-"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
-"mesterséges intelligencia segítségével generált válaszok."
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
+"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
+"intelligencia segítségével generált válaszok."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20504,9 +20993,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
-"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
-"mesterséges intelligencia segítségével generált válaszok. Ugyanakkor van egy "
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
+"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
+"intelligencia segítségével generált válaszok. Ugyanakkor van egy "
 "kezdőoldalunk, amely soha nem jelenít meg AI-alapú válaszokat: %1$s."
 
 # smartling.placeholder_format=C
@@ -20536,7 +21025,8 @@ msgstr "Ez a videó még nem tekinthető meg itt. Megnézheted itt: %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
+msgstr ""
+"Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20714,8 +21204,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "A szinkronizált adatok visszaállításához szükség lesz a szinkronizálás első "
-"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód "
-"PDF-fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
+"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód PDF-"
+"fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
 "eszközre."
 
 # smartling.placeholder_format=C
@@ -20752,6 +21242,12 @@ msgstr "Ma"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Ma"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21093,7 +21589,8 @@ msgstr "Próbálkozz ezzel: %1$s"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr "Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
+msgstr ""
+"Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -21169,9 +21666,21 @@ msgid "Try Them Out"
 msgstr "Próbáld ki őket!"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Keress rá!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21214,14 +21723,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
+msgstr ""
+"A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
+msgstr ""
+"Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21238,6 +21749,12 @@ msgid "Try for free"
 msgstr "Ingyenes próba"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21249,7 +21766,14 @@ msgstr "Próbáld ki ingyen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
+msgstr ""
+"Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21276,7 +21800,14 @@ msgstr "Próbáld ki a böngészőnket,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
+msgstr ""
+"Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21529,7 +22060,14 @@ msgstr "A pontosabb találatokhoz kapcsold be a %1$sPontos hely%2$s funkciót"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
+msgstr ""
+"Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21756,7 +22294,8 @@ msgstr "Az %1$sÁltalános > Kezdőlap%2$s alatt írd be: https://duckduckgo.com
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr "A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
+msgstr ""
+"A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21865,8 +22404,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb "
-"MI-érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
+"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb MI-"
+"érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21888,8 +22427,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el "
-"DuckDuckGo-előfizetéssel"
+"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el DuckDuckGo-"
+"előfizetéssel"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21909,6 +22448,12 @@ msgstr "Fejlett AI-modellek feloldása DuckDuckGo-előfizetéssel"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Használj fejlett AI funkciókat az előfizetéseddel!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22272,6 +22817,12 @@ msgid "Use in Safari"
 msgstr "Használat a Safariban"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22497,9 +23048,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: "
-"%1$sDuck.ai-beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd "
-"válaszd a %7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
+"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: %1$sDuck.ai-"
+"beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd válaszd a "
+"%7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22538,8 +23089,8 @@ msgstr ""
 "Látogass el a Duck.ai oldalra a másik böngésződben vagy a DuckDuckGo "
 "alkalmazásban, és nyisd meg a Duck.ai beállításait. Válaszd a „Bekapcsolás” "
 "lehetőséget a Sync & Backup alatt, és válaszd a „Szinkronizálás másik "
-"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található "
-"QR-kódot."
+"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található QR-"
+"kódot."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22592,8 +23143,8 @@ msgstr "A hangcsevegés véget ért"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel "
-"MI-modellek betanítására."
+"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel MI-"
+"modellek betanítására."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22737,9 +23288,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott "
-"YouTube-hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube "
-"ajánlásait."
+"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott YouTube-"
+"hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube ajánlásait."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22808,14 +23358,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
+msgstr ""
+"Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
+msgstr ""
+"Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22857,7 +23409,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
+msgstr ""
+"Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23009,7 +23562,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
+msgstr ""
+"Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23190,8 +23744,8 @@ msgid ""
 "anonymized by us and not used to train AI models."
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! Minden itt folytatott beszélgetésed privát, "
-"anonimizáljuk azokat, és nem használjuk fel "
-"mesterségesintelligencia-modellek tanítására."
+"anonimizáljuk azokat, és nem használjuk fel mesterségesintelligencia-"
+"modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23203,14 +23757,15 @@ msgid ""
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! A csevegést a(z) %1$s %2$s technológiája "
 "szolgáltatja. Minden itt folytatott beszélgetésed privát, melyeket a "
-"DuckDuckGo soha nem tárol, és nem használ fel a "
-"mesterségesintelligencia-modellek tanítására."
+"DuckDuckGo soha nem tárol, és nem használ fel a mesterségesintelligencia-"
+"modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
+msgstr ""
+"Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23309,7 +23864,8 @@ msgstr ""
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
+msgstr ""
+"Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23454,6 +24010,12 @@ msgstr "Mi zavart a leginkább?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Mi járatban vagy ma?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23684,7 +24246,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
+msgstr ""
+"Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23702,7 +24265,8 @@ msgstr "Hol nézhető meg a(z) <strong>%1$s</strong>?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
+msgstr ""
+"A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23872,6 +24436,14 @@ msgstr "Győzelmek"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Téli csapadék"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24164,7 +24736,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
+msgstr ""
+"A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -24224,7 +24797,8 @@ msgstr "Ezt a %1$sKeresési beállítások%2$s oldalon bármikor módosíthatod"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
+msgstr ""
+"A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24263,7 +24837,8 @@ msgstr "A havi limit felhasználásával folytathatod a csevegést."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
+msgstr ""
+"Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24300,6 +24875,13 @@ msgstr "Beszélgetésenként csak %1$s képet csatolhatsz"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Beszélgetésenként csak %1$s képet csatolhatsz."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24446,6 +25028,12 @@ msgstr ""
 "alkalmazás frissítéseit."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24493,6 +25081,12 @@ msgid "You've blocked 1 site"
 msgstr "1 webhelyet blokkoltál"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24510,7 +25104,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
+msgstr ""
+"Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24752,19 +25347,22 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
+msgstr ""
+"A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
 msgctxt "Description for the joiner-device success screen"
 msgid "Your chats will now sync between these devices."
-msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr ""
+"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the success screen after a successful pairing.
 msgctxt "Description for the success screen"
 msgid "Your chats will now sync between these devices."
-msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr ""
+"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Description explaining why delegation is needed for image generation.
@@ -24890,6 +25488,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Kereséseid nem köthetők hozzád"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24904,7 +25510,8 @@ msgstr ""
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
+msgstr ""
+"A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24964,7 +25571,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
+msgstr ""
+"Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25267,8 +25875,8 @@ msgstr "hivatalos webhely"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt "
-"%3$s-karakter)."
+"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt %3$s-"
+"karakter)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25479,3 +26087,9 @@ msgstr "év"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "év"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/hy_AM/LC_MESSAGES/duckduckgo.po
+++ b/locales/hy_AM/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1228,6 +1243,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1851,6 +1873,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3087,6 +3114,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3683,6 +3715,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3718,6 +3755,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4025,6 +4067,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4079,6 +4126,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4116,6 +4168,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4212,6 +4269,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4246,6 +4308,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4371,6 +4440,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4607,9 +4681,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4637,6 +4721,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4890,6 +4979,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5056,6 +5150,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5231,6 +5330,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5338,6 +5442,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5834,6 +5943,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6073,6 +6187,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6206,6 +6325,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6287,6 +6416,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6618,6 +6752,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7039,6 +7178,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7068,6 +7212,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7085,6 +7239,11 @@ msgstr "Ձեռք բերեք այս երգը՝"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Տարածիր ընկերներիդ մեջ և օգնիր մեզ ընդլայնվել"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7639,6 +7798,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8938,6 +9102,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8993,6 +9163,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9891,6 +10066,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #  Marked fuzzy because of translated trademark
 #. e.g. More ways to add DuckDuckGo to Firefox
 #, fuzzy
@@ -10287,6 +10467,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10837,6 +11022,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Միացված, բայց առանց թվերի"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11007,6 +11197,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11603,9 +11798,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11620,6 +11825,11 @@ msgstr "Վարդագույն"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11876,6 +12086,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12045,6 +12260,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12487,6 +12707,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12514,6 +12744,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12636,6 +12871,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12938,6 +13178,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Հետ բերել բոլոր կարգավորումները"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12946,6 +13191,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13503,6 +13753,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Փնտրել անանուն"
 
@@ -13785,6 +14040,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14188,6 +14448,11 @@ msgstr "Նշել որպես Հիմնական Որոնիչ"
 msgid "Set as Homepage"
 msgstr "Դարձնել տնային էջ"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14240,6 +14505,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14269,6 +14544,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14317,6 +14598,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14428,6 +14714,11 @@ msgstr "Ցույց տալ Bookmarklet֊ների և կարգավորումներ�
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14552,6 +14843,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14580,6 +14876,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14878,6 +15179,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15112,6 +15418,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15590,6 +15901,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15702,6 +16020,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15771,6 +16094,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16140,9 +16477,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16243,6 +16590,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16499,6 +16860,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16836,9 +17202,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Փորձի՛ր փնտրել։"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16892,6 +17268,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16902,6 +17283,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16924,6 +17310,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17124,6 +17515,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17408,6 +17804,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17704,6 +18105,11 @@ msgstr "Օգտագործել Ֆայրֆոքսում"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Օգտագործել Սաֆարիում"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18616,6 +19022,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18955,6 +19366,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19301,6 +19719,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19410,6 +19834,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19444,6 +19873,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19744,6 +20178,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20218,6 +20659,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "%1$s hari yang lalu"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s terdeteksi"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -354,6 +360,12 @@ msgid "%s used"
 msgstr "%1$s digunakan"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s tayangan"
@@ -492,7 +504,8 @@ msgstr "%1$sTekan lama%2$s ikon aplikasi DuckDuckGo di layar beranda"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
+msgstr ""
+"%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -599,6 +612,12 @@ msgstr "1 upaya diblokir oleh DuckDuckGo dalam 24 jam terakhir"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 hari yang lalu"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -892,14 +911,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr ""
+"Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr ""
+"Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1509,6 +1530,14 @@ msgid "Advanced Models"
 msgstr "Model Canggih"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Beriklan di Pencarian"
@@ -1717,7 +1746,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
+msgstr ""
+"Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2122,13 +2152,15 @@ msgstr "Apa kamu masih di sana?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
+msgstr ""
+"Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
+msgstr ""
+"Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2292,6 +2324,12 @@ msgid "Ask privately"
 msgstr "Tanya secara pribadi"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2430,18 +2468,21 @@ msgstr "Suara"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr ""
+"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr ""
+"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
+msgstr ""
+"Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3636,7 +3677,8 @@ msgstr "Mengubah warna latar belakang hasil hover, modul, dan menu dropdown"
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
+msgstr ""
+"Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3763,8 +3805,8 @@ msgstr ""
 "anonim dengan model chat AI pihak ketiga, yang mendukung model dari OpenAI, "
 "Anthropic, dan lainnya. Menonaktifkan pengaturan ini akan menyembunyikan "
 "tombol dan tautan Chat di DuckDuckGo Search. Namun, Anda masih dapat "
-"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi "
-"%1$shttps://duck.ai%2$s langsung."
+"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi %1$shttps://"
+"duck.ai%2$s langsung."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3843,6 +3885,12 @@ msgstr "Ngobrol secara pribadi dengan %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Mengobrol secara pribadi dengan AI"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4006,7 +4054,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
+msgstr ""
+"Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4388,7 +4437,8 @@ msgstr "Klik %1$sDi sini%2$s untuk mengunduh ekstensi DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
+msgstr ""
+"Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4433,7 +4483,8 @@ msgstr "Klik %1$sYa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
+msgstr ""
+"Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4632,6 +4683,12 @@ msgid "Close"
 msgstr "Tutup"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4674,6 +4731,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Tutup pencarian"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5048,6 +5111,12 @@ msgid "Continue Blocking Ads"
 msgstr "Terus Memblokir Iklan"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5113,6 +5182,12 @@ msgid "Cookie data:"
 msgstr "Data cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5158,6 +5233,12 @@ msgstr "Salin &amp; tempel %1$sabout:preferences#search%2$s ke kotak alamat"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Salin Kode"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5273,6 +5354,12 @@ msgid "Create Image"
 msgstr "Buat Gambar"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5314,6 +5401,14 @@ msgstr "Dibuat oleh"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Dibuat oleh %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5467,6 +5562,12 @@ msgstr "Sesuaikan Tanggapan"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Sesuaikan Tanggapan"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5755,10 +5856,22 @@ msgid "Delete Server Data?"
 msgstr "Hapus Data Server?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Hapus Transkrip"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5791,6 +5904,12 @@ msgstr "Hapus gambar"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Hapus gambar?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6103,6 +6222,12 @@ msgid "Dismiss promotion"
 msgstr "Tolak promosi"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6124,7 +6249,8 @@ msgstr "Bahasa Tampilan"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
+msgstr ""
+"Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6313,6 +6439,12 @@ msgid "Download DuckDuckGo"
 msgstr "Unduh DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo Browser"
@@ -6398,8 +6530,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"Buatlah beberapa opsi untuk postingan media sosial yang mengundang "
-"orang-orang ke pesta saya yang akan datang."
+"Buatlah beberapa opsi untuk postingan media sosial yang mengundang orang-"
+"orang ke pesta saya yang akan datang."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6528,6 +6660,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai oleh DuckDuckGo. Obrolan AI pribadi. Bebas."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6565,7 +6703,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
+msgstr ""
+"Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6655,7 +6794,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
+msgstr ""
+"Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6683,6 +6823,12 @@ msgstr ""
 "keakuratannya."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6698,7 +6844,8 @@ msgstr "Duck.ai ditingkatkan!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
+msgstr ""
+"Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6884,7 +7031,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
+msgstr ""
+"DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7159,9 +7307,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi "
-"kata-kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 "
-"kata acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
+"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi kata-"
+"kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 kata "
+"acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
 "sepanjang 18—20 karakter."
 
 # smartling.placeholder_format=C
@@ -7331,6 +7479,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Aktifkan Situs yang Paling Banyak Dikunjungi"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7378,7 +7532,8 @@ msgstr "Aktifkan Dikte dalam Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
+msgstr ""
+"Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7628,6 +7783,12 @@ msgid "Entertainment guide"
 msgstr "Panduan hiburan"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Guinea ekuator"
 
@@ -7726,7 +7887,8 @@ msgstr "Jelaskan jawaban yang diterima dengan bahasa yang sederhana."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
+msgstr ""
+"Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7789,6 +7951,18 @@ msgstr "Konten eksplisit"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Lirik eksplisit"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7890,6 +8064,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Gratis"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8142,7 +8322,8 @@ msgstr "Temukan hasil yang lebih dekat dari lokasimu."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
+msgstr ""
+"Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8213,7 +8394,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
+msgstr ""
+"Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8307,6 +8489,12 @@ msgstr "Paket Gratis"
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
 msgstr "Kosongkan Penyimpanan"
+
+# smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8432,8 +8620,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dari bilah menu aplikasi di Mac, pilih <strong>DuckDuckGo</strong> &gt; "
-"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal "
-"Pembaruan</strong>."
+"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal Pembaruan</"
+"strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8825,6 +9013,12 @@ msgid "Get computer help"
 msgstr "Dapatkan bantuan komputer"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8862,6 +9056,18 @@ msgid "Get the Latest Version"
 msgstr "Dapatkan Versi Terbaru"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8882,6 +9088,12 @@ msgstr "Dapatkan lagu ini di:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Ajak temanmu untuk beralih dan bantu kami makin berkembang!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9567,6 +9779,12 @@ msgid "Hide Tips"
 msgstr "Sembunyikan Tips"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9981,7 +10199,8 @@ msgstr "Saya tidak paham informasi ini"
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "I don’t want to see any information from DuckDuckGo on this page"
-msgstr "Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
+msgstr ""
+"Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -10020,7 +10239,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
+msgstr ""
+"Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10308,7 +10528,8 @@ msgstr "Di menu atas, pilih %1$sAlat%2$s > %3$sPengaturan%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
+msgstr ""
+"Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10791,7 +11012,8 @@ msgstr "Tetap buka Sync & Backup di kedua perangkat."
 #. An instruction to state that a list of companies/trackers will be updated with continued use
 msgctxt "tracker_stats"
 msgid "Keep browsing to see how many we block"
-msgstr "Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
+msgstr ""
+"Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
 
 # smartling.placeholder_format=C
 #. Header above social media links.
@@ -11187,6 +11409,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Pencarian anonim dengan DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11255,6 +11484,12 @@ msgstr "Gambar Garis"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Lineout dimenangkan"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12351,6 +12586,12 @@ msgid "More than 20 minutes"
 msgstr "Lebih dari 20 menit"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12839,6 +13080,12 @@ msgid "No Thanks"
 msgstr "Tidak, terima kasih"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "Tidak Lagi Terlacak. Selamanya."
@@ -12984,7 +13231,8 @@ msgstr "Hasil tidak ditemukan."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
+msgstr ""
+"Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13501,6 +13749,12 @@ msgid "On but no numbers"
 msgstr "Hidup, tapi tanpa angka"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13711,6 +13965,12 @@ msgstr "Buka saran obrolan"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Buka buat dan edit saran gambar"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14460,10 +14720,22 @@ msgid "Pin"
 msgstr "Pin"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Sematkan obrolan di sini dari %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14481,6 +14753,12 @@ msgstr "Merah muda"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Disematkan"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14539,13 +14817,15 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
+msgstr ""
+"Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
+msgstr ""
+"Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14800,6 +15080,12 @@ msgid "Poor formatting"
 msgstr "Pemformatan yang buruk"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15008,6 +15294,12 @@ msgid "Previous tabs"
 msgstr "Tab sebelumnya"
 
 # smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
 msgctxt "Rich Facts label"
 msgid "Price"
@@ -15017,7 +15309,8 @@ msgstr "Harga"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr "Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
+msgstr ""
+"Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -15548,6 +15841,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "AI Penalaran dengan moderasi bawaan sedang"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15581,6 +15886,12 @@ msgstr "Tab Terbaru"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Penyimpanan obrolan terbaru bisa diatur di %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15736,6 +16047,12 @@ msgstr "Coba ulang pencarian tanpa situs ini"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Kurangi Penggunaan"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16115,6 +16432,12 @@ msgid "Reset All Settings"
 msgstr "Atur Ulang Semua Pengaturan"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16125,6 +16448,12 @@ msgstr "Atur ulang dalam %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Resolusi"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16250,7 +16579,8 @@ msgstr "Hasil mengecualikan informasi dari situs yang diblokir."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
+msgstr ""
+"Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16584,7 +16914,8 @@ msgstr "Simpan dan Keluar"
 #. Description explaining that sync allows saving more chats than local browser storage.
 msgctxt "Sync feature benefit description"
 msgid "Save more chats than you can in your web browser."
-msgstr "Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
+msgstr ""
+"Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
 
 # smartling.placeholder_format=C
 #. List item explaining that users can save more chats when Sync & Backup is enabled.
@@ -16800,7 +17131,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
+msgstr ""
+"Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16823,6 +17155,12 @@ msgstr "Cari"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Cari %1$s untuk menemukan hasil yang lebih dekat dengan lokasimu?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17017,8 +17355,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "Cari secara pribadi dengan aplikasi atau ekstensi kami, tambahkan pencarian "
-"web pribadi ke browser favoritmu, atau cari langsung di "
-"%1$sduckduckgo.com%2$s."
+"web pribadi ke browser favoritmu, atau cari langsung di %1$sduckduckgo."
+"com%2$s."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17183,7 +17521,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
+msgstr ""
+"Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17194,6 +17533,12 @@ msgid ""
 msgstr ""
 "Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung. "
 "Tidak ada orang selain kamu yang dapat melihat data kamu, bahkan kami."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17367,7 +17712,8 @@ msgstr "Pilih %1$sDuckDuckGo%2$s di menu dropdown Mesin Pencari Default"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
+msgstr ""
+"Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17486,7 +17832,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
+msgstr ""
+"Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17703,6 +18050,12 @@ msgid "Set as Homepage"
 msgstr "Atur sebagai Halaman beranda"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17768,6 +18121,18 @@ msgid "Seychelles"
 msgstr "Seychelles"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17808,6 +18173,13 @@ msgstr ""
 "Bagikan lokasi tingkat kota dengan model AI untuk meningkatkan relevansi. "
 "Duck.ai tidak pernah mengungkapkan lokasi tepat kamu kepada kami atau model "
 "AI."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17866,6 +18238,12 @@ msgstr "Bagikan URL halaman"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Bagikan masukan positif"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18001,6 +18379,12 @@ msgstr "Tampilkan Bookmarklet dan Data Pengaturan"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Tampilkan Detail"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18152,6 +18536,12 @@ msgid "Show more"
 msgstr "Tampilkan Lainnya"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18185,6 +18575,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Tampilkan bilah samping"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18261,7 +18657,8 @@ msgstr "Menampilkan garis horizontal di pemisah halaman hasil"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
+msgstr ""
+"Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18277,18 +18674,21 @@ msgstr "Menampilkan tautan yang paling banyak dikunjungi di halaman tab baru"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
+msgstr ""
+"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
+msgstr ""
+"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
+msgstr ""
+"Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18326,7 +18726,8 @@ msgstr "Menampilkan pesan selamat datang di atas halaman hasil pencarian"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
+msgstr ""
+"Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18544,7 +18945,8 @@ msgstr "Terjadi sesuatu yang salah"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
+msgstr ""
+"Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18557,6 +18959,12 @@ msgstr "Ada yang salah saat mengaktifkan Sync & Backup. Silakan coba lagi."
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Ada yang tidak beres, silakan coba lagi nanti."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18855,6 +19263,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Mulai Menggunakan Batas Mingguan"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Mulai mencari!"
@@ -19135,7 +19549,8 @@ msgstr "Sarankan judul untuk postingan blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
+msgstr ""
+"Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19432,7 +19847,16 @@ msgstr "Beralih ke model yang lebih efisien"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr "Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
+msgstr ""
+"Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
+
+# smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19445,7 +19869,8 @@ msgstr "Beralih ke %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
+msgstr ""
+"Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19499,7 +19924,8 @@ msgstr "Sync & Backup Diaktifkan!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
+msgstr ""
+"Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19588,6 +20014,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sinkronisasi dan pencadangan sementara tidak tersedia."
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19673,6 +20105,22 @@ msgstr "Tajikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Ambil Alih Kendali Privasimu!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19869,7 +20317,8 @@ msgstr "Thailand (en)"
 #. Message displayed after the user has submitted feedback. It invites the user to share more feedback.
 msgctxt "Feedback toast"
 msgid "Thank you for your feedback. Have more to share?"
-msgstr "Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
+msgstr ""
+"Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
 
 # smartling.placeholder_format=C
 msgid "Thank you!"
@@ -19896,7 +20345,8 @@ msgstr "Terima kasih atas masukanmu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
+msgstr ""
+"Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
@@ -19998,7 +20448,8 @@ msgstr "Permintaan tersebut mengalami batas waktu. Silakan coba lagi."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
+msgstr ""
+"Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -20144,10 +20595,22 @@ msgid "This Month"
 msgstr "Bulan ini"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Minggu ini"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20264,19 +20727,37 @@ msgstr "Gambar ini tidak dapat dibuat."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
+msgstr ""
+"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
+msgstr ""
+"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Informasi ini tidak berguna"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20399,7 +20880,8 @@ msgstr "Video ini belum bisa ditonton di sini. Kamu bisa menontonnya di %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
+msgstr ""
+"Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20554,7 +21036,8 @@ msgstr "Untuk melanjutkan, kamu harus menyetujui %1$s dan %2$sDuck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
+msgstr ""
+"Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20586,8 +21069,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser "
-"DuckDuckGo-mu ke versi terbaru dan coba lagi."
+"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser DuckDuckGo-"
+"mu ke versi terbaru dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20613,6 +21096,12 @@ msgstr "Hari Ini"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Hari Ini"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21026,9 +21515,21 @@ msgid "Try Them Out"
 msgstr "Coba dulu"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Coba lakukan pencarian!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21097,6 +21598,12 @@ msgid "Try for free"
 msgstr "Coba Gratis"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21109,6 +21616,12 @@ msgstr "Coba Gratis"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "Coba gratis! VPN yang aman, AI pribadi dan canggih, serta banyak lagi."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21138,6 +21651,12 @@ msgid "Try our homepage that never shows these messages:"
 msgstr ""
 "Silakan coba halaman beranda kami yang tidak pernah menampilkan pesan-pesan "
 "ini"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21388,6 +21907,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Aktifkan Duck Player untuk menonton YouTube tanpa iklan bertarget"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21603,7 +22128,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
+msgstr ""
+"Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21757,6 +22283,12 @@ msgstr "Buka model AI canggih dengan berlangganan DuckDuckGo"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Buka AI canggih dengan langgananmu!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -21983,7 +22515,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
+msgstr ""
+"Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22116,6 +22649,12 @@ msgstr "Gunakan di Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Gunakan di Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23133,8 +23672,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat "
-"Duck.ai. Coba muat ulang halaman."
+"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat Duck."
+"ai. Coba muat ulang halaman."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23156,7 +23695,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
+msgstr ""
+"Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -23308,6 +23848,12 @@ msgstr "Apa yang paling mengganggu kamu?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Apa yang membuatmu kembali hari ini?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23728,6 +24274,14 @@ msgid "Wintry Mix"
 msgstr "Hujan Bersalju"
 
 # smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -24105,7 +24659,8 @@ msgstr "Kamu bisa menemukan file <b>%1$s</b> di folder unduhanmu."
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
 msgid "You can hide this reminder in %sSearch Settings%s"
-msgstr "Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
+msgstr ""
+"Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24156,6 +24711,13 @@ msgstr "Kamu hanya dapat melampirkan gambar %1$s per percakapan"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Kamu hanya bisa melampirkan gambar %1$s per percakapan."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24301,6 +24863,12 @@ msgstr ""
 "Anda memiliki versi terbaru."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24347,6 +24915,12 @@ msgstr "Kamu telah memblokir %1$s situs."
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "Kamu telah memblokir 1 situs"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24752,6 +25326,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Pencarianmu tidak dapat dilacak kembali ke kamu"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24780,9 +25362,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami "
-"alih-alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah "
-"terinstal dan dapat:"
+"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami alih-"
+"alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah terinstal dan "
+"dapat:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25347,3 +25929,9 @@ msgstr "tahun"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "th"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s terdeteksi"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s file digunakan"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -364,6 +364,8 @@ msgstr "%1$s digunakan"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
+"%1$s menghabiskan batas penggunaan hingga 2-5x lebih cepat daripada model "
+"dasar %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -504,8 +506,7 @@ msgstr "%1$sTekan lama%2$s ikon aplikasi DuckDuckGo di layar beranda"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
+msgstr "%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -617,7 +618,7 @@ msgstr "1 hari yang lalu"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 file digunakan"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -911,16 +912,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr "Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr "Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1536,6 +1535,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Model tingkat lanjut dapat menggunakan batas 2-5x lebih cepat daripada model "
+"lain. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1746,8 +1747,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
+msgstr "Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2152,15 +2152,13 @@ msgstr "Apa kamu masih di sana?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
+msgstr "Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
+msgstr "Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2327,7 +2325,7 @@ msgstr "Tanya secara pribadi"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Tanya secara pribadi"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2468,21 +2466,18 @@ msgstr "Suara"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
+msgstr "Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -3677,8 +3672,7 @@ msgstr "Mengubah warna latar belakang hasil hover, modul, dan menu dropdown"
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
+msgstr "Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3805,8 +3799,8 @@ msgstr ""
 "anonim dengan model chat AI pihak ketiga, yang mendukung model dari OpenAI, "
 "Anthropic, dan lainnya. Menonaktifkan pengaturan ini akan menyembunyikan "
 "tombol dan tautan Chat di DuckDuckGo Search. Namun, Anda masih dapat "
-"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi %1$shttps://"
-"duck.ai%2$s langsung."
+"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi "
+"%1$shttps://duck.ai%2$s langsung."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3890,7 +3884,7 @@ msgstr "Mengobrol secara pribadi dengan AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Mengobrol secara pribadi dengan AI Populer"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4054,8 +4048,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
+msgstr "Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4437,8 +4430,7 @@ msgstr "Klik %1$sDi sini%2$s untuk mengunduh ekstensi DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
+msgstr "Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4483,8 +4475,7 @@ msgstr "Klik %1$sYa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
+msgstr "Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4686,7 +4677,7 @@ msgstr "Tutup"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Tutup"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4736,7 +4727,7 @@ msgstr "Tutup pencarian"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Tutup pendapat kedua"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5114,7 +5105,7 @@ msgstr "Terus Memblokir Iklan"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Lanjutkan obrolan terbaru di sini. Atau hapus dengan Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5185,7 +5176,7 @@ msgstr "Data cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Disalin"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5238,7 +5229,7 @@ msgstr "Salin Kode"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Salin Tautan"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5357,7 +5348,7 @@ msgstr "Buat Gambar"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Buat Tautan Berbagi"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5409,6 +5400,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Membuat tautan akan membuat salinan obrolan yang dapat dilihat oleh siapa "
+"saja yang membukanya."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5567,7 +5560,7 @@ msgstr "Sesuaikan Tanggapan"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Sesuaikan Tanggapan"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5859,7 +5852,7 @@ msgstr "Hapus Data Server?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Hapus Tautan yang Dibagikan"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5871,7 +5864,7 @@ msgstr "Hapus Transkrip"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Hapus obrolan"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5909,7 +5902,7 @@ msgstr "Hapus gambar?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Hapus aku"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6225,7 +6218,7 @@ msgstr "Tolak promosi"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Tutup tur"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6249,8 +6242,7 @@ msgstr "Bahasa Tampilan"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
+msgstr "Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6442,7 +6434,7 @@ msgstr "Unduh DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Unduh DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6530,8 +6522,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"Buatlah beberapa opsi untuk postingan media sosial yang mengundang orang-"
-"orang ke pesta saya yang akan datang."
+"Buatlah beberapa opsi untuk postingan media sosial yang mengundang "
+"orang-orang ke pesta saya yang akan datang."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6663,7 +6655,7 @@ msgstr "Duck.ai oleh DuckDuckGo. Obrolan AI pribadi. Bebas."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai sekarang dapat menganalisis PDF. Cobalah!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6703,8 +6695,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
+msgstr "Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6794,8 +6785,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
+msgstr "Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -6826,7 +6816,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai mendukung model dari Anthropic, OpenAI, dan lainnya."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6844,8 +6834,7 @@ msgstr "Duck.ai ditingkatkan!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
+msgstr "Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7031,8 +7020,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
+msgstr "DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7307,9 +7295,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi kata-"
-"kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 kata "
-"acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
+"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi "
+"kata-kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 "
+"kata acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
 "sepanjang 18—20 karakter."
 
 # smartling.placeholder_format=C
@@ -7482,7 +7470,7 @@ msgstr "Aktifkan Situs yang Paling Banyak Dikunjungi"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Aktifkan Sekarang"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7532,8 +7520,7 @@ msgstr "Aktifkan Dikte dalam Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
+msgstr "Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7786,7 +7773,7 @@ msgstr "Panduan hiburan"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Seluruh Obrolan"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7887,8 +7874,7 @@ msgstr "Jelaskan jawaban yang diterima dengan bahasa yang sederhana."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
+msgstr "Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7956,13 +7942,13 @@ msgstr "Lirik eksplisit"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Jelajahi Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Jelajahi Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8069,7 +8055,7 @@ msgstr "Gratis"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRATIS & OPSIONAL"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8322,8 +8308,7 @@ msgstr "Temukan hasil yang lebih dekat dari lokasimu."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
+msgstr "Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8394,8 +8379,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
+msgstr "Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8494,7 +8478,7 @@ msgstr "Kosongkan Penyimpanan"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Gratis dan selalu pribadi"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8620,8 +8604,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dari bilah menu aplikasi di Mac, pilih <strong>DuckDuckGo</strong> &gt; "
-"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal Pembaruan</"
-"strong>."
+"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal "
+"Pembaruan</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9016,7 +9000,7 @@ msgstr "Dapatkan bantuan komputer"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9059,13 +9043,13 @@ msgstr "Dapatkan Versi Terbaru"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Dapatkan aplikasinya"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
+msgstr "Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9093,7 +9077,7 @@ msgstr "Ajak temanmu untuk beralih dan bantu kami makin berkembang!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Daftar periksa memulai"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9782,7 +9766,7 @@ msgstr "Sembunyikan Tips"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Sembunyikan Tutorial"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10199,8 +10183,7 @@ msgstr "Saya tidak paham informasi ini"
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "I don’t want to see any information from DuckDuckGo on this page"
-msgstr ""
-"Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
+msgstr "Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -10239,8 +10222,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
+msgstr "Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10528,8 +10510,7 @@ msgstr "Di menu atas, pilih %1$sAlat%2$s > %3$sPengaturan%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
+msgstr "Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11012,8 +10993,7 @@ msgstr "Tetap buka Sync & Backup di kedua perangkat."
 #. An instruction to state that a list of companies/trackers will be updated with continued use
 msgctxt "tracker_stats"
 msgid "Keep browsing to see how many we block"
-msgstr ""
-"Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
+msgstr "Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
 
 # smartling.placeholder_format=C
 #. Header above social media links.
@@ -11414,6 +11394,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11489,7 +11471,7 @@ msgstr "Lineout dimenangkan"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Tautan kedaluwarsa dalam 7 hari."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12589,7 +12571,7 @@ msgstr "Lebih dari 20 menit"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Tips lainnya"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13083,7 +13065,7 @@ msgstr "Tidak, terima kasih"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Tidak, terima kasih"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13231,8 +13213,7 @@ msgstr "Hasil tidak ditemukan."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
+msgstr "Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13752,7 +13733,7 @@ msgstr "Hidup, tapi tanpa angka"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Orientasi selesai"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13970,7 +13951,7 @@ msgstr "Buka buat dan edit saran gambar"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Buka daftar periksa untuk memulai"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14723,7 +14704,7 @@ msgstr "Pin"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Sematkan obrolan"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14735,7 +14716,7 @@ msgstr "Sematkan obrolan di sini dari %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Pin aku"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14758,7 +14739,7 @@ msgstr "Disematkan"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Chat yang disematkan akan muncul di bagian atas obrolan terbaru kamu."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14817,15 +14798,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
+msgstr "Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
+msgstr "Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15083,7 +15062,7 @@ msgstr "Pemformatan yang buruk"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
+msgstr "Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15297,7 +15276,7 @@ msgstr "Tab sebelumnya"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Tips sebelumnya"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15309,8 +15288,7 @@ msgstr "Harga"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr ""
-"Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
+msgstr "Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -15845,12 +15823,14 @@ msgstr "AI Penalaran dengan moderasi bawaan sedang"
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
 msgstr ""
+"Penalaran dapat memberikan jawaban yang lebih baik untuk pertanyaan yang "
+"kompleks."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15891,7 +15871,7 @@ msgstr "Penyimpanan obrolan terbaru bisa diatur di %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Obrolan Terbaru"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16052,7 +16032,7 @@ msgstr "Kurangi Penggunaan"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Kurangi penggunaan dengan model yang lebih efisien"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16435,7 +16415,7 @@ msgstr "Atur Ulang Semua Pengaturan"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Atur ulang tutorial"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16453,7 +16433,7 @@ msgstr "Resolusi"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Tanggapan"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16579,8 +16559,7 @@ msgstr "Hasil mengecualikan informasi dari situs yang diblokir."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
+msgstr "Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16914,8 +16893,7 @@ msgstr "Simpan dan Keluar"
 #. Description explaining that sync allows saving more chats than local browser storage.
 msgctxt "Sync feature benefit description"
 msgid "Save more chats than you can in your web browser."
-msgstr ""
-"Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
+msgstr "Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
 
 # smartling.placeholder_format=C
 #. List item explaining that users can save more chats when Sync & Backup is enabled.
@@ -17131,8 +17109,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
+msgstr "Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17160,7 +17137,7 @@ msgstr "Cari %1$s untuk menemukan hasil yang lebih dekat dengan lokasimu?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Tombol Beralih Cari & Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17355,8 +17332,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "Cari secara pribadi dengan aplikasi atau ekstensi kami, tambahkan pencarian "
-"web pribadi ke browser favoritmu, atau cari langsung di %1$sduckduckgo."
-"com%2$s."
+"web pribadi ke browser favoritmu, atau cari langsung di "
+"%1$sduckduckgo.com%2$s."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17521,8 +17498,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
+msgstr "Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17538,7 +17514,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Tersimpan dengan aman di server terenkripsi kami."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17712,8 +17688,7 @@ msgstr "Pilih %1$sDuckDuckGo%2$s di menu dropdown Mesin Pencari Default"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
+msgstr "Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17832,8 +17807,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
+msgstr "Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18053,7 +18027,7 @@ msgstr "Atur sebagai Halaman beranda"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Atur nada dan gaya tanggapan Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18124,13 +18098,13 @@ msgstr "Seychelles"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Bagikan"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Bagikan"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18179,7 +18153,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Bagikan obrolan"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18243,7 +18217,7 @@ msgstr "Bagikan masukan positif"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Cakupan bagikan"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18384,7 +18358,7 @@ msgstr "Tampilkan Detail"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Tampilkan tutorial Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18539,7 +18513,7 @@ msgstr "Tampilkan Lainnya"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Tampilkan model lainnya"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18580,7 +18554,7 @@ msgstr "Tampilkan bilah samping"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18657,8 +18631,7 @@ msgstr "Menampilkan garis horizontal di pemisah halaman hasil"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
+msgstr "Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18674,21 +18647,18 @@ msgstr "Menampilkan tautan yang paling banyak dikunjungi di halaman tab baru"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
+msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
+msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
+msgstr "Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18726,8 +18696,7 @@ msgstr "Menampilkan pesan selamat datang di atas halaman hasil pencarian"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
+msgstr "Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18945,8 +18914,7 @@ msgstr "Terjadi sesuatu yang salah"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
+msgstr "Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18964,7 +18932,7 @@ msgstr "Ada yang tidak beres, silakan coba lagi nanti."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Terjadi sesuatu yang salah. Silakan coba lagi."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19266,7 +19234,7 @@ msgstr "Mulai Menggunakan Batas Mingguan"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Mulai obrolan baru"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19549,8 +19517,7 @@ msgstr "Sarankan judul untuk postingan blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
+msgstr "Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19847,8 +19814,7 @@ msgstr "Beralih ke model yang lebih efisien"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr ""
-"Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
+msgstr "Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -19856,7 +19822,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Beralih ke pendapat kedua ini"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19869,8 +19835,7 @@ msgstr "Beralih ke %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
+msgstr "Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19924,8 +19889,7 @@ msgstr "Sync & Backup Diaktifkan!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
+msgstr "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20017,7 +19981,7 @@ msgstr "Sinkronisasi dan pencadangan sementara tidak tersedia."
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sinkronkan obrolan di semua perangkat"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20113,6 +20077,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Bawa Duck.ai bersamamu ke mana saja. Dapatkan langsung di aplikasi gratis "
+"kami untuk akses yang lebih cepat, di mana pun kamu berada."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20121,6 +20087,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Bawa Duck.ai ke mana saja. Dapatkan langsung di dalam browser gratis kami "
+"untuk akses lebih cepat, di mana pun kamu menjelajah."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20317,8 +20285,7 @@ msgstr "Thailand (en)"
 #. Message displayed after the user has submitted feedback. It invites the user to share more feedback.
 msgctxt "Feedback toast"
 msgid "Thank you for your feedback. Have more to share?"
-msgstr ""
-"Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
+msgstr "Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
 
 # smartling.placeholder_format=C
 msgid "Thank you!"
@@ -20345,8 +20312,7 @@ msgstr "Terima kasih atas masukanmu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
+msgstr "Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
@@ -20448,8 +20414,7 @@ msgstr "Permintaan tersebut mengalami batas waktu. Silakan coba lagi."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
+msgstr "Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -20598,7 +20563,7 @@ msgstr "Bulan ini"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Tanggapan Ini"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20610,7 +20575,7 @@ msgstr "Minggu ini"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Obrolan ini tetap berada di Duck.ai dan tetap pribadi untukmu."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20727,16 +20692,14 @@ msgstr "Gambar ini tidak dapat dibuat."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
+msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
+msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20750,6 +20713,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Ini hanya contoh obrolan. Buka menunya (tiga titik), lalu pilih Pin agar "
+"tetap berada di bagian atas obrolanmu!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20758,6 +20723,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Ini hanya obrolan contoh. Gunakan Fire Button di menu samping untuk "
+"menghapusnya!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20880,8 +20847,7 @@ msgstr "Video ini belum bisa ditonton di sini. Kamu bisa menontonnya di %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
+msgstr "Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21036,8 +21002,7 @@ msgstr "Untuk melanjutkan, kamu harus menyetujui %1$s dan %2$sDuck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
+msgstr "Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21069,8 +21034,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser DuckDuckGo-"
-"mu ke versi terbaru dan coba lagi."
+"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser "
+"DuckDuckGo-mu ke versi terbaru dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21102,6 +21067,8 @@ msgstr "Hari Ini"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21518,7 +21485,7 @@ msgstr "Coba dulu"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Coba model lain"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21529,7 +21496,7 @@ msgstr "Coba lakukan pencarian!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Coba saran"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21601,7 +21568,7 @@ msgstr "Coba Gratis"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Coba Gratis"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21621,7 +21588,7 @@ msgstr "Coba gratis! VPN yang aman, AI pribadi dan canggih, serta banyak lagi."
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Coba gratis selama 7 hari"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21656,7 +21623,7 @@ msgstr ""
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Coba penalaran"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21910,7 +21877,7 @@ msgstr "Aktifkan Duck Player untuk menonton YouTube tanpa iklan bertarget"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Aktifkan Toggle Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22128,8 +22095,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
+msgstr "Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22288,7 +22254,7 @@ msgstr "Buka AI canggih dengan langgananmu!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Buka model tingkat lanjut"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22515,8 +22481,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
+msgstr "Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22654,7 +22619,7 @@ msgstr "Gunakan di Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Gunakan Fire Button untuk menghapus obrolan dari riwayat."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23672,8 +23637,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat Duck."
-"ai. Coba muat ulang halaman."
+"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat "
+"Duck.ai. Coba muat ulang halaman."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23695,8 +23660,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
+msgstr "Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -23853,7 +23817,7 @@ msgstr "Apa yang membuatmu kembali hari ini?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Apa yang bisa kamu lakukan?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24280,6 +24244,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Dengan Duck.ai, obrolan kamu dianonimkan dan tidak pernah digunakan untuk "
+"melatih AI. Aktifkan atau matikan kapan saja di menu '%1$s'."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24659,8 +24625,7 @@ msgstr "Kamu bisa menemukan file <b>%1$s</b> di folder unduhanmu."
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
 msgid "You can hide this reminder in %sSearch Settings%s"
-msgstr ""
-"Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
+msgstr "Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24717,7 +24682,7 @@ msgstr "Kamu hanya bisa melampirkan gambar %1$s per percakapan."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Kamu hanya bisa melampirkan %1$s tab sekaligus."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24866,7 +24831,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Kamu sudah siap!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24920,7 +24885,7 @@ msgstr "Kamu telah memblokir 1 situs"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Kamu telah menguasai dasar-dasar Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25332,6 +25297,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Pengaturan kamu telah disimpan, namun menghapus cookie akan mengatur ulang "
+"pengaturan tersebut. Aktifkan ekstensi %1$sDuckDuckGo No AI%2$s agar "
+"pengaturan ini permanen."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25362,9 +25330,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami alih-"
-"alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah terinstal dan "
-"dapat:"
+"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami "
+"alih-alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah "
+"terinstal dan dapat:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25934,4 +25902,4 @@ msgstr "th"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/io_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/io_XX/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4015,6 +4057,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4069,6 +4116,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4106,6 +4158,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4202,6 +4259,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4236,6 +4298,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4361,6 +4430,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4597,9 +4671,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4627,6 +4711,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4880,6 +4969,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5046,6 +5140,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5221,6 +5320,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5328,6 +5432,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5816,6 +5925,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6055,6 +6169,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6188,6 +6307,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6269,6 +6398,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6600,6 +6734,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7021,6 +7160,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7050,6 +7194,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7066,6 +7220,11 @@ msgstr "Komprar ica kansono ye:"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7617,6 +7776,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8914,6 +9078,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8969,6 +9139,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9865,6 +10040,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10259,6 +10439,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10807,6 +10992,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Yes ma nula nombri"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10975,6 +11165,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11571,9 +11766,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11588,6 +11793,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11844,6 +12054,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12013,6 +12228,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12455,6 +12675,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12482,6 +12712,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12604,6 +12839,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12906,6 +13146,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12914,6 +13159,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13471,6 +13721,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13751,6 +14006,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14148,6 +14408,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Pozez kom Hemopagino"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14200,6 +14465,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14229,6 +14504,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14277,6 +14558,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14388,6 +14674,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14512,6 +14803,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14540,6 +14836,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14838,6 +15139,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15070,6 +15376,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15548,6 +15859,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15660,6 +15978,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15729,6 +16052,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16098,9 +16435,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16201,6 +16548,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16457,6 +16818,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16794,9 +17160,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Probez sercho!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16850,6 +17226,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16860,6 +17241,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16882,6 +17268,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17082,6 +17473,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17366,6 +17762,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17661,6 +18062,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18574,6 +18980,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18913,6 +19324,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19259,6 +19677,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19367,6 +19791,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19401,6 +19830,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19700,6 +20134,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20173,6 +20614,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/is_IS/LC_MESSAGES/duckduckgo.po
+++ b/locales/is_IS/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -484,6 +494,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Fyrir degi síðan"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1223,6 +1238,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1846,6 +1868,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3080,6 +3107,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3676,6 +3708,11 @@ msgstr "Klippimyndir"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3711,6 +3748,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4018,6 +4060,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4072,6 +4119,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4109,6 +4161,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4205,6 +4262,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4239,6 +4301,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4364,6 +4433,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4600,9 +4674,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4630,6 +4714,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4883,6 +4972,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5049,6 +5143,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5224,6 +5323,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5331,6 +5435,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5820,6 +5929,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6059,6 +6173,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6192,6 +6311,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6273,6 +6402,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6602,6 +6736,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7023,6 +7162,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7052,6 +7196,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7068,6 +7222,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7619,6 +7778,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8916,6 +9080,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8971,6 +9141,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9867,6 +10042,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Lengri en 20 mínútur"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10261,6 +10441,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10809,6 +10994,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Kveikt en engar tölur"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10977,6 +11167,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11577,9 +11772,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11594,6 +11799,11 @@ msgstr "Bleikt"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11850,6 +12060,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12019,6 +12234,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12461,6 +12681,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12488,6 +12718,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12610,6 +12845,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12912,6 +13152,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Endurstilla allar stillingar"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12920,6 +13165,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13477,6 +13727,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Leita í leyni"
 
@@ -13757,6 +14012,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14154,6 +14414,11 @@ msgstr "Nota sem sjálfgefna leitarvél"
 msgid "Set as Homepage"
 msgstr "Nota sem upphafssíðu"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14206,6 +14471,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14236,6 +14511,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14284,6 +14565,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14396,6 +14682,11 @@ msgstr "Sýna gögn um smábókamerki og stillingar"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Sýna nánari upplýsingar"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14519,6 +14810,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14547,6 +14843,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14846,6 +15147,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15078,6 +15384,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15558,6 +15869,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15670,6 +15988,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15740,6 +16063,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Endurheimtu friðhelgina!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16112,9 +16449,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16215,6 +16562,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16473,6 +16834,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16810,9 +17176,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Prófaðu að leita að einhverju!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16866,6 +17242,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16876,6 +17257,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16899,6 +17285,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Prófaðu upphafssíðuna okkar sem sýnir aldrei svona skilaboð:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17098,6 +17489,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17382,6 +17778,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17679,6 +18080,11 @@ msgstr "Nota í Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Nota í Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18593,6 +18999,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18932,6 +19343,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19276,6 +19694,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19384,6 +19808,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19420,6 +19849,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19717,6 +20151,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20189,6 +20630,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "%1$s giorni fa"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Lingua rilevata: %1$s"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +361,12 @@ msgid "%s used"
 msgstr "%1$s usato"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s visualizzazione"
@@ -489,7 +501,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
+msgstr ""
+"%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -604,6 +617,12 @@ msgstr "1 tentativo bloccato da DuckDuckGo nelle ultime 24 ore"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 giorno fa"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -824,7 +843,8 @@ msgstr "Limite di utilizzo di 6 ore raggiunto."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr ""
+"Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -953,8 +973,8 @@ msgstr ""
 "AI Chat consente di conversare in modo anonimo con modelli di chat di terze "
 "parti dotati di intelligenza artificiale. Disattivando questa funzione, AI "
 "Chat verrà nascosta su DuckDuckGo Search. È comunque possibile accedervi "
-"anche quando questa impostazione è disattivata visitando "
-"%1$sduckduckgo.com/aichat%2$s."
+"anche quando questa impostazione è disattivata visitando %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1025,7 +1045,8 @@ msgstr ""
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
 msgctxt "duckassist"
 msgid "AI-assisted answers have been turned off!"
-msgstr "Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
+msgstr ""
+"Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
 
 # smartling.placeholder_format=C
 #. Negative feedback suggestion for when user dislikes AI-generated content
@@ -1373,7 +1394,8 @@ msgstr "Aggiungi una casella di ricerca di %1$s al tuo sito!"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr "Aggiungi un punto di partenza e una destinazione per trovare un percorso."
+msgstr ""
+"Aggiungi un punto di partenza e una destinazione per trovare un percorso."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1518,6 +1540,14 @@ msgctxt ""
 "app variant)"
 msgid "Advanced Models"
 msgstr "Modelli avanzati"
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1804,7 +1834,8 @@ msgstr "Vuoi consentire la revisione anonima dei file per questa chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
+msgstr ""
+"Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2312,6 +2343,12 @@ msgid "Ask privately"
 msgstr "Chiedi in privato"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2452,13 +2489,15 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr ""
+"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr ""
+"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2763,8 +2802,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Prima di archiviare questo rapporto, DuckDuckGo renderà anonima la tua "
-"conversazione eliminando le informazioni personali, come nomi, indirizzi "
-"e-mail e metadati identificativi."
+"conversazione eliminando le informazioni personali, come nomi, indirizzi e-"
+"mail e metadati identificativi."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2890,12 +2929,14 @@ msgstr "Blocca il sistema di tracciamento e-mail e nascondi il tuo indirizzo."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
+msgstr ""
+"L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block most trackers as you browse."
-msgstr "Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
+msgstr ""
+"Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
 
 # smartling.placeholder_format=C
 #. Menu option to block a site from the displayed results
@@ -3876,6 +3917,12 @@ msgid "Chat privately with AI"
 msgstr "Chatta in privato con l'IA"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4524,7 +4571,8 @@ msgstr "Clicca sulla %1$slente di ingrandimento%2$s nella barra di ricerca"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr "Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
+msgstr ""
+"Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4577,18 +4625,21 @@ msgstr "Clicca sui %1$spuntini di sospensione%2$s nella barra degli strumenti."
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr "Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
+msgstr ""
+"Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %spermissions icon%s in the address bar"
-msgstr "Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
+msgstr ""
+"Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
+msgstr ""
+"Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4672,6 +4723,12 @@ msgid "Close"
 msgstr "Chiudi"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4714,6 +4771,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Chiudi ricerca"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5087,6 +5150,12 @@ msgid "Continue Blocking Ads"
 msgstr "Continua a bloccare gli annunci"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5152,6 +5221,12 @@ msgid "Cookie data:"
 msgstr "Dati del cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5190,13 +5265,20 @@ msgstr "Copia"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
+msgstr ""
+"Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Copia codice"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5266,7 +5348,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
+msgstr ""
+"Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5312,6 +5395,12 @@ msgid "Create Image"
 msgstr "Crea immagine"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5353,6 +5442,14 @@ msgstr "Creato da"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Creato da %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5506,6 +5603,12 @@ msgstr "Personalizza le risposte"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Personalizza le risposte"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5794,10 +5897,22 @@ msgid "Delete Server Data?"
 msgstr "Eliminare i dati del server?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Elimina trascrizione"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5830,6 +5945,12 @@ msgstr "Elimina immagine"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Eliminare l'immagine?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6142,6 +6263,12 @@ msgid "Dismiss promotion"
 msgstr "Ignora la promozione"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6350,6 +6477,12 @@ msgstr "Download completato"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Scarica DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6567,6 +6700,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai di DuckDuckGo. Chat privata con AI. Gratuito."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6647,8 +6786,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai non è al momento disponibile. Se il problema persiste, invia "
-"un'e-mail con il codice anonimo %1$s a %2$s"
+"Duck.ai non è al momento disponibile. Se il problema persiste, invia un'e-"
+"mail con il codice anonimo %1$s a %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6720,6 +6859,12 @@ msgstr ""
 "verificata l'accuratezza."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6735,7 +6880,8 @@ msgstr "Duck.ai è stato aggiornato!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
+msgstr ""
+"Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7374,6 +7520,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Attiva siti più visitati"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7541,7 +7693,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
+msgstr ""
+"Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7593,13 +7746,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
+msgstr ""
+"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
+msgstr ""
+"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7678,6 +7833,12 @@ msgstr "Inserisci la tua passphrase per caricare le impostazioni."
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "Guida all'intrattenimento"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7847,10 +8008,23 @@ msgid "Explicit lyrics"
 msgstr "Testi espliciti"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
+msgstr ""
+"Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7946,6 +8120,12 @@ msgstr "Voti 1° posto"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Gratuito"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8369,6 +8549,12 @@ msgid "Free Up Storage"
 msgstr "Libera spazio di archiviazione"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8408,7 +8594,8 @@ msgstr "Condivisione e uso commerciale gratuiti"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
+msgstr ""
+"Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8827,7 +9014,8 @@ msgstr "Iniziamo"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
+msgstr ""
+"Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8883,6 +9071,12 @@ msgid "Get computer help"
 msgstr "Ricevi assistenza per il computer"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8918,6 +9112,18 @@ msgid "Get the Latest Version"
 msgstr "Scarica l'ultima versione"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8938,6 +9144,12 @@ msgstr "Ascolta questa canzone su:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Dillo ai tuoi amici e aiutaci a crescere!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9283,7 +9495,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
+msgstr ""
+"Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9626,6 +9839,12 @@ msgid "Hide Tips"
 msgstr "Nascondi suggerimenti"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9672,7 +9891,8 @@ msgstr "Nascondi il tuo indirizzo e-mail"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
+msgstr ""
+"Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9916,7 +10136,8 @@ msgstr "Come funziona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
+msgstr ""
+"Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10166,7 +10387,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
+msgstr ""
+"Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10369,7 +10591,8 @@ msgstr "Nel menu in alto seleziona %1$sStrumenti%2$s > %3$sImpostazioni%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
+msgstr ""
+"Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11250,6 +11473,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Ti permette di cercare anonimamente con DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11320,6 +11550,12 @@ msgid "Lineouts Won"
 msgstr "Rimesse laterali vinte"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Font dei link:"
@@ -11333,7 +11569,8 @@ msgstr "Link:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
+msgstr ""
+"Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11444,7 +11681,8 @@ msgstr "Carica altre immagini durante lo scorrimento"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
+msgstr ""
+"Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12207,7 +12445,8 @@ msgstr "Limite mensile raggiunto"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr ""
+"Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12414,6 +12653,12 @@ msgstr "Altre statistiche su %1$s"
 msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Più di 20 minuti"
+
+# smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12905,6 +13150,12 @@ msgid "No Thanks"
 msgstr "No, grazie"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "Nessun tracciamento. Mai."
@@ -13074,13 +13325,15 @@ msgstr "Nessun sistema di tracciamento bloccato nell'ultima ora"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
+msgstr ""
+"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
+msgstr ""
+"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13567,6 +13820,12 @@ msgid "On but no numbers"
 msgstr "On, ma nessun numero"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13781,6 +14040,12 @@ msgstr "Apri i suggerimenti della chat"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Apri i suggerimenti per creare e modificare le immagini"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14531,10 +14796,22 @@ msgid "Pin"
 msgstr "Fissa"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Fissa le chat qui dal %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14552,6 +14829,12 @@ msgstr "Rosa"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Fissato"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14610,13 +14893,15 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
+msgstr ""
+"Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
+msgstr ""
+"Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14871,6 +15156,12 @@ msgid "Poor formatting"
 msgstr "Formattazione insufficiente"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15077,6 +15368,12 @@ msgstr "Immagine precedente"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Schede precedenti"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15391,7 +15688,8 @@ msgstr "Proteggi i tuoi dati durante le ricerche e la navigazione."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
+msgstr ""
+"Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15619,6 +15917,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "AI di ragionamento con moderazione integrata media"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15651,7 +15961,14 @@ msgstr "Schede recenti"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr "Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
+msgstr ""
+"Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15809,6 +16126,12 @@ msgid "Reduce Usage"
 msgstr "Riduci l'utilizzo"
 
 # smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
@@ -15956,8 +16279,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante "
-"&quot;Aggiorna&quot; o &quot;Ricarica&quot; del browser."
+"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante &quot;"
+"Aggiorna&quot; o &quot;Ricarica&quot; del browser."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15974,7 +16297,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr "Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
+msgstr ""
+"Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -16188,6 +16512,12 @@ msgid "Reset All Settings"
 msgstr "Ripristina tutte le impostazioni"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16198,6 +16528,12 @@ msgstr "Ripristino tra %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Risoluzione"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16692,8 +17028,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia "
-"end-to-end."
+"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia end-to-"
+"end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16903,6 +17239,12 @@ msgstr "Ricerca"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Vuoi cercare %1$s per trovare risultati più vicini a te?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17217,7 +17559,8 @@ msgstr "Seconda opinione"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
+msgstr ""
+"Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17267,8 +17610,8 @@ msgstr ""
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
-"end-to-end."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
+"end."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17277,8 +17620,14 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
-"end-to-end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
+"end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17427,24 +17776,27 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Scegli %1$sPersonalizzata%2$s e digita nel campo "
-"%3$shttps://duckduckgo.com%4$s"
+"Scegli %1$sPersonalizzata%2$s e digita nel campo %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17559,7 +17911,8 @@ msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sImpostazioni avanzate%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
+msgstr ""
+"Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17655,7 +18008,8 @@ msgstr "Testo selezionato da %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
+msgstr ""
+"Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17799,6 +18153,12 @@ msgid "Set as Homepage"
 msgstr "Imposta come pagina iniziale"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17866,6 +18226,18 @@ msgid "Seychelles"
 msgstr "Seychelles"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17906,6 +18278,13 @@ msgstr ""
 "Condividi una posizione a livello di città con modelli di intelligenza "
 "artificiale per migliorare la pertinenza. Duck.ai non rivela mai a noi o ai "
 "modelli di AI la posizione esatta."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17964,6 +18343,12 @@ msgstr "Condividi l'URL della pagina"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Condividi feedback positivo"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18099,6 +18484,12 @@ msgstr "Mostra bookmarklet e Dati impostazioni"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Mostra dettagli"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18250,6 +18641,12 @@ msgid "Show more"
 msgstr "Mostra di più"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18283,6 +18680,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Mostra la barra laterale"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18354,12 +18757,14 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows horizontal lines at result page breaks"
-msgstr "Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
+msgstr ""
+"Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
+msgstr ""
+"Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18380,7 +18785,8 @@ msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo al tuo browser"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
+msgstr ""
+"Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18509,7 +18915,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
+msgstr ""
+"I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18654,13 +19061,20 @@ msgstr "Qualcosa è andato storto durante il salvataggio nel server, riprova."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
+msgstr ""
+"Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Si è verificato un errore, riprova più tardi."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18678,7 +19092,8 @@ msgstr "A volte"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
+msgstr ""
+"Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18754,7 +19169,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
+msgstr ""
+"Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18959,6 +19375,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Inizia a usare il limite settimanale"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Inizia a cercare!"
@@ -19061,7 +19483,8 @@ msgstr "Interrompi la generazione"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
+msgstr ""
+"Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19538,7 +19961,16 @@ msgstr "Passa a un modello più efficiente"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr "Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
+msgstr ""
+"Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
+
+# smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19551,7 +19983,8 @@ msgstr "Passato a %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
+msgstr ""
+"Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19667,8 +20100,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Come funziona il codice?\n"
-"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di "
-"Duck.ai.\n"
+"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di Duck."
+"ai.\n"
 "2. Seleziona \"Attiva Sync & Backup\", poi \"Recupera dati sincronizzati\"\n"
 "3. Copia il codice di recupero sopra e incollalo nello spazio \"Incolla qui "
 "il tuo codice\"\n"
@@ -19694,6 +20127,12 @@ msgstr "Sincronizza con un altro dispositivo"
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "Temporaneamente la sincronizzazione e il backup non sono disponibili"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19781,6 +20220,22 @@ msgstr "Tajikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Tutela la tua privacy!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20260,10 +20715,22 @@ msgid "This Month"
 msgstr "Questo mese"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Questa settimana"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20380,7 +20847,8 @@ msgstr "Questa immagine non può essere creata."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
+msgstr ""
+"Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20395,6 +20863,22 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Questa informazione non è utile"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20444,7 +20928,8 @@ msgstr "Questa pagina richiede Javascript per funzionare."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
+msgstr ""
+"Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20739,6 +21224,12 @@ msgid "Today"
 msgstr "Oggi"
 
 # smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Togo"
 msgstr "Togo"
 
@@ -20901,7 +21392,8 @@ msgstr "Sistemi di tracciamento bloccati nell'ultima ora"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
+msgstr ""
+"I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20917,7 +21409,8 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr "I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
+msgstr ""
+"I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -21150,9 +21643,21 @@ msgid "Try Them Out"
 msgstr "Provali"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Prova una ricerca!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21202,7 +21707,8 @@ msgstr "Prova ad abilitare la posizione anonima per risultati più accurati."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
+msgstr ""
+"Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21219,6 +21725,12 @@ msgid "Try for free"
 msgstr "Prova gratuitamente"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21233,6 +21745,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Prova gratuitamente! Una VPN sicura e privata, caratterizzata da IA "
 "avanzata, nonché molto altro."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21260,6 +21778,12 @@ msgstr "Prova il nostro browser"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Prova la nostra homepage che non mostra mai questi messaggi:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21511,6 +22035,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Attiva Duck Player per guardare YouTube senza annunci mirati"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21713,8 +22243,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: "
-"https://duckduckgo.com"
+"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21743,8 +22273,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di "
-"ricerca...%4$s"
+"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di ricerca..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21758,7 +22288,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
+msgstr ""
+"In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21882,6 +22413,12 @@ msgstr ""
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Sblocca l'AI avanzata con il tuo abbonamento!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22245,6 +22782,12 @@ msgid "Use in Safari"
 msgstr "Usa in Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22403,7 +22946,8 @@ msgstr "Visualizza i prezzi per il tuo soggiorno"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
+msgstr ""
+"La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22807,7 +23351,8 @@ msgstr "Non memorizziamo nomi utente né informazioni personali."
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
+msgstr ""
+"Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22955,7 +23500,8 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
+msgstr ""
+"Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23188,7 +23734,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
+msgstr ""
+"Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23408,7 +23955,8 @@ msgstr "Quali sono i piatti da provare in questo caso?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
+msgstr ""
+"Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23433,6 +23981,12 @@ msgstr "Cosa ti ha infastidito di più?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Cosa ti ha fatto tornare oggi?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23629,7 +24183,8 @@ msgstr "Su cosa vuoi dare un'opinione?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
+msgstr ""
+"Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23853,6 +24408,14 @@ msgstr "Vittorie"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Acquaneve"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24199,7 +24762,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
+msgstr ""
+"Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24281,6 +24845,13 @@ msgstr "Puoi allegare solo %1$s immagini per conversazione"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Puoi allegare solo %1$s immagini per conversazione."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24412,7 +24983,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Non vedrai più questo messaggio a meno che non elimini i dati del browser."
+msgstr ""
+"Non vedrai più questo messaggio a meno che non elimini i dati del browser."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24423,6 +24995,12 @@ msgid ""
 msgstr ""
 "Riceverai gli aggiornamenti automatici dell'app DuckDuckGo non appena avrai "
 "l'ultima versione."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24472,6 +25050,12 @@ msgid "You've blocked 1 site"
 msgstr "Hai bloccato 1 sito"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24497,7 +25081,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Hai raggiunto la durata massima della chat vocale per una singola sessione."
+msgstr ""
+"Hai raggiunto la durata massima della chat vocale per una singola sessione."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -24509,7 +25094,8 @@ msgstr "Hai raggiunto il limite di chat vocale per oggi. Riprova domani."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
+msgstr ""
+"Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24872,6 +25458,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Le tue ricerche non sono riconducibili a te"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24910,7 +25504,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
+msgstr ""
+"Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24944,7 +25539,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
+msgstr ""
+"Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25033,7 +25629,8 @@ msgstr "di %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
+msgstr ""
+"di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25459,3 +26056,9 @@ msgstr "anni"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "anno"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "Lingua rilevata: %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s file utilizzati"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,6 +365,8 @@ msgstr "%1$s usato"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
+"%1$s consuma i limiti fino a 2-5 volte più velocemente rispetto ai modelli "
+"di base %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -501,8 +503,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
+msgstr "%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -622,7 +623,7 @@ msgstr "1 giorno fa"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 file utilizzato"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -843,8 +844,7 @@ msgstr "Limite di utilizzo di 6 ore raggiunto."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr "Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -973,8 +973,8 @@ msgstr ""
 "AI Chat consente di conversare in modo anonimo con modelli di chat di terze "
 "parti dotati di intelligenza artificiale. Disattivando questa funzione, AI "
 "Chat verrà nascosta su DuckDuckGo Search. È comunque possibile accedervi "
-"anche quando questa impostazione è disattivata visitando %1$sduckduckgo.com/"
-"aichat%2$s."
+"anche quando questa impostazione è disattivata visitando "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1045,8 +1045,7 @@ msgstr ""
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
 msgctxt "duckassist"
 msgid "AI-assisted answers have been turned off!"
-msgstr ""
-"Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
+msgstr "Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
 
 # smartling.placeholder_format=C
 #. Negative feedback suggestion for when user dislikes AI-generated content
@@ -1394,8 +1393,7 @@ msgstr "Aggiungi una casella di ricerca di %1$s al tuo sito!"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr ""
-"Aggiungi un punto di partenza e una destinazione per trovare un percorso."
+msgstr "Aggiungi un punto di partenza e una destinazione per trovare un percorso."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1548,6 +1546,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"I modelli avanzati possono consumare i limiti da 2 a 5 volte più velocemente "
+"rispetto ad altri modelli. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1834,8 +1834,7 @@ msgstr "Vuoi consentire la revisione anonima dei file per questa chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
+msgstr "Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2346,7 +2345,7 @@ msgstr "Chiedi in privato"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Chiedi in privato"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2489,15 +2488,13 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2802,8 +2799,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Prima di archiviare questo rapporto, DuckDuckGo renderà anonima la tua "
-"conversazione eliminando le informazioni personali, come nomi, indirizzi e-"
-"mail e metadati identificativi."
+"conversazione eliminando le informazioni personali, come nomi, indirizzi "
+"e-mail e metadati identificativi."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2929,14 +2926,12 @@ msgstr "Blocca il sistema di tracciamento e-mail e nascondi il tuo indirizzo."
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
+msgstr "L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block most trackers as you browse."
-msgstr ""
-"Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
+msgstr "Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
 
 # smartling.placeholder_format=C
 #. Menu option to block a site from the displayed results
@@ -3920,7 +3915,7 @@ msgstr "Chatta in privato con l'IA"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Chatta in privato con le AI più popolari"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4571,8 +4566,7 @@ msgstr "Clicca sulla %1$slente di ingrandimento%2$s nella barra di ricerca"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr ""
-"Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
+msgstr "Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4625,21 +4619,18 @@ msgstr "Clicca sui %1$spuntini di sospensione%2$s nella barra degli strumenti."
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr ""
-"Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
+msgstr "Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %spermissions icon%s in the address bar"
-msgstr ""
-"Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
+msgstr "Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
+msgstr "Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4726,7 +4717,7 @@ msgstr "Chiudi"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Chiudi"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4776,7 +4767,7 @@ msgstr "Chiudi ricerca"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Chiudi la seconda opinione"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5153,7 +5144,7 @@ msgstr "Continua a bloccare gli annunci"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Continua qui le chat recenti. Oppure eliminale con il Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5224,7 +5215,7 @@ msgstr "Dati del cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Copiato"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5265,8 +5256,7 @@ msgstr "Copia"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
+msgstr "Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5278,7 +5268,7 @@ msgstr "Copia codice"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Copia link"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5348,8 +5338,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
+msgstr "Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5398,7 +5387,7 @@ msgstr "Crea immagine"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Crea link di condivisione"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5450,6 +5439,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"La creazione di un link crea una copia della chat che può essere "
+"visualizzata da chiunque la apra."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5608,7 +5599,7 @@ msgstr "Personalizza le risposte"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Personalizza le risposte"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5900,7 +5891,7 @@ msgstr "Eliminare i dati del server?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Elimina link condiviso"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5912,7 +5903,7 @@ msgstr "Elimina trascrizione"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Elimina una chat"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5950,7 +5941,7 @@ msgstr "Eliminare l'immagine?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Eliminami"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6266,7 +6257,7 @@ msgstr "Ignora la promozione"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Chiudi tour"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6482,7 +6473,7 @@ msgstr "Scarica DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Scarica DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6703,7 +6694,7 @@ msgstr "Duck.ai di DuckDuckGo. Chat privata con AI. Gratuito."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai ora può analizzare i PDF. Provalo!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6786,8 +6777,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai non è al momento disponibile. Se il problema persiste, invia un'e-"
-"mail con il codice anonimo %1$s a %2$s"
+"Duck.ai non è al momento disponibile. Se il problema persiste, invia "
+"un'e-mail con il codice anonimo %1$s a %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6862,7 +6853,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai supporta i modelli di Anthropic, OpenAI e altri."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6880,8 +6871,7 @@ msgstr "Duck.ai è stato aggiornato!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
+msgstr "Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7523,7 +7513,7 @@ msgstr "Attiva siti più visitati"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Attiva ora"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7693,8 +7683,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
+msgstr "Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7746,15 +7735,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
+msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
+msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7838,7 +7825,7 @@ msgstr "Guida all'intrattenimento"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Intera chat"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -8011,20 +7998,19 @@ msgstr "Testi espliciti"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Esplora Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Esplora Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
+msgstr "Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8125,7 +8111,7 @@ msgstr "Gratuito"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRATIS E OPZIONALE"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8552,7 +8538,7 @@ msgstr "Libera spazio di archiviazione"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Gratuita e sempre privata"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8594,8 +8580,7 @@ msgstr "Condivisione e uso commerciale gratuiti"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
+msgstr "Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9014,8 +8999,7 @@ msgstr "Iniziamo"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
+msgstr "Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9074,7 +9058,7 @@ msgstr "Ricevi assistenza per il computer"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Ottieni limiti di utilizzo più elevati con un abbonamento DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9115,13 +9099,15 @@ msgstr "Scarica l'ultima versione"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Scarica l'app"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Scarica il browser gratuito DuckDuckGo %1$sper bloccare gli annunci su "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9149,7 +9135,7 @@ msgstr "Dillo ai tuoi amici e aiutaci a crescere!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Lista di controllo per iniziare"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9495,8 +9481,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
+msgstr "Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9842,7 +9827,7 @@ msgstr "Nascondi suggerimenti"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Nascondi tutorial"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9891,8 +9876,7 @@ msgstr "Nascondi il tuo indirizzo e-mail"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
+msgstr "Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10136,8 +10120,7 @@ msgstr "Come funziona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
+msgstr "Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10387,8 +10370,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
+msgstr "Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10591,8 +10573,7 @@ msgstr "Nel menu in alto seleziona %1$sStrumenti%2$s > %3$sImpostazioni%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
+msgstr "Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11477,7 +11458,7 @@ msgstr "Ti permette di cercare anonimamente con DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Consente di passare dalle query di ricerca ai prompt su Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11553,7 +11534,7 @@ msgstr "Rimesse laterali vinte"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Il link scade tra 7 giorni."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11569,8 +11550,7 @@ msgstr "Link:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
+msgstr "Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11681,8 +11661,7 @@ msgstr "Carica altre immagini durante lo scorrimento"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
+msgstr "Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12445,8 +12424,7 @@ msgstr "Limite mensile raggiunto"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr "Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12658,7 +12636,7 @@ msgstr "Più di 20 minuti"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Altri consigli"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13153,7 +13131,7 @@ msgstr "No, grazie"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "No, grazie"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13325,15 +13303,13 @@ msgstr "Nessun sistema di tracciamento bloccato nell'ultima ora"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr ""
-"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
+msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
+msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13823,7 +13799,7 @@ msgstr "On, ma nessun numero"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Onboarding completato"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -14045,7 +14021,7 @@ msgstr "Apri i suggerimenti per creare e modificare le immagini"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Apri la checklist per iniziare"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14799,7 +14775,7 @@ msgstr "Fissa"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Fissa una chat"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14811,7 +14787,7 @@ msgstr "Fissa le chat qui dal %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Fissami"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14834,7 +14810,7 @@ msgstr "Fissato"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Le chat fissate appariranno in cima alle tue chat recenti."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14893,15 +14869,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
+msgstr "Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
+msgstr "Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15160,6 +15134,8 @@ msgstr "Formattazione insufficiente"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Modelli di AI popolari disponibili. Non è necessario un account. Chat rese "
+"anonime da noi."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15373,7 +15349,7 @@ msgstr "Schede precedenti"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Consigli precedenti"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15688,8 +15664,7 @@ msgstr "Proteggi i tuoi dati durante le ricerche e la navigazione."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
+msgstr "Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15920,13 +15895,15 @@ msgstr "AI di ragionamento con moderazione integrata media"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Il ragionamento può fornire risposte migliori a domande complesse."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Il ragionamento è più approfondito, ma consuma i limiti 2-5 volte più "
+"velocemente. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15961,14 +15938,13 @@ msgstr "Schede recenti"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr ""
-"Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
+msgstr "Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Chat recenti"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16129,7 +16105,7 @@ msgstr "Riduci l'utilizzo"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Riduci l'utilizzo con un modello più efficiente"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16279,8 +16255,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante &quot;"
-"Aggiorna&quot; o &quot;Ricarica&quot; del browser."
+"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante "
+"&quot;Aggiorna&quot; o &quot;Ricarica&quot; del browser."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16297,8 +16273,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr ""
-"Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
+msgstr "Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -16515,7 +16490,7 @@ msgstr "Ripristina tutte le impostazioni"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Ripristina tutorial"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16533,7 +16508,7 @@ msgstr "Risoluzione"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Risposta"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -17028,8 +17003,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia end-to-"
-"end."
+"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17244,7 +17219,7 @@ msgstr "Vuoi cercare %1$s per trovare risultati più vicini a te?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Interruttore Ricerca e Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17559,8 +17534,7 @@ msgstr "Seconda opinione"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
+msgstr "Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17610,8 +17584,8 @@ msgstr ""
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
-"end."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17620,14 +17594,14 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
-"end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
+"end-to-end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Archiviate in modo sicuro sul nostro server crittografato."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17776,27 +17750,24 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Scegli %1$sPersonalizzata%2$s e digita nel campo %3$shttps://duckduckgo."
-"com%4$s"
+"Scegli %1$sPersonalizzata%2$s e digita nel campo "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17911,8 +17882,7 @@ msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sImpostazioni avanzate%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
+msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18008,8 +17978,7 @@ msgstr "Testo selezionato da %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
+msgstr "Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18156,7 +18125,7 @@ msgstr "Imposta come pagina iniziale"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Imposta il tono e lo stile delle risposte di Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18229,13 +18198,13 @@ msgstr "Seychelles"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Condividi"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Condividi"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18284,7 +18253,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Condividi chat"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18348,7 +18317,7 @@ msgstr "Condividi feedback positivo"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Ambito di condivisione"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18489,7 +18458,7 @@ msgstr "Mostra dettagli"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Mostra il tutorial di Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18644,7 +18613,7 @@ msgstr "Mostra di più"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Mostra altri modelli"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18685,7 +18654,7 @@ msgstr "Mostra la barra laterale"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Mostra consigli passo passo per ottenere il massimo da Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18757,14 +18726,12 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows horizontal lines at result page breaks"
-msgstr ""
-"Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
+msgstr "Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
+msgstr "Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18785,8 +18752,7 @@ msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo al tuo browser"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
+msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18915,8 +18881,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
+msgstr "I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19061,8 +19026,7 @@ msgstr "Qualcosa è andato storto durante il salvataggio nel server, riprova."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
+msgstr "Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19074,7 +19038,7 @@ msgstr "Si è verificato un errore, riprova più tardi."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Si è verificato un errore. Riprova."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19092,8 +19056,7 @@ msgstr "A volte"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
+msgstr "Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19169,8 +19132,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
+msgstr "Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19378,7 +19340,7 @@ msgstr "Inizia a usare il limite settimanale"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Avvia una nuova chat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19483,8 +19445,7 @@ msgstr "Interrompi la generazione"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
+msgstr "Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19961,8 +19922,7 @@ msgstr "Passa a un modello più efficiente"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr ""
-"Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
+msgstr "Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -19970,7 +19930,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Passa a questa seconda opinione"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19983,8 +19943,7 @@ msgstr "Passato a %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
+msgstr "Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20100,8 +20059,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Come funziona il codice?\n"
-"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di Duck."
-"ai.\n"
+"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di "
+"Duck.ai.\n"
 "2. Seleziona \"Attiva Sync & Backup\", poi \"Recupera dati sincronizzati\"\n"
 "3. Copia il codice di recupero sopra e incollalo nello spazio \"Incolla qui "
 "il tuo codice\"\n"
@@ -20132,7 +20091,7 @@ msgstr "Temporaneamente la sincronizzazione e il backup non sono disponibili"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sincronizza le chat su tutti i dispositivi"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20228,6 +20187,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Porta Duck.ai sempre con te. Scaricalo nella nostra app gratuita per un "
+"accesso più rapido, ovunque ti trovi."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20236,6 +20197,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Porta Duck.ai sempre con te. È integrato nel nostro browser gratuito per un "
+"accesso più rapido, ovunque navighi."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20718,7 +20681,7 @@ msgstr "Questo mese"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Questa risposta"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20730,7 +20693,7 @@ msgstr "Questa settimana"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Questa chat rimane in Duck.ai e resta privata."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20847,8 +20810,7 @@ msgstr "Questa immagine non può essere creata."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
+msgstr "Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20871,6 +20833,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Questa è solo una chat di prova. Apri il suo menu (i tre punti), quindi "
+"scegli Fissa per mantenerla in cima alle tue chat!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20879,6 +20843,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Questa è solo una chat di prova. Usa il Fire Button nel menu laterale per "
+"eliminarla!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20928,8 +20894,7 @@ msgstr "Questa pagina richiede Javascript per funzionare."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
+msgstr "Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21228,6 +21193,8 @@ msgstr "Oggi"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21392,8 +21359,7 @@ msgstr "Sistemi di tracciamento bloccati nell'ultima ora"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
+msgstr "I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21409,8 +21375,7 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr ""
-"I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
+msgstr "I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -21646,7 +21611,7 @@ msgstr "Provali"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Prova un modello diverso"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21657,7 +21622,7 @@ msgstr "Prova una ricerca!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Prova un suggerimento"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21707,8 +21672,7 @@ msgstr "Prova ad abilitare la posizione anonima per risultati più accurati."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
+msgstr "Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21728,7 +21692,7 @@ msgstr "Prova gratuitamente"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Prova gratuitamente"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21750,7 +21714,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Prova gratis per 7 giorni"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21783,7 +21747,7 @@ msgstr "Prova la nostra homepage che non mostra mai questi messaggi:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Prova il ragionamento"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -22038,7 +22002,7 @@ msgstr "Attiva Duck Player per guardare YouTube senza annunci mirati"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Attiva l'interruttore Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22243,8 +22207,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: https://"
-"duckduckgo.com"
+"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22273,8 +22237,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di ricerca..."
-"%4$s"
+"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di "
+"ricerca...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22288,8 +22252,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
+msgstr "In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22418,7 +22381,7 @@ msgstr "Sblocca l'AI avanzata con il tuo abbonamento!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Sblocca modelli avanzati"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22785,7 +22748,7 @@ msgstr "Usa in Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Usa il Fire Button per eliminare una chat dalla cronologia."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22946,8 +22909,7 @@ msgstr "Visualizza i prezzi per il tuo soggiorno"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
+msgstr "La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23351,8 +23313,7 @@ msgstr "Non memorizziamo nomi utente né informazioni personali."
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
+msgstr "Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23500,8 +23461,7 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
+msgstr "Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23734,8 +23694,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
+msgstr "Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23955,8 +23914,7 @@ msgstr "Quali sono i piatti da provare in questo caso?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
+msgstr "Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23986,7 +23944,7 @@ msgstr "Cosa ti ha fatto tornare oggi?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Cosa puoi fare?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24183,8 +24141,7 @@ msgstr "Su cosa vuoi dare un'opinione?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
+msgstr "Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24416,6 +24373,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Con Duck.ai, le tue chat vengono rese anonime e non vengono mai utilizzate "
+"per addestrare l'AI. Attiva o disattiva in qualsiasi momento nel menu “%1$s”."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24762,8 +24721,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
+msgstr "Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24851,7 +24809,7 @@ msgstr "Puoi allegare solo %1$s immagini per conversazione."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Puoi allegare solo %1$s schede alla volta."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24983,8 +24941,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Non vedrai più questo messaggio a meno che non elimini i dati del browser."
+msgstr "Non vedrai più questo messaggio a meno che non elimini i dati del browser."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25000,7 +24957,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "È tutto pronto!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -25053,7 +25010,7 @@ msgstr "Hai bloccato 1 sito"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Hai padroneggiato le basi di Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25081,8 +25038,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Hai raggiunto la durata massima della chat vocale per una singola sessione."
+msgstr "Hai raggiunto la durata massima della chat vocale per una singola sessione."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25094,8 +25050,7 @@ msgstr "Hai raggiunto il limite di chat vocale per oggi. Riprova domani."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
+msgstr "Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25464,6 +25419,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Le tue impostazioni sono salvate, ma l'eliminazione dei cookie le "
+"ripristinerà. Abilita l'estensione %1$sDuckDuckGo No AI%2$s per renderle "
+"definitive."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25504,8 +25462,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
+msgstr "Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25539,8 +25496,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
+msgstr "Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25629,8 +25585,7 @@ msgstr "di %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
+msgstr "di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26061,4 +26016,4 @@ msgstr "anno"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr "%1$sを検出しました"
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -175,7 +181,10 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
+msgstr ""
+"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
+"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -184,7 +193,10 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
+msgstr ""
+"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
+"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -199,7 +211,10 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるには、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替えてください。"
+msgstr ""
+"%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるに"
+"は、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -207,7 +222,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直してください。"
+msgstr ""
+"%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直し"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -298,8 +315,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$sはTrusted Execution "
-"Environmentで動作します。つまり、モデルプロバイダーでさえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサーバーに保存することもできません。"
+"%1$sはTrusted Execution Environmentで動作します。つまり、モデルプロバイダーで"
+"さえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサー"
+"バーに保存することもできません。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -343,6 +361,12 @@ msgid "%s used"
 msgstr "%1$s使用済み"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s回閲覧"
@@ -378,7 +402,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
+msgstr ""
+"%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替え"
+"てこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -388,7 +414,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
+msgstr ""
+"%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えて"
+"このチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -400,7 +428,9 @@ msgstr "%1$s単語"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$sをクリックしてください"
+msgstr ""
+"%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$s"
+"をクリックしてください"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -408,8 +438,8 @@ msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$sボックスをオンにしてから "
-"%8$sOK%9$sをクリックしてください"
+"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$s"
+"ボックスをオンにしてから %8$sOK%9$sをクリックしてください"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -419,8 +449,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sインストールを続行%3$sをクリックして "
-"%4$s追加ボタン%5$sを押し、%6$s許可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
+"%1$s%2$sインストールを続行%3$sをクリックして %4$s追加ボタン%5$sを押し、%6$s許"
+"可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -428,7 +458,9 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう一度試します。"
+msgstr ""
+"この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう"
+"一度試します。"
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -446,14 +478,17 @@ msgstr "%1$sさらに詳しく%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
+msgstr ""
+"%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこちら%2$sをご覧ください。"
+msgstr ""
+"DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこち"
+"ら%2$sをご覧ください。"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -471,7 +506,8 @@ msgstr "ホーム画面でDuckDuckGoのアプリアイコンを%1$s長押し%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
+msgstr ""
+"%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -578,6 +614,12 @@ msgstr "1件 - DuckDuckGoが過去24時間以内にブロックした追跡試�
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1日前"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -805,7 +847,8 @@ msgstr "6時間の使用制限に達しました。このチャットは%1$s以�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
+msgstr ""
+"6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -858,21 +901,27 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "ネットワークの問題により、Search Assistは回答を生成できません。接続を確認して、もう一度試してください。"
+msgstr ""
+"ネットワークの問題により、Search Assistは回答を生成できません。接続を確認し"
+"て、もう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてください。"
+msgstr ""
+"AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてください。"
+msgstr ""
+"Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -916,8 +965,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフにすると、DuckDuckGo SearchのAI "
-"Chat機能は非表示になりますが、%1$sduckduckgo.com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
+"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフ"
+"にすると、DuckDuckGo SearchのAI Chat機能は非表示になりますが、%1$sduckduckgo."
+"com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -977,7 +1027,11 @@ msgid ""
 "However, we also offer and often link to %sDuck.ai%s for follow-up "
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
-msgstr "AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただし、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供しています。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活用したプライベートチャットサービスです。"
+msgstr ""
+"AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただ"
+"し、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供して"
+"います。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活"
+"用したプライベートチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1161,7 +1215,9 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr "チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切り替えてください。"
+msgstr ""
+"チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切"
+"り替えてください。"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1196,14 +1252,18 @@ msgstr "広告"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
+msgstr ""
+"広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファ"
+"イリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr "広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
+msgstr ""
+"広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロ"
+"ファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1253,7 +1313,9 @@ msgstr "DuckDuckGo拡張機能を追加"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加できます："
+msgstr ""
+"DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加でき"
+"ます："
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1468,6 +1530,14 @@ msgid "Advanced Models"
 msgstr "高度なモデル"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "検索結果に広告をリンク"
@@ -1501,13 +1571,16 @@ msgstr "アフリカーンス語"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
+msgstr ""
+"ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールしてください"
+msgstr ""
+"ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールして"
+"ください"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1642,7 +1715,9 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr "すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供元が学習内容をチャットモデルの学習に利用することはありません"
+msgstr ""
+"すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供"
+"元が学習内容をチャットモデルの学習に利用することはありません"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1674,7 +1749,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されています。"
+msgstr ""
+"すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されてい"
+"ます。"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1688,7 +1765,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスなど）が削除されます。"
+msgstr ""
+"AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスな"
+"ど）が削除されます。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1719,7 +1798,9 @@ msgstr "許可"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可してください。"
+msgstr ""
+"ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可"
+"してください。"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1750,14 +1831,19 @@ msgid ""
 "Allows %s to search the web to improve responses to relevant prompts. Only "
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
-msgstr "%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$sのプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
+msgstr ""
+"%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。"
+"AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$s"
+"のプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr "デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する場合に必須)"
+msgstr ""
+"デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する"
+"場合に必須)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1894,7 +1980,9 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
+msgstr ""
+"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
+"セスできます。"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1902,7 +1990,9 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
+msgstr ""
+"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
+"セスできます。"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1915,7 +2005,9 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選択するか、完全に無効にすることができます。"
+msgstr ""
+"ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選"
+"択するか、完全に無効にすることができます。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1961,7 +2053,9 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr "Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教えてください"
+msgstr ""
+"Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教"
+"えてください"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2080,7 +2174,9 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr "履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むすべてのチャットが削除されます。"
+msgstr ""
+"履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むす"
+"べてのチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2088,7 +2184,9 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr "最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている最近のチャットも削除されます。"
+msgstr ""
+"最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている"
+"最近のチャットも削除されます。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2125,7 +2223,9 @@ msgstr "最終更新："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "私達はプライバシーポリシーに従って、個人情報を収集または共有することはありません。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
+msgstr ""
+"私達はプライバシーポリシーに従って、個人情報を収集または共有することはありま"
+"せん。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2223,6 +2323,12 @@ msgid "Ask privately"
 msgstr "非公開で質問"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2255,9 +2361,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-""
-"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist "
-"UIを完全に削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できます。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
+"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿"
+"名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist UIを完全に"
+"削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回"
+"答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻"
+"繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できま"
+"す。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2268,7 +2377,12 @@ msgid ""
 "generate a brief answer based on relevant information found. It’s important "
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
-msgstr "Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
+msgstr ""
+"Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプ"
+"ション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活"
+"用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答"
+"は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されるこ"
+"とを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2359,7 +2473,8 @@ msgstr "チャット終了後、音声は当社または OpenAI によって保�
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
+msgstr ""
+"チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2400,18 +2515,24 @@ msgstr "自動応答"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があります。"
+msgstr ""
+"リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があ"
+"ります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる場合があります。"
+msgstr ""
+"リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる"
+"場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "ソースに基づき自動生成されています。内容に不正確な部分を含む可能性があります。"
+msgstr ""
+"ソースに基づき自動生成されています。内容に不正確な部分を含む可能性がありま"
+"す。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2430,7 +2551,10 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能です。"
+msgstr ""
+"関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して"
+"情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能で"
+"す。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2439,14 +2563,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"関連する検索に DuckAssist "
-"を自動表示します。このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ利用可能です。"
+"関連する検索に DuckAssist を自動表示します。このツールを使用すると、一部の検"
+"索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ"
+"利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
+msgstr ""
+"動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2645,7 +2771,9 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr "このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータなどのPIIを削除することで、会話を匿名化します。"
+msgstr ""
+"このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータ"
+"などのPIIを削除することで、会話を匿名化します。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2771,7 +2899,8 @@ msgstr "メールトラッカーをブロックし、アドレスを非表示に
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
+msgstr ""
+"ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3025,20 +3154,28 @@ msgstr "ファイルを参照"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr ""
+"DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索"
+"エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$s"
+"にまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr ""
+"いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、"
+"高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロック、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウンロードしましょう。"
+msgstr ""
+"いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロッ"
+"ク、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウン"
+"ロードしましょう。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3124,7 +3261,8 @@ msgstr "「%1$s」をクリックすると、当社の%2$sに同意したこと�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
+msgstr ""
+"「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3145,16 +3283,19 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に保存されます。匿名の Cloud Save "
-"機能を利用すると、設定情報を (クラウド上のリモートサーバーに) "
-"より長期的に保存できます。個人を特定できる情報がクラウドに保存されたり、パスフレーズがブラウザ上に残ることもありません。"
+"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に"
+"保存されます。匿名の Cloud Save 機能を利用すると、設定情報を (クラウド上のリ"
+"モートサーバーに) より長期的に保存できます。個人を特定できる情報がクラウドに"
+"保存されたり、パスフレーズがブラウザ上に残ることもありません。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
+msgstr ""
+"音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信される"
+"ことに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3163,8 +3304,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI "
-"に送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
+"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI に送信"
+"されることに同意したことになります。開始する間に当社の%1$sを確認してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3519,7 +3661,8 @@ msgstr "サイト全体の背景色を変更する"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
+msgstr ""
+"マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3648,10 +3791,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"チャット（Duck.ai "
-""
-"サービス経由）を通じて、OpenAI、AnthropicなどのサードパーティのAIチャットモデルと匿名で会話することができます。この設定をオフにすると、DuckDuckGo "
-"Searchのチャットボタンとリンクが非表示になります。ただし、この設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用できます。"
+"チャット（Duck.ai サービス経由）を通じて、OpenAI、Anthropicなどのサードパー"
+"ティのAIチャットモデルと匿名で会話することができます。この設定をオフにする"
+"と、DuckDuckGo Searchのチャットボタンとリンクが非表示になります。ただし、この"
+"設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用"
+"できます。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3706,14 +3850,18 @@ msgstr "プライベートチャット"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートにチャットできます。"
+msgstr ""
+"無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートに"
+"チャットできます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプライベートにチャットできます。"
+msgstr ""
+"無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプラ"
+"イベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3726,6 +3874,12 @@ msgstr "%1$sとプライベートチャット"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "AIとのプライベートチャット"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3775,7 +3929,10 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスにローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが削除されます。"
+msgstr ""
+"チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスに"
+"ローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが"
+"削除されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3786,7 +3943,12 @@ msgid ""
 "help recover a chat if you lose your internet connection. Disabling chat "
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
-msgstr "チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
+msgstr ""
+"チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗"
+"号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インター"
+"ネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にする"
+"と、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効"
+"になります。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3808,14 +3970,19 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr "%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロバイダーによって匿名でレビューされます。"
+msgstr ""
+"%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップ"
+"ロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロ"
+"バイダーによって匿名でレビューされます。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr "添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはストレージを解放してください。"
+msgstr ""
+"添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはスト"
+"レージを解放してください。"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3874,7 +4041,8 @@ msgstr "この障害に関する最新情報は、DuckDuckGoのサブレディ�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "この停止に関する最新情報については、ステータスページを確認してください。"
+msgstr ""
+"この停止に関する最新情報については、ステータスページを確認してください。"
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -3939,7 +4107,8 @@ msgstr "%1$sや%2$sを含むAIモデルの選択"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
+msgstr ""
+"%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4160,8 +4329,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最近のチャットが無期限に保存される場合、またはAI "
-"Chatの未使用期間が7日を超えると自動的に削除される場合があります。"
+"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最"
+"近のチャットが無期限に保存される場合、またはAI Chatの未使用期間が7日を超える"
+"と自動的に削除される場合があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4170,7 +4340,10 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr "ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあります。ブラウザによって異なります。"
+msgstr ""
+"ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは"
+"無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあ"
+"ります。ブラウザによって異なります。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4178,7 +4351,9 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr "ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリストを当社の無料ブラウザに"
+msgstr ""
+"ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリ"
+"ストを当社の無料ブラウザに"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4186,7 +4361,11 @@ msgid ""
 "Click \"More\" to go deeper on a topic, and ask follow-up questions via "
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
-msgstr "「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。また、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなどのチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用できます。"
+msgstr ""
+"「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。ま"
+"た、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなど"
+"のチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用で"
+"きます。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4227,7 +4406,9 @@ msgstr "一覧から%1$s検索設定の変更%2$sをクリックしてくださ�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてください"
+msgstr ""
+"%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてく"
+"ださい"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4238,12 +4419,15 @@ msgstr "%1$sここ%2$sをクリックして検索エンジンとして追加し�
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo browser extension to Safari.
 msgid "Click %sHere%s to download the DuckDuckGo extension"
-msgstr "%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
+msgstr ""
+"%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
 
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてください"
+msgstr ""
+"%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてくださ"
+"い"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4257,7 +4441,9 @@ msgstr "左側のサイドバーにある%1$sプライバシーとサービス%2
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、右上の%3$s歯車アイコン%4$sをクリックしてください)"
+msgstr ""
+"%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、"
+"右上の%3$s歯車アイコン%4$sをクリックしてください)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4286,7 +4472,8 @@ msgstr "%1$sはい%2$sをクリックしてください"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
+msgstr ""
+"Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4322,7 +4509,8 @@ msgstr "下のほうの %1$sデフォルトに設定%2$s をクリックしま�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
+msgstr ""
+"アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4347,7 +4535,10 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がクリックまたはタップされるまでブラウザに残ります。"
+msgstr ""
+"「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作"
+"によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がク"
+"リックまたはタップされるまでブラウザに残ります。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4357,7 +4548,10 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
+msgstr ""
+"%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはク"
+"ラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップし"
+"ない限り、お使いのブラウザに保存されたままとなります。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4425,14 +4619,18 @@ msgstr "検索ボックスの選択項目をクリック"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューをクリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
+msgstr ""
+"%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューを"
+"クリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr "広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機能のアイコンはブラウザの右上隅に表示されています。"
+msgstr ""
+"広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機"
+"能のアイコンはブラウザの右上隅に表示されています。"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4473,6 +4671,12 @@ msgstr "クリップアート"
 #. An accessible label for a button that closes a modal dialog
 msgid "Close"
 msgstr "閉じる"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4517,6 +4721,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "検索を閉じる"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4620,7 +4830,9 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能を使うかどうかはあなた次第。強制ではありません。"
+msgstr ""
+"パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能"
+"を使うかどうかはあなた次第。強制ではありません。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -4888,6 +5100,12 @@ msgid "Continue Blocking Ads"
 msgstr "広告ブロックを継続"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4953,6 +5171,12 @@ msgid "Cookie data:"
 msgstr "Cookieデータ:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4991,13 +5215,20 @@ msgstr "コピー"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
+msgstr ""
+"「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "コードをコピー"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5067,7 +5298,9 @@ msgstr "コスタリカ"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しください。"
+msgstr ""
+"リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5113,6 +5346,12 @@ msgid "Create Image"
 msgstr "画像を作成"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5154,6 +5393,14 @@ msgstr "作成者"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "作成者：%1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5309,6 +5556,12 @@ msgid "Customize responses"
 msgstr "応答をカスタマイズする"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "このページをカスタマイズ"
@@ -5380,7 +5633,8 @@ msgstr "1日の使用制限に達しました。このチャットは%1$s以降�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
+msgstr ""
+"1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5591,10 +5845,22 @@ msgid "Delete Server Data?"
 msgstr "サーバーデータを削除しますか？"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "トランスクリプトを削除"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5629,6 +5895,12 @@ msgid "Delete image?"
 msgstr "画像を削除しますか？"
 
 # smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats to free up storage?"
@@ -5638,7 +5910,8 @@ msgstr "ストレージを解放するために最も古いチャットを削除
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
+msgstr ""
+"保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5752,7 +6025,9 @@ msgstr "Duck.aiの音声入力"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されま"
+"せん。"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5769,7 +6044,9 @@ msgstr "音声入力は一時的に利用できません"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck.aiチャットができます。"
+msgstr ""
+"音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck."
+"aiチャットができます。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -5933,6 +6210,12 @@ msgid "Dismiss promotion"
 msgstr "プロモーションを非表示"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6037,13 +6320,15 @@ msgstr "DuckDuckGoがリストにありませんか？"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
+msgstr ""
+"表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr "チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
+msgstr ""
+"チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6074,7 +6359,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供されず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr ""
+"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供さ"
+"れず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6082,7 +6369,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr ""
+"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能"
+"は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6139,6 +6428,12 @@ msgid "Download DuckDuckGo"
 msgstr "DuckDuckGoをダウンロード"
 
 # smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo Browser"
@@ -6191,7 +6486,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr "シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成します。内容は、簡潔かつ詳細に入力してください。"
+msgstr ""
+"シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成しま"
+"す。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6199,7 +6496,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr "家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容は、簡潔かつ詳細に入力してください。"
+msgstr ""
+"家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容"
+"は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6219,7 +6518,9 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか作成してください。"
+msgstr ""
+"今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか"
+"作成してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6227,7 +6528,9 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr "チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をいくつか作成してください。"
+msgstr ""
+"チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をい"
+"くつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6346,6 +6649,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai by DuckDuckGo。プライベートAIチャット。無料。"
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6355,7 +6664,8 @@ msgid ""
 msgstr ""
 "Duck.aiは、現在表示しているページに関する質問に回答できるようになりました。\n"
 "\n"
-"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したときにのみ含まれます。"
+"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したと"
+"きにのみ含まれます。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6364,7 +6674,10 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しください。"
+msgstr ""
+"Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。"
+"ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6372,13 +6685,16 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr "Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
+msgstr ""
+"Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6387,7 +6703,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻したいユーザーのためにオンライン保護に取り組む独立系企業です。"
+msgstr ""
+"Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻"
+"したいユーザーのためにオンライン保護に取り組む独立系企業です。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6401,7 +6719,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが「https://duck.ai」と覚えやすくなります"
+msgstr ""
+"Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが"
+"「https://duck.ai」と覚えやすくなります"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6415,14 +6735,18 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
+msgstr ""
+"Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」"
+"を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してください。"
+msgstr ""
+"Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6435,7 +6759,10 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr "Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiのボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスできます。"
+msgstr ""
+"Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiの"
+"ボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスで"
+"きます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6446,9 +6773,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-""
-"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデルと匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://duck.ai%2$s "
-"に直接アクセスすることでDuck.aiを利用できます。"
+"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデル"
+"と匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタ"
+"ンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://"
+"duck.ai%2$s に直接アクセスすることでDuck.aiを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6462,7 +6790,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr "Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用できます。"
+msgstr ""
+"Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用"
+"できます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6475,7 +6805,14 @@ msgstr "Duck.aiでPDFを読み、解析できるようになりました。ぜ�
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr "Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
+msgstr ""
+"Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6493,7 +6830,8 @@ msgstr "Duck.aiがアップグレードしました！"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
+msgstr ""
+"Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6503,8 +6841,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo "
-"AI、プライベートAIチャットボット、無料AIチャット、匿名AIチャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オープンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
+"Duck.ai、DuckDuckGo AI、プライベートAIチャットボット、無料AIチャット、匿名AI"
+"チャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オー"
+"プンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6532,9 +6871,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。DuckAssistの表示頻度は、なし（検索結果からDuckAssist "
-"UIを完全に削除）、オンデマンド（[アシスト] "
-"ボタンをクリックした場合にのみ表示）、時々（関連性の高い場合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点では、米国（英語）地域でのみ利用可能です。"
+"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。"
+"DuckAssistの表示頻度は、なし（検索結果からDuckAssist UIを完全に削除）、オンデ"
+"マンド（[アシスト] ボタンをクリックした場合にのみ表示）、時々（関連性の高い場"
+"合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点で"
+"は、米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6543,9 +6884,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他からチャットモデルをサポートするプライベートAI搭載チャットサービス、%1$sDuckDuckGo "
-"AI Chat%2$sもご利用いただけます。"
+"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他か"
+"らチャットモデルをサポートするプライベートAI搭載チャットサービ"
+"ス、%1$sDuckDuckGo AI Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6554,8 +6895,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャットモデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
+"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャット"
+"モデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
 "Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
@@ -6568,9 +6909,11 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 "
-"これを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、AIを活用した自然言語技術を使用して情報の要約を生成します。 "
-"現時点での回答はWikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご注意ください。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 こ"
+"れを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、"
+"AIを活用した自然言語技術を使用して情報の要約を生成します。 現時点での回答は"
+"Wikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご"
+"注意ください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6584,15 +6927,22 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI "
-"を活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssistの回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのため、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション"
+"機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI を活用した"
+"自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssist"
+"の回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのた"
+"め、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成さ"
+"れ、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重"
+"要です。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr "DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認されません。"
+msgstr ""
+"DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認さ"
+"れません。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6600,7 +6950,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続"
+"行してください。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6609,8 +6961,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
+"いるプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6619,8 +6971,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
+"いるプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6628,7 +6980,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr "DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される可能性があります。"
+msgstr ""
+"DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される"
+"可能性があります。"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6636,7 +6990,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード"
+"「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6644,13 +7000,17 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直してください。"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直"
+"してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しください。"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6768,14 +7128,18 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的に削除することで、これらのレポートを匿名化します。"
+msgstr ""
+"DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的"
+"に削除することで、これらのレポートを匿名化します。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに同意したことになります。"
+msgstr ""
+"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに"
+"同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6783,7 +7147,9 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同意したことになります。"
+msgstr ""
+"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同"
+"意したことになります。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6791,7 +7157,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による追跡行為を阻止することができます。"
+msgstr ""
+"DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による"
+"追跡行為を阻止することができます。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6803,8 +7171,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する場合、ローカルデバイスだけに保存されます。DuckDuckGo "
-"は検索時にユーザーのデバイスから送信される位置情報を検索結果を向上するために使用します。位置情報は使用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様のプライバシーを保護するため、当社がどのようにこの技術を設計したかについては、こちらをご覧ください%2$s。"
+"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する"
+"場合、ローカルデバイスだけに保存されます。DuckDuckGo は検索時にユーザーのデバ"
+"イスから送信される位置情報を検索結果を向上するために使用します。位置情報は使"
+"用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様の"
+"プライバシーを保護するため、当社がどのようにこの技術を設計したかについては、"
+"こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6823,7 +7195,9 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
+msgstr ""
+"DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を"
+"表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6908,7 +7282,10 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr "パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～20字のパスフレーズ候補として4、5個の単語が選ばれます。"
+msgstr ""
+"パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載"
+"されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～"
+"20字のパスフレーズ候補として4、5個の単語が選ばれます。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -6978,7 +7355,8 @@ msgstr "画像を編集中..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
+msgstr ""
+"メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7075,6 +7453,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "よく使用するサイトを有効化"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7109,7 +7493,9 @@ msgstr "ウェブ検索を有効にする"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後でいつでも変更できます。"
+msgstr ""
+"検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後"
+"でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7151,7 +7537,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
+msgstr ""
+"「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索"
+"データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7269,7 +7657,8 @@ msgstr "位置情報へのアクセスは必ず %1$s許可%2$s にします。"
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
+msgstr ""
+"ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7312,7 +7701,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてください。データが新しいパスフレーズで保存されます。"
+msgstr ""
+"新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてくだ"
+"さい。データが新しいパスフレーズで保存されます。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7337,7 +7728,9 @@ msgstr "テキストを入力"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイリアス%6$s: d%7$s"
+msgstr ""
+"以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイ"
+"リアス%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7362,6 +7755,12 @@ msgstr "設定を読み込むにはパスフレーズを入力してください
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "エンターテインメントガイド"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7525,6 +7924,18 @@ msgid "Explicit lyrics"
 msgstr "露骨な歌詞"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7626,6 +8037,12 @@ msgid "FREE"
 msgstr "無料"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7681,7 +8098,9 @@ msgstr "フィードバックが送信されました"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきます。"
+msgstr ""
+"お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7689,14 +8108,19 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用させていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組んで参ります。"
+msgstr ""
+"お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用さ"
+"せていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組ん"
+"で参ります。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆ペーストしてください。"
+msgstr ""
+"以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆"
+"ペーストしてください。"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -7814,7 +8238,8 @@ msgstr "金融アドバイザー"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
+msgstr ""
+"%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -7826,7 +8251,9 @@ msgstr "ダウンロードフォルダで<b>%1$s</b>を表示"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックします"
+msgstr ""
+"表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックしま"
+"す"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7863,7 +8290,9 @@ msgstr "あなたにとって最も的確な結果を見つけます。"
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されます。"
+msgstr ""
+"お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7926,7 +8355,9 @@ msgstr "霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオプションを選択したり、ボタンをクリックする必要がある場合があります。"
+msgstr ""
+"DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオ"
+"プションを選択したり、ボタンをクリックする必要がある場合があります。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8028,6 +8459,12 @@ msgid "Free Up Storage"
 msgstr "ストレージを解放"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8067,7 +8504,9 @@ msgstr "営利目的で共有、使用が可能"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されません。"
+msgstr ""
+"チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されませ"
+"ん。"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8148,8 +8587,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; "
-"<strong>[アップデートを確認...]</strong>、次に<strong>[アップデートをインストール]</strong> を選択します。"
+"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; <strong>[アッ"
+"プデートを確認...]</strong>、次に<strong>[アップデートをインストール]</"
+"strong> を選択します。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8485,7 +8925,9 @@ msgstr "開始"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがですか。"
+msgstr ""
+"VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがです"
+"か。"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8499,7 +8941,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これには、VPNやその他のプレミアムなプライバシー保護も含まれています。"
+msgstr ""
+"DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これに"
+"は、VPNやその他のプレミアムなプライバシー保護も含まれています。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8509,7 +8953,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
+msgstr ""
+"DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。"
+"VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8535,6 +8981,12 @@ msgid "Get computer help"
 msgstr "コンピューターに関するサポートを受ける"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8543,7 +8995,9 @@ msgstr "当社のブラウザを使用すれば、設定が失われることは
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロード："
+msgstr ""
+"ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロー"
+"ド："
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8570,6 +9024,18 @@ msgid "Get the Latest Version"
 msgstr "最新バージョンを入手"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8590,6 +9056,12 @@ msgstr "この曲をダウンロード:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "ご友人にもDuckDuckGoを勧めて私たちの成長を助けてください！"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8620,8 +9092,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」 › 「テキストコードをコピー」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」 › 「テキストコードをコ"
+"ピー」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8630,8 +9103,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8641,8 +9114,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」%4$sの順にクリックして、次のコードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックして、次の"
+"コードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8652,14 +9126,16 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」%4$sの順にクリックします。または、リカバリーPDFのQRコードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします。ま"
+"たは、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
+msgstr ""
+"%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8668,8 +9144,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動し、[位置情報サービス] "
-"がオンになっていることを確認します。"
+"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動"
+"し、[位置情報サービス] がオンになっていることを確認します。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8678,8 +9154,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、[DuckDuckGo] "
-"まで下にスクロールします。%3$s%4$s"
+"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、"
+"[DuckDuckGo] まで下にスクロールします。%3$s%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9272,6 +9748,12 @@ msgid "Hide Tips"
 msgstr "ヒントを非表示"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9355,7 +9837,8 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
+msgstr ""
+"Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9382,8 +9865,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"キーボードの %1$s戻る%2$s "
-"キーを押して、%3$sDuckDuckGoをリストに保存します。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
+"キーボードの %1$s戻る%2$s キーを押して、%3$sDuckDuckGoをリストに保存しま"
+"す。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9396,7 +9879,9 @@ msgstr "ミャオ語"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバシーが保護されなくなります。"
+msgstr ""
+"ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバ"
+"シーが保護されなくなります。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9445,7 +9930,9 @@ msgstr "猛暑"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr "ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様のプロファイリングには使用されません。"
+msgstr ""
+"ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様の"
+"プロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9707,7 +10194,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズはどんなものですか、またその理由は何ですか？"
+msgstr ""
+"私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズは"
+"どんなものですか、またその理由は何ですか？"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9742,8 +10231,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセット] > [位置情報とプライバシー設定をリセット]%2$s "
-"の順に移動します。"
+"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセッ"
+"ト] > [位置情報とプライバシー設定をリセット]%2$s の順に移動します。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9753,8 +10242,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク > [メニュー] > [設定] > [サイト設定] > "
-"[位置情報]%2$s の順に移動し、DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
+"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク "
+"> [メニュー] > [設定] > [サイト設定] > [位置情報]%2$s の順に移動し、"
+"DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9768,7 +10258,9 @@ msgstr "このエラーが続く場合は、%1$sに連絡してください。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追加する必要があります"
+msgstr ""
+"%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追"
+"加する必要があります"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9777,8 +10269,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"チャット "
-"プロバイダーまたは特定のチャット応答についてご不明な点がある場合は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
+"チャット プロバイダーまたは特定のチャット応答についてご不明な点がある場合"
+"は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9786,13 +10278,18 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこのコードが必要になります。このコードはテキストファイルとしてデバイスに保存できます。"
+msgstr ""
+"デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこの"
+"コードが必要になります。このコードはテキストファイルとしてデバイスに保存でき"
+"ます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力ください%2$s"
+msgstr ""
+"もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力くだ"
+"さい%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9801,14 +10298,18 @@ msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDu
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンをご利用ください。"
+msgstr ""
+"Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンを"
+"ご利用ください。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択してください。"
+msgstr ""
+"ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択して"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -9948,7 +10449,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレクトする必要があります。%1$sさらに詳しく%2$s。"
+msgstr ""
+"古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレ"
+"クトする必要があります。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9958,7 +10461,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同期」を選択します。"
+msgstr ""
+"DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同"
+"期」を選択します。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -9972,7 +10477,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に保存されている情報を正確に知ることができます。"
+msgstr ""
+"情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に"
+"保存されている情報を正確に知ることができます。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -9982,7 +10489,8 @@ msgstr "上部のメニューから%1$sツール%2$s > %3$s設定%4$sを選択"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
+msgstr ""
+"ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10308,7 +10816,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
+msgstr ""
+"この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10376,7 +10885,11 @@ msgid ""
 "Items are ranked based on relevance to your search terms and are delivered "
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
-msgstr "アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告ネットワークを通じて配信されます。クリック後はマーチャントのランディングページに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け取ることはありません。"
+msgstr ""
+"アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告"
+"ネットワークを通じて配信されます。クリック後はマーチャントのランディングペー"
+"ジに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け"
+"取ることはありません。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10384,7 +10897,9 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっと安全です。"
+msgstr ""
+"ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっ"
+"と安全です。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10851,6 +11366,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "DuckDuckGo を使って匿名で検索しましょう"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "リベリア"
 
@@ -10919,6 +11441,12 @@ msgstr "線描画"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "ラインアウト獲得"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11571,7 +12099,9 @@ msgstr "ミクロネシア"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試しください。"
+msgstr ""
+"マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試し"
+"ください。"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12011,6 +12541,12 @@ msgid "More than 20 minutes"
 msgstr "20 分以上"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12330,7 +12866,11 @@ msgid ""
 "DuckDuckGo server after being sent, to help recover a chat if you lose your "
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
-msgstr "新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
+msgstr ""
+"新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的"
+"に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立"
+"ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロ"
+"ンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12494,6 +13034,12 @@ msgid "No Thanks"
 msgstr "いいえ、結構です"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "追跡しません。"
@@ -12639,7 +13185,8 @@ msgstr "結果が見つかりません。"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
+msgstr ""
+"音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13145,13 +13692,21 @@ msgstr "オンデマンド"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順に%5$sクリックしてください"
+msgstr ""
+"Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順"
+"に%5$sクリックしてください"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "有効、ただし数字なし"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13166,7 +13721,9 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルをアップロードしてください。"
+msgstr ""
+"添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルを"
+"アップロードしてください。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13192,7 +13749,8 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
+msgstr ""
+"変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13206,7 +13764,9 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおいてからもう一度試してください。"
+msgstr ""
+"おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおい"
+"てからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13358,6 +13918,12 @@ msgstr "チャットの提案を開く"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "画像の作成と編集の提案を開く"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -13522,7 +14088,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡しています。私たちは追跡しません。"
+msgstr ""
+"他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡していま"
+"す。私たちは追跡しません。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13534,14 +14102,18 @@ msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr "私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しません。"
+msgstr ""
+"私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しま"
+"せん。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
+msgstr ""
+"当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、"
+"強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13793,7 +14365,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情報をファイルに関連付けないため、パスフレーズを復元できません。"
+msgstr ""
+"当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情"
+"報をファイルに関連付けないため、パスフレーズを復元できません。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13992,7 +14566,10 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr "検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検索設定%2$sにアクセスしてください。"
+msgstr ""
+"検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能"
+"性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検"
+"索設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14001,8 +14578,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精度が高くなります。 "
-"この機能の動作を調整したり、オフにするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精"
+"度が高くなります。 この機能の動作を調整したり、オフにするには、%1$sDuckAssist"
+"設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14011,7 +14589,10 @@ msgid ""
 "DuckAssist more likely to appear automatically and often yields better "
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
-msgstr "検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精"
+"度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設"
+"定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14043,7 +14624,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr ""
+"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14051,7 +14633,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr ""
+"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14059,7 +14642,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGoの保護が付属しません。"
+msgstr ""
+"目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGo"
+"の保護が付属しません。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14080,10 +14665,22 @@ msgid "Pin"
 msgstr "ピン"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "%1$s %2$sからここにチャットをピン留めします"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14101,6 +14698,12 @@ msgstr "ピンク色"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "ピン留め済み"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14141,7 +14744,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "このプロンプトがボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
+msgstr ""
+"このプロンプトがボットにより行われていないことを確認するため、次のチャレンジ"
+"を完了してください。"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14149,7 +14754,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "この検索がボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
+msgstr ""
+"この検索がボットにより行われていないことを確認するため、次のチャレンジを完了"
+"してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14181,7 +14788,9 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
-msgstr "注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除されます。"
+msgstr ""
+"注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除され"
+"ます。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14189,7 +14798,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害または違法である理由を説明してください。"
+msgstr ""
+"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害また"
+"は違法である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14197,7 +14808,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法または有害である理由を説明してください。"
+msgstr ""
+"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法また"
+"は有害である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14408,6 +15021,12 @@ msgid "Poor formatting"
 msgstr "フォーマットが不十分"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14614,6 +15233,12 @@ msgstr "前の画像"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "前のタブ"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -14908,7 +15533,9 @@ msgstr "確認する"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示します。"
+msgstr ""
+"ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示し"
+"ます。"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -14950,7 +15577,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独自のテキストを挿入します。]"
+msgstr ""
+"次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独"
+"自のテキストを挿入します。]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15152,6 +15781,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "中度のモデレーションが組み込まれた推論AI"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15187,12 +15828,20 @@ msgid "Recent chat storage can be adjusted in %s."
 msgstr "最近のチャットのストレージは%1$sで調整できます。"
 
 # smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
 msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
+msgstr ""
+"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
+"バイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15200,7 +15849,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
+msgstr ""
+"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
+"バイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15209,7 +15860,10 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。"
+msgstr ""
+"最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポン"
+"スは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、イ"
+"ンターネット接続が途切れた場合のチャット復旧に役立ちます。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15334,11 +15988,19 @@ msgid "Reduce Usage"
 msgstr "使用を減らす"
 
 # smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr "結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズを縮小します"
+msgstr ""
+"結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズ"
+"を縮小します"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15479,8 +16141,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッシュ）]、または [Reload（再読み込み）] "
-"ボタンをクリックします。"
+"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッ"
+"シュ）]、または [Reload（再読み込み）] ボタンをクリックします。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15569,14 +16231,18 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
+msgstr ""
+"「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
+"します。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
+msgstr ""
+"「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
+"します。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15633,14 +16299,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
+msgstr ""
+"レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の"
+"匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
+msgstr ""
+"DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個"
+"人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15648,7 +16318,10 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべてのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
+msgstr ""
+"DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべ"
+"てのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を"
+"特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15695,6 +16368,12 @@ msgid "Reset All Settings"
 msgstr "すべての設定をリセット"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -15705,6 +16384,12 @@ msgstr "%1$sでリセットされます"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "解像度"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -15727,7 +16412,10 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象です。"
+msgstr ""
+"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
+"イスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象"
+"です。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15735,7 +16423,10 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象になります。"
+msgstr ""
+"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
+"イスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象"
+"になります。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15745,9 +16436,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-""
-"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なアドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて生成されているため、不正確な情報が含まれている可能性があります。Search "
-"Assistには、当社の%1$s利用規約%2$sが適用されます。"
+"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なア"
+"ドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて"
+"生成されているため、不正確な情報が含まれている可能性があります。Search Assist"
+"には、当社の%1$s利用規約%2$sが適用されます。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16171,7 +16863,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージを使用すれば、さらに多くのチャットを保存できます。"
+msgstr ""
+"最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージ"
+"を使用すれば、さらに多くのチャットを保存できます。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16184,7 +16878,9 @@ msgstr "最新のチャットを最大30件デバイスにローカルで保存�
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょう。"
+msgstr ""
+"エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょ"
+"う。"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16331,7 +17027,9 @@ msgstr "下方向にスクロールし、%1$s詳細設定を表示%2$s をクリ
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) をクリックします"
+msgstr ""
+"%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変"
+"更%4$s (または %5$s新たに追加%6$s) をクリックします"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16340,8 +17038,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) "
-"をクリックします。"
+"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変"
+"更%4$s (または %5$s新たに追加%6$s) をクリックします。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16365,7 +17063,9 @@ msgstr "%1$sDuckDuckGo%2$sまで下にスクロールし、位置情報の使用
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s をクリックします。"
+msgstr ""
+"%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s "
+"をクリックします。"
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16388,6 +17088,12 @@ msgstr "検索"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "%1$sを検索してお近くの検索結果を表示しますか？"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16413,17 +17119,20 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search "
-""
-"Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コンテンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。Search "
-"Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
+"Search Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コン"
+"テンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻"
+"度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々"
+"（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。"
+"Search Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr "Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけることができませんでした。別の検索をお試しください。"
+msgstr ""
+"Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけること"
+"ができませんでした。別の検索をお試しください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16432,8 +17141,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search "
-"Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。これを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情報に基づいてAIを使って簡潔な回答を生成します。"
+"Search Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。こ"
+"れを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情"
+"報に基づいてAIを使って簡潔な回答を生成します。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16553,7 +17263,9 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、Wikipediaで「ducks」を直接検索します。"
+msgstr ""
+"%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、"
+"Wikipediaで「ducks」を直接検索します。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16571,7 +17283,10 @@ msgstr "プライベートに検索し、トラッカーをブロック"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りのブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索できます。"
+msgstr ""
+"検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りの"
+"ブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索"
+"できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16590,8 +17305,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されますが、設定をクラウド上のリモートサーバーに匿名で保存できるCloud "
-"Saveもご利用いただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズがブラウザの外に送信されることもありません。"
+"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されます"
+"が、設定をクラウド上のリモートサーバーに匿名で保存できるCloud Saveもご利用い"
+"ただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズが"
+"ブラウザの外に送信されることもありません。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16693,7 +17410,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16701,7 +17420,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16709,7 +17430,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべての同期済みのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべての同期済みのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16717,7 +17440,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべてのデバイスからアクセスできます。"
+msgstr ""
+"チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべ"
+"てのデバイスからアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16731,7 +17456,15 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr ""
+"データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。"
+"DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16875,35 +17608,41 @@ msgstr "Safariメニューの%1$s「このウェブサイトの設定...」%2$s 
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
+msgstr ""
+"%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
+msgstr ""
+"%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr ""
+"リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16915,7 +17654,9 @@ msgstr "検索エンジンから%1$sDuckDuckGo%2$sを選択してください"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択してください"
+msgstr ""
+"%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択"
+"してください"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -16926,7 +17667,8 @@ msgstr "選ぶなら%1$sDuckDuckGo%2$s！"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
+msgstr ""
+"ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -16939,7 +17681,9 @@ msgstr "ドロップダウンメニューの%1$sアドオン管理%2$sを選択�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$sメニュー > 設定%4$sの順に選択してください"
+msgstr ""
+"Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$s"
+"メニュー > 設定%4$sの順に選択してください"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -16947,8 +17691,8 @@ msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合は、%3$sOpera > "
-"オプション%4$sの順に選択してください"
+"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合"
+"は、%3$sOpera > オプション%4$sの順に選択してください"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -16967,7 +17711,8 @@ msgstr "%1$s検索エンジン%2$s を選択"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
+msgstr ""
+"%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17012,13 +17757,17 @@ msgstr "%1$s設定%2$sを選択し、%3$s検索エンジン%4$sを選択して�
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオプションをどれか一つどうぞ)"
+msgstr ""
+"%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオ"
+"プションをどれか一つどうぞ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr ""
+"リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$s"
+"します"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17090,7 +17839,9 @@ msgstr "選択テキストの参照元：%1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しください。"
+msgstr ""
+"選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17133,7 +17884,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これらの指示は、今後のすべての会話に適用されます。"
+msgstr ""
+"AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これら"
+"の指示は、今後のすべての会話に適用されます。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17231,6 +17984,12 @@ msgid "Set as Homepage"
 msgstr "ホームページに設定する"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17242,7 +18001,9 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるようにSync & Backupを設定します。"
+msgstr ""
+"チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるように"
+"Sync & Backupを設定します。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17294,6 +18055,18 @@ msgid "Seychelles"
 msgstr "セーシェル"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17328,7 +18101,16 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お客様の正確な位置情報を当社や AI モデルに決して公開しません。"
+msgstr ""
+"都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お"
+"客様の正確な位置情報を当社や AI モデルに決して公開しません。"
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17389,6 +18171,12 @@ msgid "Share positive feedback"
 msgstr "肯定的なフィードバックを共有する"
 
 # smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17410,7 +18198,9 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事象の報告には必須）"
+msgstr ""
+"プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事"
+"象の報告には必須）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17522,6 +18312,12 @@ msgid "Show Detail"
 msgstr "詳細を表示"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "DuckAssist<sup>ベータ版</sup>を表示"
@@ -17530,7 +18326,9 @@ msgstr "DuckAssist<sup>ベータ版</sup>を表示"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできます。）"
+msgstr ""
+"DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできま"
+"す。）"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -17669,6 +18467,12 @@ msgid "Show more"
 msgstr "さらに表示"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -17702,6 +18506,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "サイドバーを表示する"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -17755,14 +18565,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオフにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
+msgstr ""
+"DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオ"
+"フにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これをオフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
+msgstr ""
+"DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これを"
+"オフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17799,7 +18613,8 @@ msgstr "DuckDuckGoを端末に追加するリマインダーを随時表示"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
+msgstr ""
+"DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17820,7 +18635,9 @@ msgstr "入力に応じて検索ボックスの下に検索候補を表示"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表示"
+msgstr ""
+"ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表"
+"示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18057,13 +18874,20 @@ msgstr "サーバーへの保存が失敗しました。再度お試しくださ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
+msgstr ""
+"Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "問題が発生しました。後ほどもう一度お試しください。"
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18081,7 +18905,8 @@ msgstr "時々表示する"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
+msgstr ""
+"申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18119,7 +18944,9 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像または形式を試してください。"
+msgstr ""
+"申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像また"
+"は形式を試してください。"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18127,13 +18954,17 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされたことを確認してください。"
+msgstr ""
+"申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされ"
+"たことを確認してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
-msgstr "申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai に聞いてみてください。"
+msgstr ""
+"申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai "
+"に聞いてみてください。"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18141,13 +18972,17 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行するには、%1$sこちらをクリック%2$sしてください。"
+msgstr ""
+"申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行す"
+"るには、%1$sこちらをクリック%2$sしてください。"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてからもう一度試してください。"
+msgstr ""
+"申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてか"
+"らもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18201,7 +19036,9 @@ msgstr "ソーステキストが消去されました"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度お試しください。"
+msgstr ""
+"ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度"
+"お試しください。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18350,6 +19187,12 @@ msgid "Start Using Weekly Limit"
 msgstr "週間制限の使用を開始"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "検索を始めよう！"
@@ -18400,7 +19243,8 @@ msgstr "DuckDuckGoを使用し続ける"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
+msgstr ""
+"プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -18544,7 +19388,9 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr "Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像を作成してください。"
+msgstr ""
+"Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像"
+"を作成してください。"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -18612,7 +19458,8 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
+msgstr ""
+"手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -18924,6 +19771,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "どんなときでも、あなたを追跡しないサーチエンジンに乗り換えよう。"
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -18934,7 +19789,8 @@ msgstr "%1$sに切り替えました"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
+msgstr ""
+"切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19037,21 +19893,25 @@ msgid ""
 msgstr ""
 "同期リカバリーコード\n"
 "\n"
-""
-""
-"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同期済みのデータを回復できます。\n"
+"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複"
+"数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同"
+"期済みのデータを回復できます。\n"
 "\n"
 "この情報は安全に保管してください。\n"
-"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできます。\n"
+"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできま"
+"す。\n"
 "\n"
 "%1$s\n"
 "\n"
 "このコードの仕組みは？\n"
 "1. ブラウザでDuck.aiにアクセスし、Duck.aiの設定を開きます。\n"
-"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択します\n"
-"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付けます\n"
+"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択しま"
+"す\n"
+"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付"
+"けます\n"
 "\n"
-"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除され、復元できなくなります。"
+"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除さ"
+"れ、復元できなくなります。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19070,6 +19930,12 @@ msgstr "別のデバイスと同期"
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sync & Backupは一時的にご利用いただけません"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19159,6 +20025,22 @@ msgid "Take Back Your Privacy!"
 msgstr "あなたのプライバシーを取り戻す"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19179,7 +20061,8 @@ msgstr "個人データを自己管理しましょう！"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
+msgstr ""
+"この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19393,7 +20276,10 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワードや支払い情報がこうした情報に含まれる場合もあります。"
+msgstr ""
+"つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情"
+"報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワード"
+"や支払い情報がこうした情報に含まれる場合もあります。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19401,7 +20287,9 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr "Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動保存できます。"
+msgstr ""
+"Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動"
+"保存できます。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19430,14 +20318,18 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr "暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本人だけです。"
+msgstr ""
+"暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本"
+"人だけです。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除します。"
+msgstr ""
+"モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除しま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -19451,7 +20343,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
+msgstr ""
+"モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19509,7 +20402,9 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確認し、ローカルデータの保存が有効になっていることをご確認ください。"
+msgstr ""
+"このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確"
+"認し、ローカルデータの保存が有効になっていることをご確認ください。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19523,7 +20418,9 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr "検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してください。"
+msgstr ""
+"検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -19541,7 +20438,10 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加するために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoをデフォルトの検索エンジンにするために使用されます。"
+msgstr ""
+"これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加す"
+"るために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoを"
+"デフォルトの検索エンジンにするために使用されます。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19578,7 +20478,9 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみてください。"
+msgstr ""
+"このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみ"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19586,7 +20488,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャットを開始してください。"
+msgstr ""
+"このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャッ"
+"トを開始してください。"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19601,10 +20505,22 @@ msgid "This Month"
 msgstr "今月"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "今週"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19612,7 +20528,10 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr "この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
+msgstr ""
+"この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AI"
+"チャットでは不正確な情報や不快な情報が表示される場合があります（詳細について"
+"は%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19621,7 +20540,10 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な内容が表示される場合があります（詳細については%2$sを参照してください）。"
+msgstr ""
+"この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AI"
+"チャットでは不正確な情報や不快な内容が表示される場合があります（詳細について"
+"は%2$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19629,7 +20551,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
+msgstr ""
+"この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な"
+"情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19639,8 +20563,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI "
-"Chat（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
+"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI Chat（%1$s）で生成されま"
+"した。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細"
+"については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19672,7 +20597,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr ""
+"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -19680,7 +20606,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr ""
+"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -19711,19 +20638,39 @@ msgstr "この画像は作成できませんでした。"
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
+msgstr ""
+"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
+msgstr ""
+"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "この情報は役に立たない"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -19743,7 +20690,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除します。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
+msgstr ""
+"このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除しま"
+"す。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19751,7 +20700,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "このモデルプロバイダーはこのチャットに関連するデータを保存していません。他のモデルプロバイダーは限定的なデータ保持モデルを採用しています。"
+msgstr ""
+"このモデルプロバイダーはこのチャットに関連するデータを保存していません。他の"
+"モデルプロバイダーは限定的なデータ保持モデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19787,7 +20738,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後でどのブラウザからでもアクセスできます。"
+msgstr ""
+"チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後"
+"でどのブラウザからでもアクセスできます。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19795,7 +20748,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。"
+msgstr ""
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
+"すると、AI支援の回答が再表示されることがあります。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19805,9 +20760,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。ただし、%1$s "
-"にはAI支援の回答が一切表示されないスタートページもご用意しています。"
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
+"すると、AI支援の回答が再表示されることがあります。ただし、%1$s にはAI支援の回"
+"答が一切表示されないスタートページもご用意しています。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19830,13 +20785,16 @@ msgstr "この翻訳は正しくありません"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能です。"
+msgstr ""
+"この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能で"
+"す。"
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
+msgstr ""
+"このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19846,8 +20804,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除され、Sync & Backupとの接続は解除されます。Sync & "
-"Backupに接続している他のブラウザでは、引き続きチャットにアクセスできます。"
+"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除さ"
+"れ、Sync & Backupとの接続は解除されます。Sync & Backupに接続している他のブラ"
+"ウザでは、引き続きチャットにアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19855,7 +20814,9 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。この操作は取り消せません。"
+msgstr ""
+"これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。こ"
+"の操作は取り消せません。"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -19992,7 +20953,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印刷アイコンをクリックします。%4$s"
+msgstr ""
+"ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印"
+"刷アイコンをクリックします。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20001,7 +20964,10 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "同期したデータを復元するには、同期を初めて設定したときに保存したリカバリーコードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保存されている可能性があります。"
+msgstr ""
+"同期したデータを復元するには、同期を初めて設定したときに保存したリカバリー"
+"コードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保"
+"存されている可能性があります。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20009,14 +20975,18 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアップデートし、再度お試しください。"
+msgstr ""
+"チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアッ"
+"プデートし、再度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr "音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるように設定してください。"
+msgstr ""
+"音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるよ"
+"うに設定してください。"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20033,6 +21003,12 @@ msgstr "今日"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "今日"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20205,7 +21181,9 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、ブロック件数が表示されるようになります。"
+msgstr ""
+"DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、"
+"ブロック件数が表示されるようになります。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20252,7 +21230,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
+msgstr ""
+"この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって"
+"行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20260,7 +21240,9 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
+msgstr ""
+"この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行け"
+"ばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20368,7 +21350,8 @@ msgstr "%1$sを試す"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr "このようなメッセージが表示されないようにするには、%1$sをお試しください。"
+msgstr ""
+"このようなメッセージが表示されないようにするには、%1$sをお試しください。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -20378,7 +21361,9 @@ msgstr "プロバイダーの可視性がゼロの最初のモデル%1$sをお�
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試しを！"
+msgstr ""
+"%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試し"
+"を！"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -20440,9 +21425,21 @@ msgid "Try Them Out"
 msgstr "試してみよう"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "検索を試そう！"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -20477,13 +21474,16 @@ msgstr "別のキーワードを試してみてください。"
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しください。"
+msgstr ""
+"より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しく"
+"ださい。"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
+msgstr ""
+"検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -20507,6 +21507,12 @@ msgid "Try for free"
 msgstr "無料で試す"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -20519,6 +21525,12 @@ msgstr "無料で試す"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "無料でお試しください！安全なVPN、プライベートで高度なAIなど。"
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20548,6 +21560,12 @@ msgid "Try our homepage that never shows these messages:"
 msgstr "次のようなメッセージを表示しない当ページをご覧ください。"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
 msgid "Try related keywords"
@@ -20568,7 +21586,8 @@ msgstr "位置情報を手動で設定してみてください。"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
+msgstr ""
+"%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -20626,7 +21645,8 @@ msgstr "最近追加されたオープンソースのLlama 3.1とMixtralをお�
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
+msgstr ""
+"まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -20793,6 +21813,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Duck Playerをオンにするとターゲティング広告なしでYouTubeを視聴できます"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -20802,7 +21828,8 @@ msgstr "より正確な結果を得るには、「正確な位置情報」をオ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
+msgstr ""
+"より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -20846,14 +21873,17 @@ msgstr "「%1$sDuckDuckGo%2$s」と %3$s フォームの最初のフィールド
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Type %sduckduckgo.com%s in the %ssecond form field"
-msgstr "「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
+msgstr ""
+"「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索してから回答が表示されるまでに、多少タイムラグが生じる場合があります。"
+msgstr ""
+"DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索して"
+"から回答が表示されるまでに、多少タイムラグが生じる場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20982,14 +22012,18 @@ msgstr "長所と短所を明らかにする"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$sページがセレクト%6$s クリックします。"
+msgstr ""
+"%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$s"
+"ページがセレクト%6$s クリックします。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと入力してください"
+msgstr ""
+"%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと"
+"入力してください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -20999,7 +22033,8 @@ msgstr "%1$s開く%2$s の中から %3$s特定のページを開く%4$s を選�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
+msgstr ""
+"%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21009,13 +22044,17 @@ msgstr "%1$s検索設定%2$sで、%3$sDuckDuckGo%4$sを選択します"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$sを選択します"
+msgstr ""
+"%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$s"
+"を選択します"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックします"
+msgstr ""
+"%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックし"
+"ます"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21104,7 +22143,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上限がPlusプランの2倍になります。"
+msgstr ""
+"Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上"
+"限がPlusプランの2倍になります。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21147,6 +22188,12 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "サブスクリプションで高度なAIをアンロックしましょう！"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -21158,7 +22205,9 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょう。%1$s"
+msgstr ""
+"DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょ"
+"う。%1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -21237,7 +22286,9 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr "DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度なモデルにアクセスしよう"
+msgstr ""
+"DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度な"
+"モデルにアクセスしよう"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21361,7 +22412,9 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr "ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像を作成してください。"
+msgstr ""
+"ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像"
+"を作成してください。"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -21462,7 +22515,10 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必要ありません。"
+msgstr ""
+"ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、"
+"詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必"
+"要ありません。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21474,7 +22530,8 @@ msgstr "DuckDuckGo Private Searchを使う"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
+msgstr ""
+"あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -21499,19 +22556,29 @@ msgid "Use in Safari"
 msgstr "Safariで使用"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr "デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大切に保管してください。"
+msgstr ""
+"デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大"
+"切に保管してください。"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr "デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを復元してください。"
+msgstr ""
+"デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを"
+"復元してください。"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -21660,7 +22727,9 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは Microsoft の広告ネットワークで管理されています"
+msgstr ""
+"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは "
+"Microsoft の広告ネットワークで管理されています"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21668,7 +22737,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックはTripAdvisorの広告ネットワークで管理されています。"
+msgstr ""
+"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは"
+"TripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21679,7 +22750,9 @@ msgstr "ヴァージン諸島"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセ"
+"スしてください。"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -21687,7 +22760,9 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにア"
+"クセスしてください。"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -21695,7 +22770,9 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従ってください。"
+msgstr ""
+"タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従って"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21710,8 +22787,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s "
-"に進み、%7$s別のデバイスと同期%8$sを選択してください。"
+"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21720,7 +22798,10 @@ msgid ""
 "Visit Duck.ai in your other browser and open Duck.ai Settings. Select “Turn "
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
-msgstr "別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。または、リカバリーPDFのQRコードをスキャンしてください。"
+msgstr ""
+"別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆"
+"Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。ま"
+"たは、リカバリーPDFのQRコードをスキャンしてください。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21730,8 +22811,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してください。"
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s "
+"> %3$sSync & Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選"
+"択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21740,7 +22822,10 @@ msgid ""
 "Visit Duck.ai in your other browser or the DuckDuckGo app and open Duck.ai "
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
-msgstr "他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開きます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択します。または、リカバリーPDFのQRコードをスキャンします。"
+msgstr ""
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開き"
+"ます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択しま"
+"す。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21792,7 +22877,9 @@ msgstr "ボイスチャットは終了しました"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -21936,8 +23023,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、YouTube "
-"のおすすめに影響されずに動画を視聴できます。"
+"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、"
+"YouTube のおすすめに影響されずに動画を視聴できます。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21956,7 +23043,11 @@ msgid ""
 "because we have to stream the content from there. DuckDuckGo is an "
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
-msgstr "このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテンツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGoは独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ございません。"
+msgstr ""
+"このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテン"
+"ツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGo"
+"は独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ござ"
+"いません。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21968,7 +23059,8 @@ msgstr "匿名化に対応"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
+msgstr ""
+"%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -21979,7 +23071,10 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報するには、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してしてください。"
+msgstr ""
+"当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報する"
+"には、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してし"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21990,7 +23085,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
+msgstr ""
+"当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する"
+"場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22003,7 +23100,9 @@ msgstr "匿名の%1$s位置情報%2$sを使用すると、おおよその結果�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることができません。"
+msgstr ""
+"添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることがで"
+"きません。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22030,7 +23129,9 @@ msgstr "私たちはあなたの個人情報を保存しません。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr "個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束します。"
+msgstr ""
+"個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束"
+"します。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22043,7 +23144,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った理由」を教えてください。"
+msgstr ""
+"私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った"
+"理由」を教えてください。"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22051,7 +23154,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと思った理由」を教えてください。"
+msgstr ""
+"私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと"
+"思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22090,18 +23195,23 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr "私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であなたを追跡して、それを広告主に販売することはありません。"
+msgstr ""
+"私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であ"
+"なたを追跡して、それを広告主に販売することはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しません。"
+msgstr ""
+"私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しま"
+"せん。"
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
+msgstr ""
+"私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22115,7 +23225,8 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
+msgstr ""
+"チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22139,7 +23250,9 @@ msgstr "接続が失われました。メッセージの送信をもう一度お
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr "私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索広告%2$sから収益を得ています。"
+msgstr ""
+"私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索"
+"広告%2$sから収益を得ています。"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22147,13 +23260,17 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されます。この設定は後でいつでも変更できます。"
+msgstr ""
+"匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されま"
+"す。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名でのフィードバックを頼りにしています。"
+msgstr ""
+"DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名"
+"でのフィードバックを頼りにしています。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22173,7 +23290,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
+msgstr ""
+"このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご"
+"提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22186,7 +23305,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエラーが続く場合は、%1$sに連絡してください。"
+msgstr ""
+"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエ"
+"ラーが続く場合は、%1$sに連絡してください。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22194,7 +23315,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウザのキャッシュをクリアすると解決に役立つ場合があります。"
+msgstr ""
+"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウ"
+"ザのキャッシュをクリアすると解決に役立つ場合があります。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22208,7 +23331,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力しています。"
+msgstr ""
+"ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力していま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22216,7 +23341,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr "Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要があります。"
+msgstr ""
+"Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要"
+"があります。"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22337,7 +23464,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのト"
+"レーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22345,7 +23474,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、"
+"AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22355,14 +23486,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatへようこそ！このチャットセッションは%1$sの%2$sを使用しています。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルのトレーニングに使用されたりすることはありません。"
+"DuckDuckGo AI Chatへようこそ！このチャットセッションは%1$sの%2$sを使用してい"
+"ます。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルの"
+"トレーニングに使用されたりすることはありません。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになりました。"
+msgstr ""
+"新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになり"
+"ました。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22429,7 +23563,9 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr "申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込みしてみてください。"
+msgstr ""
+"申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込"
+"みしてみてください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22443,7 +23579,9 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr "プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありますか？"
+msgstr ""
+"プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありま"
+"すか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -22463,7 +23601,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をどう言い換えられますか？"
+msgstr ""
+"「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をど"
+"う言い換えられますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22481,7 +23621,12 @@ msgid ""
 "ai integrations, and privacy protections. Keep it quite short, simple, and "
 "easy to understand for people with or without much AI, or technical, "
 "experience."
-msgstr "Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメリットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、誰でも簡単に理解できるように回答します。"
+msgstr ""
+"Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメ"
+"リットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回"
+"答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に"
+"重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、"
+"誰でも簡単に理解できるように回答します。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22591,6 +23736,12 @@ msgstr "特にどの点が気になりましたか？"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "今日はどういったご用件でお戻りになられましたか？"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -22710,7 +23861,9 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットとの違いは？"
+msgstr ""
+"Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットと"
+"の違いは？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -22810,7 +23963,9 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr "初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何ですか？"
+msgstr ""
+"初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何です"
+"か？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23003,6 +24158,14 @@ msgstr "勝ち"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "みぞれ混じりの雪"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -23275,7 +24438,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
+msgstr ""
+"%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合"
+"があります。"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23283,7 +24448,9 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検索できます。"
+msgstr ""
+"%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検"
+"索できます。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23296,7 +24463,8 @@ msgstr "DuckDuckGo AI Chatには%1$sから直接アクセスできます。"
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
+msgstr ""
+"%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23304,17 +24472,22 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr "Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
+msgstr ""
+"Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
+msgstr ""
+"%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできま"
+"す。"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr "%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
+msgstr ""
+"%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりする"
+"こともできます。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -23327,7 +24500,9 @@ msgstr "添付するテキストは最大%1$sまで選択できます。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりできます。"
+msgstr ""
+"Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりで"
+"きます。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23347,7 +24522,9 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任意で削除できます。"
+msgstr ""
+"設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任"
+"意で削除できます。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23376,7 +24553,8 @@ msgstr "月間制限時間を使ってチャットを続行できます。"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
+msgstr ""
+"このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23415,6 +24593,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "画像は会話ごとに%1$s点しか添付できません。"
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -23432,7 +24617,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトのブロックを解除する必要があります。"
+msgstr ""
+"最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトの"
+"ブロックを解除する必要があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23488,7 +24675,8 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
+msgstr ""
+"これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23496,7 +24684,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスクリプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
+msgstr ""
+"高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスク"
+"リプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23517,7 +24707,10 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。これにより、暗号化されたサーバーからチャットデータが削除されることはありません。"
+msgstr ""
+"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
+"チャットはローカルストレージで引き続き利用可能です。これにより、暗号化された"
+"サーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23526,7 +24719,10 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。この操作により、暗号化されたサーバーからチャットデータが削除されることはありません。"
+msgstr ""
+"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
+"チャットはローカルストレージで引き続き利用可能です。この操作により、暗号化さ"
+"れたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23539,7 +24735,14 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr "最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
+msgstr ""
+"最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -23547,7 +24750,10 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを使ってもプライベートに閲覧できます。このアプリはすでにインストールされており、以下が可能になります。"
+msgstr ""
+"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを"
+"使ってもプライベートに閲覧できます。このアプリはすでにインストールされてお"
+"り、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23559,7 +24765,9 @@ msgstr "あなたは今、匿名で検索しています！"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡をもっと減らすヒントを学びましょう。"
+msgstr ""
+"今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡を"
+"もっと減らすヒントを学びましょう。"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23585,6 +24793,12 @@ msgid "You've blocked 1 site"
 msgstr "1件のサイトをブロックしました"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -23602,7 +24816,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
+msgstr ""
+"現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -23615,12 +24830,14 @@ msgstr "1回のセッションの最大ボイスチャット時間に達しま�
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
+msgstr ""
+"本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
+msgstr ""
+"ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23629,8 +24846,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"添付ファイル付きのDuck.aiチャットのSync & "
-"Backup用ストレージ容量が不足しています。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされたチャットは削除されません。"
+"添付ファイル付きのDuck.aiチャットのSync & Backup用ストレージ容量が不足してい"
+"ます。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされ"
+"たチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23640,8 +24858,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.aiチャットのSync & "
-"Backup用ストレージ容量が不足しています。同期を再開するには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留めされたチャットは削除されません。"
+"Duck.aiチャットのSync & Backup用ストレージ容量が不足しています。同期を再開す"
+"るには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留め"
+"されたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23654,7 +24873,9 @@ msgstr "ストレージの容量がいっぱいです"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録されています。"
+msgstr ""
+"YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録"
+"されています。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23697,7 +24918,10 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
+msgstr ""
+"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
+"同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージ"
+"に保存されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23706,7 +24930,10 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルストレージに保存されます。"
+msgstr ""
+"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
+"同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルスト"
+"レージに保存されます。"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23730,14 +24957,18 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr "お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGoがこのデータにアクセスすることはありません。"
+msgstr ""
+"お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGo"
+"がこのデータにアクセスすることはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、DuckDuckGoはこのデータにアクセスすることはできません。"
+msgstr ""
+"ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、"
+"DuckDuckGoはこのデータにアクセスすることはできません。"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -23745,7 +24976,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
+msgstr ""
+"%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示さ"
+"れる場合があります。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -23757,41 +24990,50 @@ msgstr "チャットが保存されるようになりました。"
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr "チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはありません。"
+msgstr ""
+"チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはあ"
+"りません。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
+msgstr ""
+"チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
+msgstr ""
+"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
+msgstr ""
+"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -23805,7 +25047,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されません。チャット履歴を保持するには、以下の手順に従ってください。"
+msgstr ""
+"チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されま"
+"せん。チャット履歴を保持するには、以下の手順に従ってください。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -23813,7 +25057,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
+msgstr ""
+"チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -23844,7 +25089,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
+msgstr ""
+"あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検"
+"索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -23887,10 +25134,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) "
-""
-"を使用した512ビットのキーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残ります。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo "
-"がお客様のパスフレーズを知ることはありません。"
+"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) を使用した512ビットの"
+"キーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残りま"
+"す。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo がお客様の"
+"パスフレーズを知ることはありません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23904,7 +25151,10 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータが取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはできません。"
+msgstr ""
+"プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータ"
+"が取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはで"
+"きません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23917,7 +25167,9 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr "最近のチャットはここにあります！チャットはいつでも参照したり、消去したりできます。"
+msgstr ""
+"最近のチャットはここにあります！チャットはいつでも参照したり、消去したりでき"
+"ます。"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -23943,14 +25195,23 @@ msgid "Your searches can’t be tied back to you"
 msgstr "検索結果はあなたに結びつけられません"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
-"AI%2$s拡張機能をインストールしてください。%3$s詳細情報%4$s"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
+"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能をインストールしてくださ"
+"い。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -23969,7 +25230,10 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにインストールされており、以下が可能になります。"
+msgstr ""
+"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウ"
+"ザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにイン"
+"ストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -23977,7 +25241,9 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直してください。"
+msgstr ""
+"メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直して"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23985,7 +25251,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして続行します。"
+msgstr ""
+"この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして"
+"続行します。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -23993,7 +25261,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始します。"
+msgstr ""
+"この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始"
+"します。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24007,13 +25277,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
+msgstr ""
+"ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24096,7 +25368,9 @@ msgstr "（%1$s）"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されています。"
+msgstr ""
+"DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されて"
+"います。"
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -24309,7 +25583,9 @@ msgstr "公式ウェブサイト"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードしたものです)"
+msgstr ""
+"あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードし"
+"たものです)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -24520,3 +25796,9 @@ msgstr "年"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "年"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$sを検出しました"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s件のファイルを使用"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -181,10 +181,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
-"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
-"てください。"
+msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -193,10 +190,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
-"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
-"てください。"
+msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -211,10 +205,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるに"
-"は、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替え"
-"てください。"
+msgstr "%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるには、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -222,9 +213,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直し"
-"てください。"
+msgstr "%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -315,9 +304,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$sはTrusted Execution Environmentで動作します。つまり、モデルプロバイダーで"
-"さえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサー"
-"バーに保存することもできません。"
+"%1$sはTrusted Execution "
+"Environmentで動作します。つまり、モデルプロバイダーでさえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサーバーに保存することもできません。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -364,7 +352,7 @@ msgstr "%1$s使用済み"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$sは基本モデル%2$sより最大2～5倍早く使用制限に達します"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -402,9 +390,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替え"
-"てこのチャットを続けることができます。"
+msgstr "%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -414,9 +400,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えて"
-"このチャットを続けることができます。"
+msgstr "%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -428,9 +412,7 @@ msgstr "%1$s単語"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$s"
-"をクリックしてください"
+msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$sをクリックしてください"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -438,8 +420,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$s"
-"ボックスをオンにしてから %8$sOK%9$sをクリックしてください"
+"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$sボックスをオンにしてから "
+"%8$sOK%9$sをクリックしてください"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -449,8 +431,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sインストールを続行%3$sをクリックして %4$s追加ボタン%5$sを押し、%6$s許"
-"可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
+"%1$s%2$sインストールを続行%3$sをクリックして "
+"%4$s追加ボタン%5$sを押し、%6$s許可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -458,9 +440,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう"
-"一度試します。"
+msgstr "この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう一度試します。"
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -478,17 +458,14 @@ msgstr "%1$sさらに詳しく%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
+msgstr "%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこち"
-"ら%2$sをご覧ください。"
+msgstr "DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこちら%2$sをご覧ください。"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -506,8 +483,7 @@ msgstr "ホーム画面でDuckDuckGoのアプリアイコンを%1$s長押し%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
+msgstr "%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -619,7 +595,7 @@ msgstr "1日前"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1件のファイルを使用"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -847,8 +823,7 @@ msgstr "6時間の使用制限に達しました。このチャットは%1$s以�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
+msgstr "6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -901,27 +876,21 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"ネットワークの問題により、Search Assistは回答を生成できません。接続を確認し"
-"て、もう一度試してください。"
+msgstr "ネットワークの問題により、Search Assistは回答を生成できません。接続を確認して、もう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
-"い。"
+msgstr "AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
-"い。"
+msgstr "Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてください。"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -965,9 +934,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフ"
-"にすると、DuckDuckGo SearchのAI Chat機能は非表示になりますが、%1$sduckduckgo."
-"com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
+"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフにすると、DuckDuckGo SearchのAI "
+"Chat機能は非表示になりますが、%1$sduckduckgo.com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1027,11 +995,7 @@ msgid ""
 "However, we also offer and often link to %sDuck.ai%s for follow-up "
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
-msgstr ""
-"AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただ"
-"し、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供して"
-"います。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活"
-"用したプライベートチャットサービスです。"
+msgstr "AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただし、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供しています。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活用したプライベートチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1215,9 +1179,7 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr ""
-"チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切"
-"り替えてください。"
+msgstr "チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1252,18 +1214,14 @@ msgstr "広告"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファ"
-"イリングには使用されません。"
+msgstr "広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr ""
-"広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロ"
-"ファイリングには使用されません。"
+msgstr "広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1313,9 +1271,7 @@ msgstr "DuckDuckGo拡張機能を追加"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加でき"
-"ます："
+msgstr "DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加できます："
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1535,7 +1491,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
+msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1571,16 +1527,13 @@ msgstr "アフリカーンス語"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
+msgstr "ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールして"
-"ください"
+msgstr "ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールしてください"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1715,9 +1668,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供"
-"元が学習内容をチャットモデルの学習に利用することはありません"
+msgstr "すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供元が学習内容をチャットモデルの学習に利用することはありません"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1749,9 +1700,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されてい"
-"ます。"
+msgstr "すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されています。"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1765,9 +1714,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスな"
-"ど）が削除されます。"
+msgstr "AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスなど）が削除されます。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1798,9 +1745,7 @@ msgstr "許可"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可"
-"してください。"
+msgstr "ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可してください。"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1831,19 +1776,14 @@ msgid ""
 "Allows %s to search the web to improve responses to relevant prompts. Only "
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
-msgstr ""
-"%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。"
-"AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$s"
-"のプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
+msgstr "%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$sのプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr ""
-"デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する"
-"場合に必須)"
+msgstr "デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する場合に必須)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1980,9 +1920,7 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
-"セスできます。"
+msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1990,9 +1928,7 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
-"セスできます。"
+msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2005,9 +1941,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選"
-"択するか、完全に無効にすることができます。"
+msgstr "ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選択するか、完全に無効にすることができます。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2053,9 +1987,7 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr ""
-"Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教"
-"えてください"
+msgstr "Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教えてください"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2174,9 +2106,7 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr ""
-"履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むす"
-"べてのチャットが削除されます。"
+msgstr "履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むすべてのチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2184,9 +2114,7 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr ""
-"最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている"
-"最近のチャットも削除されます。"
+msgstr "最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている最近のチャットも削除されます。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2223,9 +2151,7 @@ msgstr "最終更新："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"私達はプライバシーポリシーに従って、個人情報を収集または共有することはありま"
-"せん。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
+msgstr "私達はプライバシーポリシーに従って、個人情報を収集または共有することはありません。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2326,7 +2252,7 @@ msgstr "非公開で質問"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "非公開で質問"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2361,12 +2287,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿"
-"名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist UIを完全に"
-"削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回"
-"答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻"
-"繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できま"
-"す。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
+""
+"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist "
+"UIを完全に削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できます。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2377,12 +2300,7 @@ msgid ""
 "generate a brief answer based on relevant information found. It’s important "
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
-msgstr ""
-"Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプ"
-"ション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活"
-"用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答"
-"は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されるこ"
-"とを覚えておくことが重要です。"
+msgstr "Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2473,8 +2391,7 @@ msgstr "チャット終了後、音声は当社または OpenAI によって保�
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
+msgstr "チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2515,24 +2432,18 @@ msgstr "自動応答"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があ"
-"ります。"
+msgstr "リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる"
-"場合があります。"
+msgstr "リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"ソースに基づき自動生成されています。内容に不正確な部分を含む可能性がありま"
-"す。"
+msgstr "ソースに基づき自動生成されています。内容に不正確な部分を含む可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2551,10 +2462,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して"
-"情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能で"
-"す。"
+msgstr "関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2563,16 +2471,14 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"関連する検索に DuckAssist を自動表示します。このツールを使用すると、一部の検"
-"索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ"
-"利用可能です。"
+"関連する検索に DuckAssist "
+"を自動表示します。このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
+msgstr "動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2771,9 +2677,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータ"
-"などのPIIを削除することで、会話を匿名化します。"
+msgstr "このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータなどのPIIを削除することで、会話を匿名化します。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2899,8 +2803,7 @@ msgstr "メールトラッカーをブロックし、アドレスを非表示に
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
+msgstr "ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3154,28 +3057,20 @@ msgstr "ファイルを参照"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索"
-"エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$s"
-"にまとめました。"
+msgstr "DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、"
-"高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr "いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロッ"
-"ク、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウン"
-"ロードしましょう。"
+msgstr "いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロック、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウンロードしましょう。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3261,8 +3156,7 @@ msgstr "「%1$s」をクリックすると、当社の%2$sに同意したこと�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
+msgstr "「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3283,19 +3177,16 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に"
-"保存されます。匿名の Cloud Save 機能を利用すると、設定情報を (クラウド上のリ"
-"モートサーバーに) より長期的に保存できます。個人を特定できる情報がクラウドに"
-"保存されたり、パスフレーズがブラウザ上に残ることもありません。"
+"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に保存されます。匿名の Cloud Save "
+"機能を利用すると、設定情報を (クラウド上のリモートサーバーに) "
+"より長期的に保存できます。個人を特定できる情報がクラウドに保存されたり、パスフレーズがブラウザ上に残ることもありません。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信される"
-"ことに同意したことになります。開始する間に当社の%1$sを確認してください。"
+msgstr "音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3304,9 +3195,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI に送信"
-"されることに同意したことになります。開始する間に当社の%1$sを確認してくださ"
-"い。"
+"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI "
+"に送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3661,8 +3551,7 @@ msgstr "サイト全体の背景色を変更する"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
+msgstr "マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3791,11 +3680,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"チャット（Duck.ai サービス経由）を通じて、OpenAI、Anthropicなどのサードパー"
-"ティのAIチャットモデルと匿名で会話することができます。この設定をオフにする"
-"と、DuckDuckGo Searchのチャットボタンとリンクが非表示になります。ただし、この"
-"設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用"
-"できます。"
+"チャット（Duck.ai "
+""
+"サービス経由）を通じて、OpenAI、AnthropicなどのサードパーティのAIチャットモデルと匿名で会話することができます。この設定をオフにすると、DuckDuckGo "
+"Searchのチャットボタンとリンクが非表示になります。ただし、この設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3850,18 +3738,14 @@ msgstr "プライベートチャット"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートに"
-"チャットできます。"
+msgstr "無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプラ"
-"イベートにチャットできます。"
+msgstr "無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプライベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3879,7 +3763,7 @@ msgstr "AIとのプライベートチャット"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "人気のAIとプライベートにチャット"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3929,10 +3813,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスに"
-"ローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが"
-"削除されます。"
+msgstr "チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスにローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3943,12 +3824,7 @@ msgid ""
 "help recover a chat if you lose your internet connection. Disabling chat "
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
-msgstr ""
-"チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗"
-"号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インター"
-"ネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にする"
-"と、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効"
-"になります。"
+msgstr "チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3970,19 +3846,14 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップ"
-"ロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロ"
-"バイダーによって匿名でレビューされます。"
+msgstr "%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロバイダーによって匿名でレビューされます。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr ""
-"添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはスト"
-"レージを解放してください。"
+msgstr "添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはストレージを解放してください。"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4041,8 +3912,7 @@ msgstr "この障害に関する最新情報は、DuckDuckGoのサブレディ�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"この停止に関する最新情報については、ステータスページを確認してください。"
+msgstr "この停止に関する最新情報については、ステータスページを確認してください。"
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4107,8 +3977,7 @@ msgstr "%1$sや%2$sを含むAIモデルの選択"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
+msgstr "%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4329,9 +4198,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最"
-"近のチャットが無期限に保存される場合、またはAI Chatの未使用期間が7日を超える"
-"と自動的に削除される場合があります。"
+"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最近のチャットが無期限に保存される場合、またはAI "
+"Chatの未使用期間が7日を超えると自動的に削除される場合があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4340,10 +4208,7 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr ""
-"ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは"
-"無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあ"
-"ります。ブラウザによって異なります。"
+msgstr "ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあります。ブラウザによって異なります。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4351,9 +4216,7 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr ""
-"ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリ"
-"ストを当社の無料ブラウザに"
+msgstr "ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリストを当社の無料ブラウザに"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4361,11 +4224,7 @@ msgid ""
 "Click \"More\" to go deeper on a topic, and ask follow-up questions via "
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
-msgstr ""
-"「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。ま"
-"た、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなど"
-"のチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用で"
-"きます。"
+msgstr "「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。また、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなどのチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用できます。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4406,9 +4265,7 @@ msgstr "一覧から%1$s検索設定の変更%2$sをクリックしてくださ�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてく"
-"ださい"
+msgstr "%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてください"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4419,15 +4276,12 @@ msgstr "%1$sここ%2$sをクリックして検索エンジンとして追加し�
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo browser extension to Safari.
 msgid "Click %sHere%s to download the DuckDuckGo extension"
-msgstr ""
-"%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
+msgstr "%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
 
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてくださ"
-"い"
+msgstr "%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてください"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4441,9 +4295,7 @@ msgstr "左側のサイドバーにある%1$sプライバシーとサービス%2
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、"
-"右上の%3$s歯車アイコン%4$sをクリックしてください)"
+msgstr "%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、右上の%3$s歯車アイコン%4$sをクリックしてください)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4472,8 +4324,7 @@ msgstr "%1$sはい%2$sをクリックしてください"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
+msgstr "Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4509,8 +4360,7 @@ msgstr "下のほうの %1$sデフォルトに設定%2$s をクリックしま�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
+msgstr "アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4535,10 +4385,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作"
-"によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がク"
-"リックまたはタップされるまでブラウザに残ります。"
+msgstr "「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がクリックまたはタップされるまでブラウザに残ります。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4548,10 +4395,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはク"
-"ラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップし"
-"ない限り、お使いのブラウザに保存されたままとなります。"
+msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4619,18 +4463,14 @@ msgstr "検索ボックスの選択項目をクリック"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューを"
-"クリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
+msgstr "%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューをクリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr ""
-"広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機"
-"能のアイコンはブラウザの右上隅に表示されています。"
+msgstr "広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機能のアイコンはブラウザの右上隅に表示されています。"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4676,7 +4516,7 @@ msgstr "閉じる"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "閉じる"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4726,7 +4566,7 @@ msgstr "検索を閉じる"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "他のAIモデルの回答を閉じる"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4830,9 +4670,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能"
-"を使うかどうかはあなた次第。強制ではありません。"
+msgstr "パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能を使うかどうかはあなた次第。強制ではありません。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5103,7 +4941,7 @@ msgstr "広告ブロックを継続"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "最近のチャットはここから再開できます。または、Fire Buttonで削除することもできます。"
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5174,7 +5012,7 @@ msgstr "Cookieデータ:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "コピーしました"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5215,8 +5053,7 @@ msgstr "コピー"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
+msgstr "「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5228,7 +5065,7 @@ msgstr "コードをコピー"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "リンクをコピー"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5298,9 +5135,7 @@ msgstr "コスタリカ"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しくださ"
-"い。"
+msgstr "リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5349,7 +5184,7 @@ msgstr "画像を作成"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "共有リンクを作成"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5400,7 +5235,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
+msgstr "リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧できるようになります。"
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5559,7 +5394,7 @@ msgstr "応答をカスタマイズする"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "応答をカスタマイズする"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5633,8 +5468,7 @@ msgstr "1日の使用制限に達しました。このチャットは%1$s以降�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
+msgstr "1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5848,7 +5682,7 @@ msgstr "サーバーデータを削除しますか？"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "共有リンクを削除"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5860,7 +5694,7 @@ msgstr "トランスクリプトを削除"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "チャットを削除"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5898,7 +5732,7 @@ msgstr "画像を削除しますか？"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "これを削除"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5910,8 +5744,7 @@ msgstr "ストレージを解放するために最も古いチャットを削除
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
+msgstr "保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6025,9 +5858,7 @@ msgstr "Duck.aiの音声入力"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されま"
-"せん。"
+msgstr "音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6044,9 +5875,7 @@ msgstr "音声入力は一時的に利用できません"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck."
-"aiチャットができます。"
+msgstr "音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck.aiチャットができます。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6213,7 +6042,7 @@ msgstr "プロモーションを非表示"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "ツアーを閉じる"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6320,15 +6149,13 @@ msgstr "DuckDuckGoがリストにありませんか？"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
+msgstr "表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr ""
-"チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
+msgstr "チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6359,9 +6186,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供さ"
-"れず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6369,9 +6194,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr ""
-"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能"
-"は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6431,7 +6254,7 @@ msgstr "DuckDuckGoをダウンロード"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "DuckDuckGoをダウンロード"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6486,9 +6309,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr ""
-"シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成しま"
-"す。内容は、簡潔かつ詳細に入力してください。"
+msgstr "シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成します。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6496,9 +6317,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr ""
-"家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容"
-"は、簡潔かつ詳細に入力してください。"
+msgstr "家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6518,9 +6337,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか"
-"作成してください。"
+msgstr "今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6528,9 +6345,7 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr ""
-"チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をい"
-"くつか作成してください。"
+msgstr "チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をいくつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6652,7 +6467,7 @@ msgstr "Duck.ai by DuckDuckGo。プライベートAIチャット。無料。"
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.aiでPDFを解析できるようになりました。ぜひお試しください！"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6664,8 +6479,7 @@ msgid ""
 msgstr ""
 "Duck.aiは、現在表示しているページに関する質問に回答できるようになりました。\n"
 "\n"
-"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したと"
-"きにのみ含まれます。"
+"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したときにのみ含まれます。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6674,10 +6488,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。"
-"ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しくださ"
-"い。"
+msgstr "Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6685,16 +6496,13 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr ""
-"Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してくだ"
-"さい。"
+msgstr "Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
+msgstr "Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6703,9 +6511,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻"
-"したいユーザーのためにオンライン保護に取り組む独立系企業です。"
+msgstr "Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻したいユーザーのためにオンライン保護に取り組む独立系企業です。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6719,9 +6525,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが"
-"「https://duck.ai」と覚えやすくなります"
+msgstr "Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが「https://duck.ai」と覚えやすくなります"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6735,18 +6539,14 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」"
-"を%2$s宛てにメールで送信してください"
+msgstr "Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してくださ"
-"い。"
+msgstr "Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6759,10 +6559,7 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr ""
-"Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiの"
-"ボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスで"
-"きます。"
+msgstr "Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiのボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスできます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6773,10 +6570,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデル"
-"と匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタ"
-"ンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://"
-"duck.ai%2$s に直接アクセスすることでDuck.aiを利用できます。"
+""
+"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデルと匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://duck.ai%2$s "
+"に直接アクセスすることでDuck.aiを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6790,9 +6586,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr ""
-"Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用"
-"できます。"
+msgstr "Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用できます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6805,14 +6599,13 @@ msgstr "Duck.aiでPDFを読み、解析できるようになりました。ぜ�
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr ""
-"Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
+msgstr "Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.aiはAnthropicやOpenAIなどのモデルをサポートしています。"
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6830,8 +6623,7 @@ msgstr "Duck.aiがアップグレードしました！"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
+msgstr "Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6841,9 +6633,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、プライベートAIチャットボット、無料AIチャット、匿名AI"
-"チャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オー"
-"プンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
+"Duck.ai、DuckDuckGo "
+"AI、プライベートAIチャットボット、無料AIチャット、匿名AIチャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オープンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6871,11 +6662,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。"
-"DuckAssistの表示頻度は、なし（検索結果からDuckAssist UIを完全に削除）、オンデ"
-"マンド（[アシスト] ボタンをクリックした場合にのみ表示）、時々（関連性の高い場"
-"合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点で"
-"は、米国（英語）地域でのみ利用可能です。"
+"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。DuckAssistの表示頻度は、なし（検索結果からDuckAssist "
+"UIを完全に削除）、オンデマンド（[アシスト] "
+"ボタンをクリックした場合にのみ表示）、時々（関連性の高い場合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点では、米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6884,9 +6673,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他か"
-"らチャットモデルをサポートするプライベートAI搭載チャットサービ"
-"ス、%1$sDuckDuckGo AI Chat%2$sもご利用いただけます。"
+""
+"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他からチャットモデルをサポートするプライベートAI搭載チャットサービス、%1$sDuckDuckGo "
+"AI Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6895,8 +6684,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャット"
-"モデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
+""
+"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャットモデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
 "Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
@@ -6909,11 +6698,9 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 こ"
-"れを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、"
-"AIを活用した自然言語技術を使用して情報の要約を生成します。 現時点での回答は"
-"Wikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご"
-"注意ください。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 "
+"これを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、AIを活用した自然言語技術を使用して情報の要約を生成します。 "
+"現時点での回答はWikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご注意ください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6927,22 +6714,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション"
-"機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI を活用した"
-"自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssist"
-"の回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのた"
-"め、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成さ"
-"れ、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重"
-"要です。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI "
+"を活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssistの回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのため、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr ""
-"DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認さ"
-"れません。"
+msgstr "DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認されません。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6950,9 +6730,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続"
-"行してください。"
+msgstr "DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6961,8 +6739,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
-"いるプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI "
+"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6971,8 +6749,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
-"いるプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI "
+"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6980,9 +6758,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr ""
-"DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される"
-"可能性があります。"
+msgstr "DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される可能性があります。"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6990,9 +6766,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード"
-"「%1$s」を%2$s宛てにメールで送信してください"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7000,17 +6774,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直"
-"してください。"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しくださ"
-"い。"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7128,18 +6898,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的"
-"に削除することで、これらのレポートを匿名化します。"
+msgstr "DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的に削除することで、これらのレポートを匿名化します。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに"
-"同意したことになります。"
+msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7147,9 +6913,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同"
-"意したことになります。"
+msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7157,9 +6921,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による"
-"追跡行為を阻止することができます。"
+msgstr "DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による追跡行為を阻止することができます。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7171,12 +6933,8 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する"
-"場合、ローカルデバイスだけに保存されます。DuckDuckGo は検索時にユーザーのデバ"
-"イスから送信される位置情報を検索結果を向上するために使用します。位置情報は使"
-"用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様の"
-"プライバシーを保護するため、当社がどのようにこの技術を設計したかについては、"
-"こちらをご覧ください%2$s。"
+"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する場合、ローカルデバイスだけに保存されます。DuckDuckGo "
+"は検索時にユーザーのデバイスから送信される位置情報を検索結果を向上するために使用します。位置情報は使用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様のプライバシーを保護するため、当社がどのようにこの技術を設計したかについては、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7195,9 +6953,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を"
-"表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
+msgstr "DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7282,10 +7038,7 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr ""
-"パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載"
-"されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～"
-"20字のパスフレーズ候補として4、5個の単語が選ばれます。"
+msgstr "パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～20字のパスフレーズ候補として4、5個の単語が選ばれます。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7355,8 +7108,7 @@ msgstr "画像を編集中..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
+msgstr "メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7456,7 +7208,7 @@ msgstr "よく使用するサイトを有効化"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "今すぐ有効化"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7493,9 +7245,7 @@ msgstr "ウェブ検索を有効にする"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後"
-"でいつでも変更できます。"
+msgstr "検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7537,9 +7287,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索"
-"データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
+msgstr "「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7657,8 +7405,7 @@ msgstr "位置情報へのアクセスは必ず %1$s許可%2$s にします。"
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
+msgstr "ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7701,9 +7448,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてくだ"
-"さい。データが新しいパスフレーズで保存されます。"
+msgstr "新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてください。データが新しいパスフレーズで保存されます。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7728,9 +7473,7 @@ msgstr "テキストを入力"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイ"
-"リアス%6$s: d%7$s"
+msgstr "以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイリアス%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7760,7 +7503,7 @@ msgstr "エンターテインメントガイド"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "チャット全体"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7927,13 +7670,13 @@ msgstr "露骨な歌詞"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.aiを探索"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.aiを探索"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8040,7 +7783,7 @@ msgstr "無料"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "無料で任意"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8098,9 +7841,7 @@ msgstr "フィードバックが送信されました"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきま"
-"す。"
+msgstr "お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきます。"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8108,19 +7849,14 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用さ"
-"せていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組ん"
-"で参ります。"
+msgstr "お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用させていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組んで参ります。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆"
-"ペーストしてください。"
+msgstr "以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆ペーストしてください。"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8238,8 +7974,7 @@ msgstr "金融アドバイザー"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
+msgstr "%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8251,9 +7986,7 @@ msgstr "ダウンロードフォルダで<b>%1$s</b>を表示"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックしま"
-"す"
+msgstr "表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックします"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8290,9 +8023,7 @@ msgstr "あなたにとって最も的確な結果を見つけます。"
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されま"
-"す。"
+msgstr "お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されます。"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8355,9 +8086,7 @@ msgstr "霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオ"
-"プションを選択したり、ボタンをクリックする必要がある場合があります。"
+msgstr "DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオプションを選択したり、ボタンをクリックする必要がある場合があります。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8462,7 +8191,7 @@ msgstr "ストレージを解放"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "無料で常に非公開"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8504,9 +8233,7 @@ msgstr "営利目的で共有、使用が可能"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されませ"
-"ん。"
+msgstr "チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8587,9 +8314,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; <strong>[アッ"
-"プデートを確認...]</strong>、次に<strong>[アップデートをインストール]</"
-"strong> を選択します。"
+"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; "
+"<strong>[アップデートを確認...]</strong>、次に<strong>[アップデートをインストール]</strong> を選択します。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8925,9 +8651,7 @@ msgstr "開始"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがです"
-"か。"
+msgstr "VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがですか。"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8941,9 +8665,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これに"
-"は、VPNやその他のプレミアムなプライバシー保護も含まれています。"
+msgstr "DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これには、VPNやその他のプレミアムなプライバシー保護も含まれています。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8953,9 +8675,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。"
-"VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
+msgstr "DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8984,7 +8704,7 @@ msgstr "コンピューターに関するサポートを受ける"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "DuckDuckGoサブスクリプションを使うと、使用上限が増えます。"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8995,9 +8715,7 @@ msgstr "当社のブラウザを使用すれば、設定が失われることは
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロー"
-"ド："
+msgstr "ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロード："
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9027,13 +8745,13 @@ msgstr "最新バージョンを入手"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "アプリをダウンロード"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
+msgstr "DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょう。%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9061,7 +8779,7 @@ msgstr "ご友人にもDuckDuckGoを勧めて私たちの成長を助けてく�
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "開始チェックリスト"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9092,9 +8810,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」 › 「テキストコードをコ"
-"ピー」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」 › 「テキストコードをコピー」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9103,8 +8820,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9114,9 +8831,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックして、次の"
-"コードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックして、次のコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9126,16 +8842,14 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします。ま"
-"たは、リカバリーPDFのQRコードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックします。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
+msgstr "%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9144,8 +8858,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動"
-"し、[位置情報サービス] がオンになっていることを確認します。"
+"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動し、[位置情報サービス] "
+"がオンになっていることを確認します。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9154,8 +8868,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、"
-"[DuckDuckGo] まで下にスクロールします。%3$s%4$s"
+"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、[DuckDuckGo] "
+"まで下にスクロールします。%3$s%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9751,7 +9465,7 @@ msgstr "ヒントを非表示"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "チュートリアルを非表示"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9837,8 +9551,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
+msgstr "Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9865,8 +9578,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"キーボードの %1$s戻る%2$s キーを押して、%3$sDuckDuckGoをリストに保存しま"
-"す。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
+"キーボードの %1$s戻る%2$s "
+"キーを押して、%3$sDuckDuckGoをリストに保存します。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9879,9 +9592,7 @@ msgstr "ミャオ語"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバ"
-"シーが保護されなくなります。"
+msgstr "ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバシーが保護されなくなります。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9930,9 +9641,7 @@ msgstr "猛暑"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr ""
-"ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様の"
-"プロファイリングには使用されません。"
+msgstr "ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10194,9 +9903,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズは"
-"どんなものですか、またその理由は何ですか？"
+msgstr "私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズはどんなものですか、またその理由は何ですか？"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10231,8 +9938,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセッ"
-"ト] > [位置情報とプライバシー設定をリセット]%2$s の順に移動します。"
+"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセット] > [位置情報とプライバシー設定をリセット]%2$s "
+"の順に移動します。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10242,9 +9949,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク "
-"> [メニュー] > [設定] > [サイト設定] > [位置情報]%2$s の順に移動し、"
-"DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
+"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク > [メニュー] > [設定] > [サイト設定] > "
+"[位置情報]%2$s の順に移動し、DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10258,9 +9964,7 @@ msgstr "このエラーが続く場合は、%1$sに連絡してください。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追"
-"加する必要があります"
+msgstr "%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追加する必要があります"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10269,8 +9973,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"チャット プロバイダーまたは特定のチャット応答についてご不明な点がある場合"
-"は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
+"チャット "
+"プロバイダーまたは特定のチャット応答についてご不明な点がある場合は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10278,18 +9982,13 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこの"
-"コードが必要になります。このコードはテキストファイルとしてデバイスに保存でき"
-"ます。"
+msgstr "デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこのコードが必要になります。このコードはテキストファイルとしてデバイスに保存できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力くだ"
-"さい%2$s"
+msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力ください%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10298,18 +9997,14 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンを"
-"ご利用ください。"
+msgstr "Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンをご利用ください。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択して"
-"ください。"
+msgstr "ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択してください。"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10449,9 +10144,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレ"
-"クトする必要があります。%1$sさらに詳しく%2$s。"
+msgstr "古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレクトする必要があります。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10461,9 +10154,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同"
-"期」を選択します。"
+msgstr "DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同期」を選択します。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10477,9 +10168,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に"
-"保存されている情報を正確に知ることができます。"
+msgstr "情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に保存されている情報を正確に知ることができます。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10489,8 +10178,7 @@ msgstr "上部のメニューから%1$sツール%2$s > %3$s設定%4$sを選択"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
+msgstr "ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10816,8 +10504,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
+msgstr "この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10885,11 +10572,7 @@ msgid ""
 "Items are ranked based on relevance to your search terms and are delivered "
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
-msgstr ""
-"アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告"
-"ネットワークを通じて配信されます。クリック後はマーチャントのランディングペー"
-"ジに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け"
-"取ることはありません。"
+msgstr "アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告ネットワークを通じて配信されます。クリック後はマーチャントのランディングページに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け取ることはありません。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10897,9 +10580,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっ"
-"と安全です。"
+msgstr "ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっと安全です。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11370,7 +11051,7 @@ msgstr "DuckDuckGo を使って匿名で検索しましょう"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11446,7 +11127,7 @@ msgstr "ラインアウト獲得"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "リンクは7日後に期限切れとなります。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12099,9 +11780,7 @@ msgstr "ミクロネシア"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試し"
-"ください。"
+msgstr "マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12544,7 +12223,7 @@ msgstr "20 分以上"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "その他のヒント"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12866,11 +12545,7 @@ msgid ""
 "DuckDuckGo server after being sent, to help recover a chat if you lose your "
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
-msgstr ""
-"新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的"
-"に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立"
-"ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロ"
-"ンプトと応答の一時的な保存が無効になります。"
+msgstr "新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13037,7 +12712,7 @@ msgstr "いいえ、結構です"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "いいえ、結構です"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13185,8 +12860,7 @@ msgstr "結果が見つかりません。"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
+msgstr "音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13692,9 +13366,7 @@ msgstr "オンデマンド"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順"
-"に%5$sクリックしてください"
+msgstr "Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順に%5$sクリックしてください"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13706,7 +13378,7 @@ msgstr "有効、ただし数字なし"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "オンボーディング完了"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13721,9 +13393,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルを"
-"アップロードしてください。"
+msgstr "添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルをアップロードしてください。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13749,8 +13419,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
+msgstr "変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13764,9 +13433,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおい"
-"てからもう一度試してください。"
+msgstr "おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおいてからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13923,7 +13590,7 @@ msgstr "画像の作成と編集の提案を開く"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "開始チェックリストを開く"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14088,9 +13755,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡していま"
-"す。私たちは追跡しません。"
+msgstr "他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡しています。私たちは追跡しません。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14102,18 +13767,14 @@ msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr ""
-"私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しま"
-"せん。"
+msgstr "私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しません。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、"
-"強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
+msgstr "当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14365,9 +14026,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情"
-"報をファイルに関連付けないため、パスフレーズを復元できません。"
+msgstr "当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情報をファイルに関連付けないため、パスフレーズを復元できません。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14566,10 +14225,7 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr ""
-"検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能"
-"性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検"
-"索設定%2$sにアクセスしてください。"
+msgstr "検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検索設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14578,9 +14234,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精"
-"度が高くなります。 この機能の動作を調整したり、オフにするには、%1$sDuckAssist"
-"設定%2$sにアクセスしてください。"
+"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精度が高くなります。 "
+"この機能の動作を調整したり、オフにするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14589,10 +14244,7 @@ msgid ""
 "DuckAssist more likely to appear automatically and often yields better "
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
-msgstr ""
-"検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精"
-"度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設"
-"定%2$sにアクセスしてください。"
+msgstr "検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14624,8 +14276,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14633,8 +14284,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14642,9 +14292,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGo"
-"の保護が付属しません。"
+msgstr "目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGoの保護が付属しません。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14668,7 +14316,7 @@ msgstr "ピン"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "チャットをピン留め"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14680,7 +14328,7 @@ msgstr "%1$s %2$sからここにチャットをピン留めします"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "これをピン留め"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14703,7 +14351,7 @@ msgstr "ピン留め済み"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "ピン留めされたチャットは、最近のチャットの先頭に表示されます。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14744,9 +14392,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"このプロンプトがボットにより行われていないことを確認するため、次のチャレンジ"
-"を完了してください。"
+msgstr "このプロンプトがボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14754,9 +14400,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"この検索がボットにより行われていないことを確認するため、次のチャレンジを完了"
-"してください。"
+msgstr "この検索がボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14788,9 +14432,7 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
-msgstr ""
-"注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除され"
-"ます。"
+msgstr "注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除されます。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14798,9 +14440,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害また"
-"は違法である理由を説明してください。"
+msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害または違法である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14808,9 +14448,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法また"
-"は有害である理由を説明してください。"
+msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法または有害である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15024,7 +14662,7 @@ msgstr "フォーマットが不十分"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
+msgstr "人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャットは匿名化されます。"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15238,7 +14876,7 @@ msgstr "前のタブ"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "前のヒント"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15533,9 +15171,7 @@ msgstr "確認する"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示し"
-"ます。"
+msgstr "ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示します。"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15577,9 +15213,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独"
-"自のテキストを挿入します。]"
+msgstr "次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独自のテキストを挿入します。]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15784,13 +15418,13 @@ msgstr "中度のモデレーションが組み込まれた推論AI"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "推論により、複雑な質問に対してより適切な回答が得られます。"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "推論はきめ細かくなりますが、2～5倍早く使用制限に達します。%1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15831,7 +15465,7 @@ msgstr "最近のチャットのストレージは%1$sで調整できます。"
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "最近のチャット"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15839,9 +15473,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
-"バイスにローカルで保存されます。"
+msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15849,9 +15481,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
-"バイスにローカルで保存されます。"
+msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15860,10 +15490,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポン"
-"スは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、イ"
-"ンターネット接続が途切れた場合のチャット復旧に役立ちます。"
+msgstr "最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15991,16 +15618,14 @@ msgstr "使用を減らす"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "より効率的なモデルを使うと、使用量が減ります"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr ""
-"結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズ"
-"を縮小します"
+msgstr "結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズを縮小します"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16141,8 +15766,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッ"
-"シュ）]、または [Reload（再読み込み）] ボタンをクリックします。"
+"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッシュ）]、または [Reload（再読み込み）] "
+"ボタンをクリックします。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16231,18 +15856,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
-"します。キャッシュされた回答は常に自動的に表示されます。"
+msgstr "「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
-"します。キャッシュされた回答は常に自動的に表示されます。"
+msgstr "「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16299,18 +15920,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の"
-"匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
+msgstr "レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個"
-"人を特定できる情報を含めないようお願いいたします。"
+msgstr "DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16318,10 +15935,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべ"
-"てのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を"
-"特定できる情報を含めないようお願いいたします。"
+msgstr "DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべてのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16371,7 +15985,7 @@ msgstr "すべての設定をリセット"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "チュートリアルをリセット"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16389,7 +16003,7 @@ msgstr "解像度"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "応答"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16412,10 +16026,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
-"イスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象"
-"です。"
+msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象です。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16423,10 +16034,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
-"イスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象"
-"になります。"
+msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象になります。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16436,10 +16044,9 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なア"
-"ドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて"
-"生成されているため、不正確な情報が含まれている可能性があります。Search Assist"
-"には、当社の%1$s利用規約%2$sが適用されます。"
+""
+"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なアドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて生成されているため、不正確な情報が含まれている可能性があります。Search "
+"Assistには、当社の%1$s利用規約%2$sが適用されます。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16863,9 +16470,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージ"
-"を使用すれば、さらに多くのチャットを保存できます。"
+msgstr "最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージを使用すれば、さらに多くのチャットを保存できます。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16878,9 +16483,7 @@ msgstr "最新のチャットを最大30件デバイスにローカルで保存�
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょ"
-"う。"
+msgstr "エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょう。"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17027,9 +16630,7 @@ msgstr "下方向にスクロールし、%1$s詳細設定を表示%2$s をクリ
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変"
-"更%4$s (または %5$s新たに追加%6$s) をクリックします"
+msgstr "%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) をクリックします"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17038,8 +16639,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変"
-"更%4$s (または %5$s新たに追加%6$s) をクリックします。"
+"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) "
+"をクリックします。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17063,9 +16664,7 @@ msgstr "%1$sDuckDuckGo%2$sまで下にスクロールし、位置情報の使用
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s "
-"をクリックします。"
+msgstr "%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s をクリックします。"
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17093,7 +16692,7 @@ msgstr "%1$sを検索してお近くの検索結果を表示しますか？"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "検索とDuck.aiの切り替え"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17119,20 +16718,17 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コン"
-"テンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻"
-"度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々"
-"（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。"
-"Search Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
+"Search "
+""
+"Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コンテンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。Search "
+"Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr ""
-"Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけること"
-"ができませんでした。別の検索をお試しください。"
+msgstr "Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけることができませんでした。別の検索をお試しください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17141,9 +16737,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。こ"
-"れを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情"
-"報に基づいてAIを使って簡潔な回答を生成します。"
+"Search "
+"Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。これを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情報に基づいてAIを使って簡潔な回答を生成します。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17263,9 +16858,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、"
-"Wikipediaで「ducks」を直接検索します。"
+msgstr "%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、Wikipediaで「ducks」を直接検索します。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17283,10 +16876,7 @@ msgstr "プライベートに検索し、トラッカーをブロック"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りの"
-"ブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索"
-"できます。"
+msgstr "検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りのブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17305,10 +16895,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されます"
-"が、設定をクラウド上のリモートサーバーに匿名で保存できるCloud Saveもご利用い"
-"ただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズが"
-"ブラウザの外に送信されることもありません。"
+"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されますが、設定をクラウド上のリモートサーバーに匿名で保存できるCloud "
+"Saveもご利用いただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズがブラウザの外に送信されることもありません。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17410,9 +16998,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべてのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17420,9 +17006,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべてのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17430,9 +17014,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべての同期済みのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべての同期済みのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17440,9 +17022,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべ"
-"てのデバイスからアクセスできます。"
+msgstr "チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべてのデバイスからアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17456,15 +17036,13 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。"
-"DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr "データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "当社の暗号化サーバーに安全に保存されます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17608,41 +17186,35 @@ msgstr "Safariメニューの%1$s「このウェブサイトの設定...」%2$s 
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
+msgstr "%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
+msgstr "%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr "リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17654,9 +17226,7 @@ msgstr "検索エンジンから%1$sDuckDuckGo%2$sを選択してください"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択"
-"してください"
+msgstr "%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択してください"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17667,8 +17237,7 @@ msgstr "選ぶなら%1$sDuckDuckGo%2$s！"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
+msgstr "ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17681,9 +17250,7 @@ msgstr "ドロップダウンメニューの%1$sアドオン管理%2$sを選択�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$s"
-"メニュー > 設定%4$sの順に選択してください"
+msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$sメニュー > 設定%4$sの順に選択してください"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17691,8 +17258,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合"
-"は、%3$sOpera > オプション%4$sの順に選択してください"
+"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合は、%3$sOpera > "
+"オプション%4$sの順に選択してください"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17711,8 +17278,7 @@ msgstr "%1$s検索エンジン%2$s を選択"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
+msgstr "%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17757,17 +17323,13 @@ msgstr "%1$s設定%2$sを選択し、%3$s検索エンジン%4$sを選択して�
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオ"
-"プションをどれか一つどうぞ)"
+msgstr "%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオプションをどれか一つどうぞ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$s"
-"します"
+msgstr "リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17839,9 +17401,7 @@ msgstr "選択テキストの参照元：%1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しくだ"
-"さい。"
+msgstr "選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17884,9 +17444,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これら"
-"の指示は、今後のすべての会話に適用されます。"
+msgstr "AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これらの指示は、今後のすべての会話に適用されます。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17987,7 +17545,7 @@ msgstr "ホームページに設定する"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Duck.aiの回答のトーンとスタイルを設定します。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18001,9 +17559,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるように"
-"Sync & Backupを設定します。"
+msgstr "チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるようにSync & Backupを設定します。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18058,13 +17614,13 @@ msgstr "セーシェル"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "共有"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "共有"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18101,16 +17657,14 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お"
-"客様の正確な位置情報を当社や AI モデルに決して公開しません。"
+msgstr "都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お客様の正確な位置情報を当社や AI モデルに決して公開しません。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "チャットを共有"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18174,7 +17728,7 @@ msgstr "肯定的なフィードバックを共有する"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "共有スコープ"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18198,9 +17752,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事"
-"象の報告には必須）"
+msgstr "プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事象の報告には必須）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18315,7 +17867,7 @@ msgstr "詳細を表示"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Duck.aiのチュートリアルを表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18326,9 +17878,7 @@ msgstr "DuckAssist<sup>ベータ版</sup>を表示"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできま"
-"す。）"
+msgstr "DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできます。）"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18470,7 +18020,7 @@ msgstr "さらに表示"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "他のモデルを表示"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18511,7 +18061,7 @@ msgstr "サイドバーを表示する"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18565,18 +18115,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオ"
-"フにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
+msgstr "DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオフにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これを"
-"オフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
+msgstr "DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これをオフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18613,8 +18159,7 @@ msgstr "DuckDuckGoを端末に追加するリマインダーを随時表示"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
+msgstr "DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18635,9 +18180,7 @@ msgstr "入力に応じて検索ボックスの下に検索候補を表示"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表"
-"示"
+msgstr "ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18874,8 +18417,7 @@ msgstr "サーバーへの保存が失敗しました。再度お試しくださ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
+msgstr "Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18887,7 +18429,7 @@ msgstr "問題が発生しました。後ほどもう一度お試しください
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "問題が発生しました。もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18905,8 +18447,7 @@ msgstr "時々表示する"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
+msgstr "申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18944,9 +18485,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像また"
-"は形式を試してください。"
+msgstr "申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像または形式を試してください。"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18954,17 +18493,13 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされ"
-"たことを確認してください。"
+msgstr "申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされたことを確認してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
-msgstr ""
-"申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai "
-"に聞いてみてください。"
+msgstr "申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai に聞いてみてください。"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18972,17 +18507,13 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行す"
-"るには、%1$sこちらをクリック%2$sしてください。"
+msgstr "申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行するには、%1$sこちらをクリック%2$sしてください。"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてか"
-"らもう一度試してください。"
+msgstr "申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19036,9 +18567,7 @@ msgstr "ソーステキストが消去されました"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度"
-"お試しください。"
+msgstr "ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19190,7 +18719,7 @@ msgstr "週間制限の使用を開始"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "新しいチャットを開始"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19243,8 +18772,7 @@ msgstr "DuckDuckGoを使用し続ける"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
+msgstr "プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19388,9 +18916,7 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr ""
-"Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像"
-"を作成してください。"
+msgstr "Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像を作成してください。"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19458,8 +18984,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
+msgstr "手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19776,7 +19301,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "他のモデルの回答に切り替え"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19789,8 +19314,7 @@ msgstr "%1$sに切り替えました"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
+msgstr "切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19893,25 +19417,21 @@ msgid ""
 msgstr ""
 "同期リカバリーコード\n"
 "\n"
-"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複"
-"数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同"
-"期済みのデータを回復できます。\n"
+""
+""
+"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同期済みのデータを回復できます。\n"
 "\n"
 "この情報は安全に保管してください。\n"
-"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできま"
-"す。\n"
+"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできます。\n"
 "\n"
 "%1$s\n"
 "\n"
 "このコードの仕組みは？\n"
 "1. ブラウザでDuck.aiにアクセスし、Duck.aiの設定を開きます。\n"
-"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択しま"
-"す\n"
-"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付"
-"けます\n"
+"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択します\n"
+"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付けます\n"
 "\n"
-"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除さ"
-"れ、復元できなくなります。"
+"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除され、復元できなくなります。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19935,7 +19455,7 @@ msgstr "Sync & Backupは一時的にご利用いただけません"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "デバイス間でチャットを同期"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20030,7 +19550,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
+msgstr "Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、無料アプリに組み込めます。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20038,7 +19558,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
+msgstr "Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこからでも素早くアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20061,8 +19581,7 @@ msgstr "個人データを自己管理しましょう！"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
+msgstr "この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20276,10 +19795,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情"
-"報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワード"
-"や支払い情報がこうした情報に含まれる場合もあります。"
+msgstr "つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワードや支払い情報がこうした情報に含まれる場合もあります。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20287,9 +19803,7 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr ""
-"Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動"
-"保存できます。"
+msgstr "Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動保存できます。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20318,18 +19832,14 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr ""
-"暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本"
-"人だけです。"
+msgstr "暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本人だけです。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除しま"
-"す。"
+msgstr "モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除します。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20343,8 +19853,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
+msgstr "モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20402,9 +19911,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確"
-"認し、ローカルデータの保存が有効になっていることをご確認ください。"
+msgstr "このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確認し、ローカルデータの保存が有効になっていることをご確認ください。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20418,9 +19925,7 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr ""
-"検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してくださ"
-"い。"
+msgstr "検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してください。"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20438,10 +19943,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加す"
-"るために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoを"
-"デフォルトの検索エンジンにするために使用されます。"
+msgstr "これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加するために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoをデフォルトの検索エンジンにするために使用されます。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20478,9 +19980,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみ"
-"てください。"
+msgstr "このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20488,9 +19988,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャッ"
-"トを開始してください。"
+msgstr "このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャットを開始してください。"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20508,7 +20006,7 @@ msgstr "今月"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "この応答"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20520,7 +20018,7 @@ msgstr "今週"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "このチャットはDuck.aiに残り、非公開に保たれます。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20528,10 +20026,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AI"
-"チャットでは不正確な情報や不快な情報が表示される場合があります（詳細について"
-"は%4$sを参照してください）。"
+msgstr "この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20540,10 +20035,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AI"
-"チャットでは不正確な情報や不快な内容が表示される場合があります（詳細について"
-"は%2$sを参照してください）。"
+msgstr "この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な内容が表示される場合があります（詳細については%2$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20551,9 +20043,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な"
-"情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
+msgstr "この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20563,9 +20053,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI Chat（%1$s）で生成されま"
-"した。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細"
-"については%4$sを参照してください）。"
+"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI "
+"Chat（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20597,8 +20086,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20606,8 +20094,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20638,18 +20125,14 @@ msgstr "この画像は作成できませんでした。"
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
-"さい。"
+msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
-"さい。"
+msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20662,7 +20145,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
+msgstr "これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択すると、チャットの先頭に固定できます！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20670,7 +20153,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
+msgstr "これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してください！"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20690,9 +20173,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除しま"
-"す。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
+msgstr "このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除します。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20700,9 +20181,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"このモデルプロバイダーはこのチャットに関連するデータを保存していません。他の"
-"モデルプロバイダーは限定的なデータ保持モデルを採用しています。"
+msgstr "このモデルプロバイダーはこのチャットに関連するデータを保存していません。他のモデルプロバイダーは限定的なデータ保持モデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20738,9 +20217,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後"
-"でどのブラウザからでもアクセスできます。"
+msgstr "チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後でどのブラウザからでもアクセスできます。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20748,9 +20225,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
-"すると、AI支援の回答が再表示されることがあります。"
+msgstr "この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20760,9 +20235,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
-"すると、AI支援の回答が再表示されることがあります。ただし、%1$s にはAI支援の回"
-"答が一切表示されないスタートページもご用意しています。"
+""
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。ただし、%1$s "
+"にはAI支援の回答が一切表示されないスタートページもご用意しています。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20785,16 +20260,13 @@ msgstr "この翻訳は正しくありません"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能で"
-"す。"
+msgstr "この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能です。"
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
+msgstr "このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20804,9 +20276,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除さ"
-"れ、Sync & Backupとの接続は解除されます。Sync & Backupに接続している他のブラ"
-"ウザでは、引き続きチャットにアクセスできます。"
+"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除され、Sync & Backupとの接続は解除されます。Sync & "
+"Backupに接続している他のブラウザでは、引き続きチャットにアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20814,9 +20285,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。こ"
-"の操作は取り消せません。"
+msgstr "これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。この操作は取り消せません。"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20953,9 +20422,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印"
-"刷アイコンをクリックします。%4$s"
+msgstr "ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印刷アイコンをクリックします。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20964,10 +20431,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"同期したデータを復元するには、同期を初めて設定したときに保存したリカバリー"
-"コードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保"
-"存されている可能性があります。"
+msgstr "同期したデータを復元するには、同期を初めて設定したときに保存したリカバリーコードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保存されている可能性があります。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20975,18 +20439,14 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアッ"
-"プデートし、再度お試しください。"
+msgstr "チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアップデートし、再度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr ""
-"音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるよ"
-"うに設定してください。"
+msgstr "音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるように設定してください。"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21008,7 +20468,7 @@ msgstr "今日"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
+msgstr "トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にできます。%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21181,9 +20641,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、"
-"ブロック件数が表示されるようになります。"
+msgstr "DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、ブロック件数が表示されるようになります。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21230,9 +20688,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって"
-"行けばいいですか？」"
+msgstr "この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21240,9 +20696,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行け"
-"ばいいですか？」"
+msgstr "この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21350,8 +20804,7 @@ msgstr "%1$sを試す"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr ""
-"このようなメッセージが表示されないようにするには、%1$sをお試しください。"
+msgstr "このようなメッセージが表示されないようにするには、%1$sをお試しください。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -21361,9 +20814,7 @@ msgstr "プロバイダーの可視性がゼロの最初のモデル%1$sをお�
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試し"
-"を！"
+msgstr "%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試しを！"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -21428,7 +20879,7 @@ msgstr "試してみよう"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "別のモデルを試す"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21439,7 +20890,7 @@ msgstr "検索を試そう！"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "提案を試す"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21474,16 +20925,13 @@ msgstr "別のキーワードを試してみてください。"
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しく"
-"ださい。"
+msgstr "より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しください。"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
+msgstr "検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21510,7 +20958,7 @@ msgstr "無料で試す"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "無料で試す"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21530,7 +20978,7 @@ msgstr "無料でお試しください！安全なVPN、プライベートで高
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "7日間無料トライアル"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21563,7 +21011,7 @@ msgstr "次のようなメッセージを表示しない当ページをご覧く
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "推論を試してみよう"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21586,8 +21034,7 @@ msgstr "位置情報を手動で設定してみてください。"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
+msgstr "%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -21645,8 +21092,7 @@ msgstr "最近追加されたオープンソースのLlama 3.1とMixtralをお�
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
+msgstr "まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21816,7 +21262,7 @@ msgstr "Duck Playerをオンにするとターゲティング広告なしでYouT
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Duck.aiの切り替えをオンにする"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21828,8 +21274,7 @@ msgstr "より正確な結果を得るには、「正確な位置情報」をオ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
+msgstr "より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21873,17 +21318,14 @@ msgstr "「%1$sDuckDuckGo%2$s」と %3$s フォームの最初のフィールド
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Type %sduckduckgo.com%s in the %ssecond form field"
-msgstr ""
-"「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
+msgstr "「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索して"
-"から回答が表示されるまでに、多少タイムラグが生じる場合があります。"
+msgstr "DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索してから回答が表示されるまでに、多少タイムラグが生じる場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22012,18 +21454,14 @@ msgstr "長所と短所を明らかにする"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$s"
-"ページがセレクト%6$s クリックします。"
+msgstr "%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$sページがセレクト%6$s クリックします。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと"
-"入力してください"
+msgstr "%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと入力してください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22033,8 +21471,7 @@ msgstr "%1$s開く%2$s の中から %3$s特定のページを開く%4$s を選�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
+msgstr "%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22044,17 +21481,13 @@ msgstr "%1$s検索設定%2$sで、%3$sDuckDuckGo%4$sを選択します"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$s"
-"を選択します"
+msgstr "%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$sを選択します"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックし"
-"ます"
+msgstr "%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックします"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22143,9 +21576,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上"
-"限がPlusプランの2倍になります。"
+msgstr "Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上限がPlusプランの2倍になります。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22191,7 +21622,7 @@ msgstr "サブスクリプションで高度なAIをアンロックしましょ�
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "高度なモデルにアクセス"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22205,9 +21636,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょ"
-"う。%1$s"
+msgstr "DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょう。%1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22286,9 +21715,7 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr ""
-"DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度な"
-"モデルにアクセスしよう"
+msgstr "DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度なモデルにアクセスしよう"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22412,9 +21839,7 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr ""
-"ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像"
-"を作成してください。"
+msgstr "ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像を作成してください。"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -22515,10 +21940,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、"
-"詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必"
-"要ありません。"
+msgstr "ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必要ありません。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22530,8 +21952,7 @@ msgstr "DuckDuckGo Private Searchを使う"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
+msgstr "あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22559,7 +21980,7 @@ msgstr "Safariで使用"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Fire Buttonを使って履歴からチャットを削除できます。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22567,18 +21988,14 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大"
-"切に保管してください。"
+msgstr "デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大切に保管してください。"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr ""
-"デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを"
-"復元してください。"
+msgstr "デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを復元してください。"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -22727,9 +22144,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは "
-"Microsoft の広告ネットワークで管理されています"
+msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは Microsoft の広告ネットワークで管理されています"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22737,9 +22152,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは"
-"TripAdvisorの広告ネットワークで管理されています。"
+msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックはTripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22750,9 +22163,7 @@ msgstr "ヴァージン諸島"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr ""
-"この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセ"
-"スしてください。"
+msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22760,9 +22171,7 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr ""
-"この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにア"
-"クセスしてください。"
+msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22770,9 +22179,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従って"
-"ください。"
+msgstr "タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従ってください。"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22787,9 +22194,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してくださ"
-"い。"
+"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s "
+"に進み、%7$s別のデバイスと同期%8$sを選択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22798,10 +22204,7 @@ msgid ""
 "Visit Duck.ai in your other browser and open Duck.ai Settings. Select “Turn "
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
-msgstr ""
-"別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆"
-"Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。ま"
-"たは、リカバリーPDFのQRコードをスキャンしてください。"
+msgstr "別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。または、リカバリーPDFのQRコードをスキャンしてください。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22811,9 +22214,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s "
-"> %3$sSync & Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選"
-"択してください。"
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22822,10 +22224,7 @@ msgid ""
 "Visit Duck.ai in your other browser or the DuckDuckGo app and open Duck.ai "
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
-msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開き"
-"ます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択しま"
-"す。または、リカバリーPDFのQRコードをスキャンします。"
+msgstr "他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開きます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択します。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22877,9 +22276,7 @@ msgstr "ボイスチャットは終了しました"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用"
-"されません。"
+msgstr "ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23023,8 +22420,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、"
-"YouTube のおすすめに影響されずに動画を視聴できます。"
+"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、YouTube "
+"のおすすめに影響されずに動画を視聴できます。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23043,11 +22440,7 @@ msgid ""
 "because we have to stream the content from there. DuckDuckGo is an "
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
-msgstr ""
-"このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテン"
-"ツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGo"
-"は独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ござ"
-"いません。"
+msgstr "このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテンツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGoは独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ございません。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23059,8 +22452,7 @@ msgstr "匿名化に対応"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
+msgstr "%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23071,10 +22463,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報する"
-"には、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してし"
-"てください。"
+msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報するには、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してしてください。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23085,9 +22474,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する"
-"場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
+msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23100,9 +22487,7 @@ msgstr "匿名の%1$s位置情報%2$sを使用すると、おおよその結果�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることがで"
-"きません。"
+msgstr "添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることができません。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23129,9 +22514,7 @@ msgstr "私たちはあなたの個人情報を保存しません。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr ""
-"個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束"
-"します。"
+msgstr "個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束します。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23144,9 +22527,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った"
-"理由」を教えてください。"
+msgstr "私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23154,9 +22535,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと"
-"思った理由」を教えてください。"
+msgstr "私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23195,23 +22574,18 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr ""
-"私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であ"
-"なたを追跡して、それを広告主に販売することはありません。"
+msgstr "私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であなたを追跡して、それを広告主に販売することはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しま"
-"せん。"
+msgstr "私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しません。"
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
+msgstr "私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23225,8 +22599,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
+msgstr "チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23250,9 +22623,7 @@ msgstr "接続が失われました。メッセージの送信をもう一度お
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr ""
-"私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索"
-"広告%2$sから収益を得ています。"
+msgstr "私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索広告%2$sから収益を得ています。"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23260,17 +22631,13 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されま"
-"す。この設定は後でいつでも変更できます。"
+msgstr "匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されます。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名"
-"でのフィードバックを頼りにしています。"
+msgstr "DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名でのフィードバックを頼りにしています。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23290,9 +22657,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご"
-"提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
+msgstr "このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23305,9 +22670,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエ"
-"ラーが続く場合は、%1$sに連絡してください。"
+msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエラーが続く場合は、%1$sに連絡してください。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23315,9 +22678,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウ"
-"ザのキャッシュをクリアすると解決に役立つ場合があります。"
+msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウザのキャッシュをクリアすると解決に役立つ場合があります。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23331,9 +22692,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力していま"
-"す。"
+msgstr "ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力しています。"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23341,9 +22700,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr ""
-"Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要"
-"があります。"
+msgstr "Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要があります。"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23464,9 +22821,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのト"
-"レーニングには使用されません。"
+msgstr "Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23474,9 +22829,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、"
-"AIモデルのトレーニングには使用されません。"
+msgstr "DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23486,17 +22839,14 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chatへようこそ！このチャットセッションは%1$sの%2$sを使用してい"
-"ます。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルの"
-"トレーニングに使用されたりすることはありません。"
+"DuckDuckGo AI "
+"Chatへようこそ！このチャットセッションは%1$sの%2$sを使用しています。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルのトレーニングに使用されたりすることはありません。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになり"
-"ました。"
+msgstr "新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになりました。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23563,9 +22913,7 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr ""
-"申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込"
-"みしてみてください。"
+msgstr "申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込みしてみてください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23579,9 +22927,7 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr ""
-"プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありま"
-"すか？"
+msgstr "プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -23601,9 +22947,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をど"
-"う言い換えられますか？"
+msgstr "「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をどう言い換えられますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23621,12 +22965,7 @@ msgid ""
 "ai integrations, and privacy protections. Keep it quite short, simple, and "
 "easy to understand for people with or without much AI, or technical, "
 "experience."
-msgstr ""
-"Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメ"
-"リットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回"
-"答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に"
-"重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、"
-"誰でも簡単に理解できるように回答します。"
+msgstr "Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメリットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、誰でも簡単に理解できるように回答します。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23741,7 +23080,7 @@ msgstr "今日はどういったご用件でお戻りになられましたか？
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "何ができますか？"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23861,9 +23200,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットと"
-"の違いは？"
+msgstr "Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットとの違いは？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23963,9 +23300,7 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr ""
-"初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何です"
-"か？"
+msgstr "初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何ですか？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24165,7 +23500,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
+msgstr "Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはありません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24438,9 +23773,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合"
-"があります。"
+msgstr "%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24448,9 +23781,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検"
-"索できます。"
+msgstr "%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検索できます。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24463,8 +23794,7 @@ msgstr "DuckDuckGo AI Chatには%1$sから直接アクセスできます。"
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
+msgstr "%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24472,22 +23802,17 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr ""
-"Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
+msgstr "Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできま"
-"す。"
+msgstr "%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr ""
-"%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりする"
-"こともできます。"
+msgstr "%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24500,9 +23825,7 @@ msgstr "添付するテキストは最大%1$sまで選択できます。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりで"
-"きます。"
+msgstr "Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24522,9 +23845,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任"
-"意で削除できます。"
+msgstr "設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任意で削除できます。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24553,8 +23874,7 @@ msgstr "月間制限時間を使ってチャットを続行できます。"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
+msgstr "このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24597,7 +23917,7 @@ msgstr "画像は会話ごとに%1$s点しか添付できません。"
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "一度に添付できるタブは%1$s個までです。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24617,9 +23937,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトの"
-"ブロックを解除する必要があります。"
+msgstr "最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトのブロックを解除する必要があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24675,8 +23993,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
+msgstr "これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24684,9 +24001,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスク"
-"リプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
+msgstr "高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスクリプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24707,10 +24022,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
-"チャットはローカルストレージで引き続き利用可能です。これにより、暗号化された"
-"サーバーからチャットデータが削除されることはありません。"
+msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。これにより、暗号化されたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24719,10 +24031,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
-"チャットはローカルストレージで引き続き利用可能です。この操作により、暗号化さ"
-"れたサーバーからチャットデータが削除されることはありません。"
+msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。この操作により、暗号化されたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24735,14 +24044,13 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr ""
-"最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
+msgstr "最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "準備が完了しました！"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24750,10 +24058,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを"
-"使ってもプライベートに閲覧できます。このアプリはすでにインストールされてお"
-"り、以下が可能になります。"
+msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを使ってもプライベートに閲覧できます。このアプリはすでにインストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24765,9 +24070,7 @@ msgstr "あなたは今、匿名で検索しています！"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡を"
-"もっと減らすヒントを学びましょう。"
+msgstr "今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡をもっと減らすヒントを学びましょう。"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24796,7 +24099,7 @@ msgstr "1件のサイトをブロックしました"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Duck.aiの基本をマスターしました"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24816,8 +24119,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
+msgstr "現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24830,14 +24132,12 @@ msgstr "1回のセッションの最大ボイスチャット時間に達しま�
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
+msgstr "本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
+msgstr "ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24846,9 +24146,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"添付ファイル付きのDuck.aiチャットのSync & Backup用ストレージ容量が不足してい"
-"ます。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされ"
-"たチャットは削除されません。"
+"添付ファイル付きのDuck.aiチャットのSync & "
+"Backup用ストレージ容量が不足しています。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24858,9 +24157,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.aiチャットのSync & Backup用ストレージ容量が不足しています。同期を再開す"
-"るには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留め"
-"されたチャットは削除されません。"
+"Duck.aiチャットのSync & "
+"Backup用ストレージ容量が不足しています。同期を再開するには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24873,9 +24171,7 @@ msgstr "ストレージの容量がいっぱいです"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録"
-"されています。"
+msgstr "YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録されています。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24918,10 +24214,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージ"
-"に保存されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24930,10 +24223,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルスト"
-"レージに保存されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24957,18 +24247,14 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr ""
-"お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGo"
-"がこのデータにアクセスすることはありません。"
+msgstr "お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGoがこのデータにアクセスすることはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、"
-"DuckDuckGoはこのデータにアクセスすることはできません。"
+msgstr "ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、DuckDuckGoはこのデータにアクセスすることはできません。"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24976,9 +24262,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示さ"
-"れる場合があります。"
+msgstr "%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24990,50 +24274,41 @@ msgstr "チャットが保存されるようになりました。"
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr ""
-"チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはあ"
-"りません。"
+msgstr "チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
+msgstr "チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
-"されません。"
+msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
-"されません。"
+msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25047,9 +24322,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されま"
-"せん。チャット履歴を保持するには、以下の手順に従ってください。"
+msgstr "チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されません。チャット履歴を保持するには、以下の手順に従ってください。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25057,8 +24330,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
+msgstr "チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25089,9 +24361,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検"
-"索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
+msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25134,10 +24404,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) を使用した512ビットの"
-"キーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残りま"
-"す。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo がお客様の"
-"パスフレーズを知ることはありません。"
+"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) "
+""
+"を使用した512ビットのキーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残ります。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo "
+"がお客様のパスフレーズを知ることはありません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25151,10 +24421,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータ"
-"が取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはで"
-"きません。"
+msgstr "プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータが取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはできません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25167,9 +24434,7 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr ""
-"最近のチャットはここにあります！チャットはいつでも参照したり、消去したりでき"
-"ます。"
+msgstr "最近のチャットはここにあります！チャットはいつでも参照したり、消去したりできます。"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25201,6 +24466,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
+"AI%2$s拡張機能を有効にしてください。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25209,9 +24476,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
-"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能をインストールしてくださ"
-"い。%3$s詳細情報%4$s"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
+"AI%2$s拡張機能をインストールしてください。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25230,10 +24496,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウ"
-"ザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにイン"
-"ストールされており、以下が可能になります。"
+msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにインストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25241,9 +24504,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直して"
-"ください。"
+msgstr "メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25251,9 +24512,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして"
-"続行します。"
+msgstr "この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして続行します。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25261,9 +24520,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始"
-"します。"
+msgstr "この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始します。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25277,15 +24534,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr "1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
+msgstr "ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25368,9 +24623,7 @@ msgstr "（%1$s）"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されて"
-"います。"
+msgstr "DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されています。"
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25583,9 +24836,7 @@ msgstr "公式ウェブサイト"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードし"
-"たものです)"
+msgstr "あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードしたものです)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25801,4 +25052,4 @@ msgstr "年"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ka_GE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ka_GE/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4015,6 +4057,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4069,6 +4116,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4106,6 +4158,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4202,6 +4259,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4236,6 +4298,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4361,6 +4430,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4597,9 +4671,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4627,6 +4711,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4880,6 +4969,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5046,6 +5140,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5221,6 +5320,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5328,6 +5432,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5816,6 +5925,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6055,6 +6169,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6188,6 +6307,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6269,6 +6398,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6598,6 +6732,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7019,6 +7158,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7048,6 +7192,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7064,6 +7218,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7615,6 +7774,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8912,6 +9076,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8967,6 +9137,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9863,6 +10038,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10257,6 +10437,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10805,6 +10990,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "ჩართე მაგრამ ციფრები არა"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10973,6 +11163,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11569,9 +11764,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11586,6 +11791,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11842,6 +12052,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12011,6 +12226,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12453,6 +12673,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12480,6 +12710,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12602,6 +12837,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12904,6 +13144,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12912,6 +13157,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13469,6 +13719,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13749,6 +14004,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14146,6 +14406,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "მთავარ გვერდად დაყენება"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14198,6 +14463,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14227,6 +14502,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14275,6 +14556,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14386,6 +14672,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14510,6 +14801,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14538,6 +14834,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14836,6 +15137,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15068,6 +15374,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15546,6 +15857,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15658,6 +15976,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15727,6 +16050,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16096,9 +16433,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16199,6 +16546,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16455,6 +16816,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16792,8 +17158,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16848,6 +17224,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16858,6 +17239,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16880,6 +17266,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17080,6 +17471,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17364,6 +17760,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17659,6 +18060,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18572,6 +18978,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18911,6 +19322,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19255,6 +19673,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19363,6 +19787,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19397,6 +19826,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19694,6 +20128,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20166,6 +20607,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Load Cloud Settings"

--- a/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
@@ -104,6 +104,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%s muktashif"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -285,6 +290,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -483,6 +493,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 wass aya"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1847,6 +1869,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3081,6 +3108,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3686,6 +3718,11 @@ msgstr "Clipart"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3721,6 +3758,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4028,6 +4070,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4082,6 +4129,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4119,6 +4171,11 @@ msgstr "Nɣel &amp; senṭeḍ %sabout:preferences#search%s ɣer ufeggag n tensa
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4215,6 +4272,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4249,6 +4311,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4374,6 +4443,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4610,9 +4684,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4640,6 +4724,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4893,6 +4982,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5059,6 +5153,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5234,6 +5333,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5341,6 +5445,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5829,6 +5938,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6068,6 +6182,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6201,6 +6320,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6282,6 +6411,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6615,6 +6749,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7036,6 +7175,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7065,6 +7209,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7082,6 +7236,11 @@ msgstr "Awi tizlit-a seg:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Mmeslay d yimeddukal-ik akken ad aɣ-tɛiwneḍ ad nimɣur!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7632,6 +7791,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8935,6 +9099,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Ad k-yeǧǧ ad tnadiḍ s wudem udrig DuckDuckGo"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8990,6 +9160,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9886,6 +10061,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Ugar n 20 n tisdatin"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10280,6 +10460,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10830,6 +11015,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Yermed maca ulac imḍanen"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10999,6 +11189,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11599,9 +11794,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11616,6 +11821,11 @@ msgstr "Axuxi"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11872,6 +12082,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12041,6 +12256,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12483,6 +12703,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12510,6 +12740,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12632,6 +12867,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12934,6 +13174,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Ales awennez n yiɣewwaren meṛṛa"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12942,6 +13187,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13502,6 +13752,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Nadi s wudem urdig"
 
@@ -13784,6 +14039,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14187,6 +14447,11 @@ msgstr "Sbadu-it d amsedday n unadi amezwer"
 msgid "Set as Homepage"
 msgstr "Sbadu d asebter agejdan"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14239,6 +14504,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14268,6 +14543,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14316,6 +14597,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14428,6 +14714,11 @@ msgstr "Sken if_erdisen war isefka"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Sken talqayt"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14551,6 +14842,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14579,6 +14875,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14877,6 +15178,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15109,6 +15415,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15587,6 +15898,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Ddu ɣer umsedday n unadi ur k-yeṭṭafaṛen ara. Ur ǧǧin."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15699,6 +16017,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15769,6 +16092,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Ṭṭef tabaḍnit-ik gar ifassen-ik!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16144,9 +16481,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16247,6 +16594,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16505,6 +16866,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16842,9 +17208,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Ɛreḍ anadi!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16898,6 +17274,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16908,6 +17289,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16931,6 +17317,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Ɛreḍ asebter-nneɣ agejdan ur d-neskan ara iznan-a:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17130,6 +17521,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17418,6 +17814,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17714,6 +18115,11 @@ msgstr "Seqdec deg Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Seqdec deg Safaṛi"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18634,6 +19040,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Acu i k-id-yewwin ass-a?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18973,6 +19384,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19319,6 +19737,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19427,6 +19851,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19463,6 +19892,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19767,6 +20201,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20239,6 +20680,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/kn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/kn_IN/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3080,6 +3107,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3676,6 +3708,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3711,6 +3748,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4018,6 +4060,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4072,6 +4119,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4109,6 +4161,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4205,6 +4262,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4239,6 +4301,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4364,6 +4433,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4600,9 +4674,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4630,6 +4714,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4883,6 +4972,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5049,6 +5143,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5224,6 +5323,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5331,6 +5435,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5821,6 +5930,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6060,6 +6174,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6193,6 +6312,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6274,6 +6403,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6605,6 +6739,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7026,6 +7165,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7055,6 +7199,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7071,6 +7225,11 @@ msgstr "ಈ ಹಾಡನ್ನು ಇಲ್ಲಿ ಪಡೆಯಿರಿ:"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7622,6 +7781,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8920,6 +9084,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8975,6 +9145,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9871,6 +10046,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10265,6 +10445,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10813,6 +10998,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "ಆದರೆ ಯಾವುದೇ ಸಂಖ್ಯೆಗಳನ್ನು"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10981,6 +11171,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11577,9 +11772,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11594,6 +11799,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11850,6 +12060,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12019,6 +12234,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12461,6 +12681,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12488,6 +12718,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12610,6 +12845,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12912,6 +13152,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12920,6 +13165,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13477,6 +13727,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13759,6 +14014,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14156,6 +14416,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "ಮುಖಪುಟವಾಗಿ ಸೆಟ್ ಮಾಡಿ"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14208,6 +14473,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14237,6 +14512,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14285,6 +14566,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14396,6 +14682,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14520,6 +14811,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14548,6 +14844,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14846,6 +15147,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15078,6 +15384,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15556,6 +15867,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15668,6 +15986,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15737,6 +16060,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16106,9 +16443,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16209,6 +16556,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16465,6 +16826,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16802,9 +17168,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "ಹುಡುಕಾಟವನ್ನು ಪ್ರಯತ್ನಿಸಿ!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16858,6 +17234,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16868,6 +17249,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16890,6 +17276,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17090,6 +17481,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17374,6 +17770,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17669,6 +18070,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18582,6 +18988,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18921,6 +19332,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19267,6 +19685,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19375,6 +19799,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19409,6 +19838,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19709,6 +20143,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20182,6 +20623,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s 감지됨"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "파일 %1$s개 사용됨"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -182,9 +182,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
-"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
-"요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
+"이용하거나, Plus 또는 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -194,9 +193,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
-"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
-"요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
+"이용하거나, Plus 또는 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -212,8 +210,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구"
-"독을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
+"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구독을 다시 활성화해서 채팅을 계속 이용하거나, "
+"무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -221,9 +219,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다"
-"시 시도하세요."
+msgstr "%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -314,8 +310,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사"
-"용자의 메시지나 모델의 응답을 보거나 서버에 이 채팅을 저장할 수 없습니다."
+"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사용자의 메시지나 모델의 응답을 보거나 서버에 이 "
+"채팅을 저장할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -362,7 +358,7 @@ msgstr "%1$s 사용"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -400,9 +396,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔"
-"서 이 채팅을 계속할 수 있습니다."
+msgstr "%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -412,9 +406,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채"
-"팅을 계속할 수 있습니다."
+msgstr "%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -426,9 +418,7 @@ msgstr "단어 %1$s개"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합"
-"니다.%7$s"
+msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합니다.%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -436,8 +426,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 "
-"표시한 후 %8$s확인%9$s을 클릭합니다."
+"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 표시한 후 %8$s확인%9$s을 "
+"클릭합니다."
 
 # Firefox
 # smartling.placeholder_format=C
@@ -447,8 +437,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s"
-"에 체크 표시한 후 %8$s확인%9$s을 클릭합니다."
+"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s에 체크 표시한 후 "
+"%8$s확인%9$s을 클릭합니다."
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -456,9 +446,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 "
-"시도해 보세요."
+msgstr "이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -476,16 +464,14 @@ msgstr "%1$s더 알아보기%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
+msgstr "%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
+msgstr "DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -503,8 +489,7 @@ msgstr "홈 화면에서 DuckDuckGo 앱 아이콘을 %1$s길게 누릅니다%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
+msgstr "%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -616,7 +601,7 @@ msgstr "1일 전"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "파일 1개 사용됨"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -837,17 +822,14 @@ msgstr "6시간 사용 제한에 도달했습니다."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr "6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니"
-"다."
+msgstr "6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -900,17 +882,14 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 "
-"확인하고 다시 시도하세요."
+msgstr "Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 확인하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
+msgstr "새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -961,9 +940,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능"
-"을 끄면 DuckDuckGo Search의 AI Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 "
-"%1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 이용할 수 있습니다."
+"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능을 끄면 DuckDuckGo Search의 AI "
+"Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 %1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 "
+"이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1024,10 +1003,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문"
-"을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 제공하는 경우는 많습니다. Duck.ai"
-"는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI 기반 "
-"채팅 서비스입니다."
+"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 "
+"제공하는 경우는 많습니다. Duck.ai는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI "
+"기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1211,9 +1189,7 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr ""
-"이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전"
-"환하세요."
+msgstr "이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1248,18 +1224,14 @@ msgstr "광고"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사"
-"용되지 않습니다."
+msgstr "광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr ""
-"광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 "
-"데 사용되지 않습니다."
+msgstr "광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1309,9 +1281,7 @@ msgstr "DuckDuckGo 확장 프로그램 추가"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세"
-"요."
+msgstr "다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세요."
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1531,7 +1501,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
+msgstr "고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1573,8 +1543,7 @@ msgstr "다운로드가 완료되고 파일이 열리면 %1$s설치%2$s를 클�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
+msgstr "다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1710,8 +1679,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 "
-"대화 내용을 채팅 모델 훈련에 사용하지 않습니다."
+"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 대화 내용을 채팅 모델 훈련에 사용하지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1743,8 +1712,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
+msgstr "모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1758,9 +1726,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니"
-"다."
+msgstr "AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니다."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1791,8 +1757,7 @@ msgstr "허용"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
+msgstr "음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1824,17 +1789,15 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이"
-"터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 보냅니다. %2$s 모델의 프롬"
-"프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
+"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 "
+"보냅니다. %2$s 모델의 프롬프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr ""
-"Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
+msgstr "Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1971,8 +1934,7 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1980,8 +1942,7 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1994,9 +1955,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택"
-"하거나 완전히 비활성화할 수 있습니다."
+msgstr "웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택하거나 완전히 비활성화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2042,9 +2001,7 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr ""
-"Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보"
-"를 들려줘)?"
+msgstr "Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보를 들려줘)?"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2209,8 +2166,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거"
-"나 공유하지 않습니다. 모든 개인정보 보호는 사용자의 기기에서 이루어집니다."
+"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거나 공유하지 않습니다. 모든 개인정보 보호는 "
+"사용자의 기기에서 이루어집니다."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2311,7 +2268,7 @@ msgstr "비공개로 질문하기"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "비공개로 질문하기"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2346,11 +2303,10 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 "
-"생성할 수 있습니다. Assist 표시 빈도 선택 가능: 안 함(검색 결과에서 Assist UI"
-"를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), 가끔(관"
-"련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표"
-"시). 현재 AI 지원 답변은 미국(영어) 지역에서만 이용 가능합니다."
+"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 생성할 수 있습니다. Assist 표시 빈도 선택 "
+"가능: 안 함(검색 결과에서 Assist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), "
+"가끔(관련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표시). 현재 AI 지원 답변은 미국(영어) "
+"지역에서만 이용 가능합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2362,10 +2318,9 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이"
-"며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관"
-"련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤"
-"링%2$s을 기반으로 자동 생성합니다."
+"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 "
+"자연어 기술을 사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 "
+"자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2497,17 +2452,13 @@ msgstr "자동 응답"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습"
-"니다."
+msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 "
-"있습니다."
+msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2532,9 +2483,8 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 "
-"익명으로 정보를 조회하고 요약할 수 있습니다. 현재 Assist 서비스는 영어 사용 "
-"지역에서만 제공됩니다."
+"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
+"현재 Assist 서비스는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2543,16 +2493,14 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색"
-"에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. 현재 DuckAssist 서비스"
-"는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 "
+"수 있습니다. 현재 DuckAssist 서비스는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
+msgstr "영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2752,8 +2700,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데"
-"이터와 같은 개인정보(PII)를 제거하여 대화 내용을 익명화합니다."
+"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데이터와 같은 개인정보(PII)를 제거하여 대화 "
+"내용을 익명화합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3134,18 +3082,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 "
-"%1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 "
-"이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
+"암호화 보호 강화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확"
-"장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 "
-"있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
+"암호화 보호 강화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3153,9 +3099,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으"
-"로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 차단, 사이트 암호화 기능을 이"
-"용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 "
+"차단, 사이트 암호화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3262,10 +3207,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 "
-"Cloud Save를 사용하여 설정을 보다 영구적으로 저장할 수 있습니다(클라우드의 원"
-"격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암"
-"호 또한 서버에 저장되지 않습니다."
+"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 Cloud Save를 사용하여 설정을 보다 영구적으로 "
+"저장할 수 있습니다(클라우드의 원격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호 또한 서버에 저장되지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3273,8 +3217,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
-"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
+"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s "
+"페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3283,8 +3227,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
-"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
+"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 "
+"%1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3319,8 +3263,7 @@ msgstr "카메룬"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
+msgstr "닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3640,9 +3583,7 @@ msgstr "전체 사이트에 적용되는 배경 색상을 변경합니다."
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경"
-"합니다."
+msgstr "검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경합니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3771,9 +3712,8 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 "
-"타사 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 DuckDuckGo "
-"Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 타사 AI 채팅 모델과 익명으로 대화할 "
+"수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
 "%1$shttps://duck.ai%2$s에 바로 접속해서 채팅을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
@@ -3829,18 +3769,14 @@ msgstr "비공개로 채팅하기"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅"
-"하세요."
+msgstr "DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공"
-"개로 채팅하세요."
+msgstr "DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3858,7 +3794,7 @@ msgstr "AI와 비공개 채팅"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "인기 AI와 비공개로 채팅하기"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3908,9 +3844,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채"
-"팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
+msgstr "채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3922,10 +3856,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅"
-"을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버"
-"에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로"
-"운 프롬프트와 응답의 임시 저장이 중단됩니다."
+"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
+"암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 "
+"저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3948,17 +3881,15 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일"
-"은 %2$s의 콘텐츠 조정 공급자에 의한 익명 검토를 거칩니다."
+"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일은 %2$s의 콘텐츠 조정 공급자에 의한 익명 "
+"검토를 거칩니다."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr ""
-"첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화"
-"를 재개할 수 있습니다."
+msgstr "첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화를 재개할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4011,8 +3942,7 @@ msgstr "철자 검사"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
+msgstr "DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4304,9 +4234,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무"
-"기한으로 보관하거나, AI Chat을 7일 이상 사용하지 않으면 자동으로 삭제할 수 있"
-"습니다."
+"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무기한으로 보관하거나, AI Chat을 7일 이상 사용하지 "
+"않으면 자동으로 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4316,9 +4245,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅"
-"이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 사용하지 않으면 자동으로 "
-"삭제될 수도 있습니다."
+"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 "
+"사용하지 않으면 자동으로 삭제될 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4326,9 +4254,7 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr ""
-"브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 "
-"DuckDuckGo 무료 브라우저에"
+msgstr "브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 DuckDuckGo 무료 브라우저에"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4337,9 +4263,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모"
-"델을 지원하는 DuckDuckGo의 비공개 AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 "
-"후속 질문을 하세요."
+"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 "
+"AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 후속 질문을 하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4380,9 +4305,7 @@ msgstr "드롭다운 메뉴에서 %1$s검색 설정 변경%2$s을 클릭하세�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환"
-"경설정%4$s을 클릭하세요."
+msgstr "Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환경설정%4$s을 클릭하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4398,9 +4321,7 @@ msgstr "DuckDuckGo 확장 프로그램을 다운로드하려면 %1$s여기%2$s�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세"
-"요."
+msgstr "%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세요."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4414,9 +4335,7 @@ msgstr "왼쪽 사이드바에서 %1$s개인정보 및 서비스%2$s를 클릭�
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s"
-"기어 모양 아이콘%4$s을 클릭하세요)."
+msgstr "상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s기어 모양 아이콘%4$s을 클릭하세요)."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4445,8 +4364,7 @@ msgstr "%1$s예%2$s를 클릭하세요."
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
+msgstr "Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4508,9 +4426,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지"
-"만 브라우저에는 남아있습니다. 남아있는 데이터를 제거하려면 %3$s모든 검색 설"
-"정 초기화%4$s를 클릭하거나 누르세요."
+"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지만 브라우저에는 남아있습니다. 남아있는 데이터를 "
+"제거하려면 %3$s모든 검색 설정 초기화%4$s를 클릭하거나 누르세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4521,9 +4438,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서"
-"는 데이터가 삭제되지만, %3$s모든 설정 초기화%4$s를 클릭하거나 누를 때까지 브"
-"라우저에는 데이터가 남아 있게 됩니다."
+"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서는 데이터가 삭제되지만, %3$s모든 설정 "
+"초기화%4$s를 클릭하거나 누를 때까지 브라우저에는 데이터가 남아 있게 됩니다."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4591,18 +4507,14 @@ msgstr "검색 창에서 드롭다운을 클릭하세요."
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 "
-"%3$sDuckDuckGo%4$s를 선택하세요."
+msgstr "주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 %3$sDuckDuckGo%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr ""
-"광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리"
-"에 있습니다."
+msgstr "광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리에 있습니다."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4648,7 +4560,7 @@ msgstr "닫기"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "닫기"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4698,7 +4610,7 @@ msgstr "검색 닫기"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "다른 답변 닫기"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4802,9 +4714,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 "
-"수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
+msgstr "Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5075,7 +4985,7 @@ msgstr "광고 차단 계속하기"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5146,7 +5056,7 @@ msgstr "쿠키 데이터:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "복사됨"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5187,8 +5097,7 @@ msgstr "복사"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
+msgstr "주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5200,7 +5109,7 @@ msgstr "코드 복사"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "링크 복사"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5319,7 +5228,7 @@ msgstr "이미지 만들기"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "공유 링크 생성"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5370,7 +5279,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
+msgstr "링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5529,7 +5438,7 @@ msgstr "응답 맞춤 설정"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "응답 맞춤 설정"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5596,17 +5505,14 @@ msgstr "일일 한도에 도달했습니다."
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr "일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있"
-"습니다."
+msgstr "일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5820,7 +5726,7 @@ msgstr "서버 데이터를 삭제하시겠습니까?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "공유 링크 삭제"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5832,7 +5738,7 @@ msgstr "녹취록 삭제"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "채팅 삭제"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5870,7 +5776,7 @@ msgstr "이미지를 삭제할래?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "삭제해 보세요"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5996,8 +5902,7 @@ msgstr "Duck.ai 받아쓰기"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr "당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6014,9 +5919,7 @@ msgstr "받아쓰기를 일시적으로 사용할 수 없습니다"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력"
-"하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
+msgstr "받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6183,7 +6086,7 @@ msgstr "프로모션 무시하기"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "둘러보기 닫기"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6290,9 +6193,7 @@ msgstr "목록에 DuckDuckGo가 보이지 않으시나요?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요."
-"%4$s"
+msgstr "파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6330,8 +6231,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 "
-"AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 AI 이미지를 걸러냅니다. "
+"%3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6340,8 +6241,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하"
-"지 않고 AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하지 않고 AI 이미지를 걸러냅니다. "
+"%3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6401,7 +6302,7 @@ msgstr "DuckDuckGo 다운로드"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "DuckDuckGo 다운로드"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6456,9 +6357,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr ""
-"실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하"
-"세요."
+msgstr "실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6466,9 +6365,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr ""
-"가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 "
-"작성하세요."
+msgstr "가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6488,9 +6385,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성"
-"하세요."
+msgstr "다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6498,9 +6393,7 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr ""
-"팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써"
-"보세요."
+msgstr "팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써보세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6622,7 +6515,7 @@ msgstr "Duck.ai - DuckDuckGo가 선보이는 비공개 무료 AI 채팅"
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "이제 Duck.ai가 PDF를 분석할 수 있습니다. 사용해 보세요!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6632,9 +6525,8 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있"
-"습니다. 페이지 내용은 사용자가 첨부할 때만 포함됩니다. 또는 설정에서 페이지 "
-"자동 첨부를 선택하세요."
+"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있습니다. 페이지 내용은 사용자가 첨부할 때만 "
+"포함됩니다. 또는 설정에서 페이지 자동 첨부를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6644,8 +6536,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 "
-"설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 시도하세요."
+"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 "
+"시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6653,16 +6545,13 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr ""
-"Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
+msgstr "Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합"
-"니다!"
+msgstr "Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6671,9 +6560,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사"
-"람들을 위한 독립된 온라인 보호 기업입니다."
+msgstr "Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사람들을 위한 독립된 온라인 보호 기업입니다."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6687,9 +6574,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기"
-"억하기 쉽게 바뀌었습니다."
+msgstr "Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기억하기 쉽게 바뀌었습니다."
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6703,18 +6588,14 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)"
-"를 %2$s 이메일로 보내주세요"
+msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세"
-"요."
+msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6728,9 +6609,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄"
-"면 Duck.ai 버튼과 링크가 숨겨지지만 %1$sduck.ai%2$s에 들어가서 직접 기능을 이"
-"용할 수 있습니다."
+"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄면 Duck.ai 버튼과 링크가 숨겨지지만 "
+"%1$sduck.ai%2$s에 들어가서 직접 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6741,10 +6621,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화"
-"할 수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보"
-"이지 않습니다. 하지만 이 설정이 꺼져 있어도 %1$shttps://duck.ai%2$s에 바로 접"
-"속해서 Duck.ai를 이용할 수 있습니다."
+"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 "
+"DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"%1$shttps://duck.ai%2$s에 바로 접속해서 Duck.ai를 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6758,9 +6637,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr ""
-"Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하"
-"실 수 있습니다."
+msgstr "Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하실 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6779,7 +6656,7 @@ msgstr "Duck.ai 답변은 특정 자료에 근거하거나 정확성을 확인�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai는 Anthropic, OpenAI 등의 모델을 지원합니다."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6797,8 +6674,7 @@ msgstr "Duck.ai가 업그레이드되었습니다!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
+msgstr "Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6808,9 +6684,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필"
-"요 없는 AI 채팅, OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이"
-"버시 중심 AI, 계정 필요 없는 AI 채팅"
+"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필요 없는 AI 채팅, "
+"OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이버시 중심 AI, 계정 필요 없는 AI 채팅"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6838,11 +6713,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
-"DuckAssist 표시 빈도 선택 가능: 안 함(검색 결과에서 DuckAssist UI를 완전히 제"
-"거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 표"
-"시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영"
-"어) 지역에서만 제공됩니다."
+"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. DuckAssist 표시 빈도 선택 가능: 안 "
+"함(검색 결과에서 DuckAssist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 "
+"표시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영어) 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6851,9 +6724,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
-"지원하는 비공개 AI 기반 채팅 서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니"
-"다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6862,9 +6734,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
-"지원하는 비공개 AI 기반 채팅 서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니"
-"다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6876,10 +6747,9 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 "
-"관련 사이트에서 의미있는 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여 "
-"해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용"
-"을 기반으로 답변을 제공하며 정확성 검사는 하지 않습니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 관련 사이트에서 의미있는 콘텐츠를 검색한 "
+"다음 AI 기반 자연어 기술을 사용하여 해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용을 기반으로 "
+"답변을 제공하며 정확성 검사는 하지 않습니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6893,21 +6763,17 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관"
-"련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관련 정보를 바"
-"탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 "
-"바로 링크하고 답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정"
-"보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 자"
-"동 생성합니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 "
+"사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 바로 링크하고 "
+"답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 "
+"기반으로 자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr ""
-"DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습"
-"니다."
+msgstr "DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6915,9 +6781,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채"
-"팅은 내일 계속하세요."
+msgstr "하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6926,8 +6790,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
-"개 AI 기반 채팅 서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스입니다."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6936,8 +6800,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
-"개 AI 기반 채팅 서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스입니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6945,9 +6809,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr ""
-"DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있"
-"습니다."
+msgstr "DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6955,9 +6817,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 "
-"코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6965,16 +6825,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다"
-"시 시도하세요."
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7093,17 +6950,15 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정"
-"보(PII)를 자동으로 제거해 이러한 보고서를 익명화합니다."
+"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정보(PII)를 자동으로 제거해 이러한 보고서를 "
+"익명화합니다."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동"
-"의합니다."
+msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동의합니다."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7111,9 +6966,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s"
-"에 동의합니다."
+msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s에 동의합니다."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7122,8 +6975,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에"
-"서 사용자 추적을 시도하는 Google과 Facebook 등의 추적기도 차단합니다."
+"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에서 사용자 추적을 시도하는 Google과 "
+"Facebook 등의 추적기도 차단합니다."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7135,11 +6988,10 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위"
-"치 정보는 로컬 기기에만 저장됩니다. 사용자가 검색을 하면 사용자의 기기는 해"
-"당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 "
-"데 사용한 후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보"
-"를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요%2$s."
+"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위치 정보는 로컬 기기에만 저장됩니다. 사용자가 "
+"검색을 하면 사용자의 기기는 해당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 데 사용한 "
+"후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 "
+"알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7159,8 +7011,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋"
-"은 결과를 제공할 수 있습니다. %1$s자세히 알아보세요%2$s."
+"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋은 결과를 제공할 수 있습니다. %1$s자세히 "
+"알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7246,9 +7098,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 "
-"목록을 받습니다. 그러 다음 브라우저에서 목록에 포함된 4~5개의 무작위 단어를 "
-"선택하여 최소 18~20자 이상의 암호를 만듭니다."
+"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 목록을 받습니다. 그러 다음 브라우저에서 목록에 "
+"포함된 4~5개의 무작위 단어를 선택하여 최소 18~20자 이상의 암호를 만듭니다."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7418,7 +7269,7 @@ msgstr "가장 많이 방문한 사이트 활성화"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "지금 활성화"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7455,9 +7306,7 @@ msgstr "웹 검색 활성화"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변"
-"경할 수 있습니다."
+msgstr "보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7499,9 +7348,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위"
-"치는 DuckDuckGo에 공개하지 않을 수 있습니다."
+msgstr "익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위치는 DuckDuckGo에 공개하지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7662,9 +7509,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이"
-"터가 새 암호로 저장됩니다."
+msgstr "새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이터가 새 암호로 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7689,9 +7534,7 @@ msgstr "번역할 내용 입력하기"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네"
-"임%6$s: d%7$s"
+msgstr "다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네임%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7721,7 +7564,7 @@ msgstr "엔터테인먼트 가이드"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "전체 채팅"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7791,9 +7634,7 @@ msgstr "지도 확장하기"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습"
-"니다."
+msgstr "개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습니다."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7890,13 +7731,13 @@ msgstr "노골적인 가사"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai 둘러보기"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai 둘러보기"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8003,7 +7844,7 @@ msgstr "무료"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "무료 및 선택 사항"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8061,8 +7902,7 @@ msgstr "피드백이 성공적으로 전송되었습니다."
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
+msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8070,9 +7910,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사"
-"용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
+msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8162,16 +8000,13 @@ msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니�
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
+msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
-"이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세"
-"요%2$s"
+msgstr "이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세요%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8212,8 +8047,7 @@ msgstr "다운로드 폴더에서 <b>%1$s</b> 파일을 찾으세요"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
+msgstr "표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8250,8 +8084,7 @@ msgstr "여러분과 보다 관련있는 결과를 찾아보세요."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
+msgstr "내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8314,9 +8147,7 @@ msgstr "안개"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 "
-"클릭해야 할 수도 있습니다."
+msgstr "안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 클릭해야 할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8421,7 +8252,7 @@ msgstr "저장 공간 확보하기"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "무료 및 항상 비공개"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8433,8 +8264,7 @@ msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
+msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8545,8 +8375,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 확"
-"인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
+"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 "
+"확인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8896,9 +8726,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 "
-"Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8908,9 +8736,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 "
-"Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8939,7 +8765,7 @@ msgstr "컴퓨터 도움 받기"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "DuckDuckGo를 구독해서 사용 한도를 높이세요."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8950,9 +8776,7 @@ msgstr "설정이 사라지지 않도록 DuckDuckGo 브라우저를 이용하세
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 "
-"수 있습니다."
+msgstr "다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8982,13 +8806,13 @@ msgstr "최신 버전 다운로드"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "앱 받기"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
+msgstr "무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9016,7 +8840,7 @@ msgstr "더 많은 사람들에게 추천해서 DuckDuckGo의 성장을 도와�
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "시작하기 체크리스트"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9047,8 +8871,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9057,8 +8881,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9068,8 +8892,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어가서 코드 스캔:"
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9079,9 +8903,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR"
-"을 스캔하세요."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9095,9 +8918,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr ""
-"%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비"
-"스'가 켜져 있는지 확인합니다."
+msgstr "%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비스'가 켜져 있는지 확인합니다."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9105,9 +8926,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 "
-"%3$sDuckDuckGo%4$s를 찾습니다."
+msgstr "%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 %3$sDuckDuckGo%4$s를 찾습니다."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9703,7 +9522,7 @@ msgstr "팁 숨기기"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "튜토리얼 숨기기"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9789,9 +9608,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 "
-"강조 표시합니다."
+msgstr "중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 강조 표시합니다."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9818,8 +9635,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그"
-"런 다음 %5$s기본값으로 설정%6$s을 클릭하세요"
+"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그런 다음 %5$s기본값으로 "
+"설정%6$s을 클릭하세요"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9832,9 +9649,7 @@ msgstr "몽족어"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 "
-"보호 기능을 사용할 수 없게 됩니다."
+msgstr "잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 보호 기능을 사용할 수 없게 됩니다."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9883,9 +9698,7 @@ msgstr "더움"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr ""
-"호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수"
-"집하는 데 사용되지 않습니다."
+msgstr "호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10147,9 +9960,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으"
-"며, 그 이유는 무엇인가요?"
+msgstr "바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으며, 그 이유는 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10183,9 +9994,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 "
-"및 개인정보 보호 재설정%2$s으로 이동하세요."
+msgstr "여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 및 개인정보 보호 재설정%2$s으로 이동하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10195,8 +10004,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사"
-"이트 설정 > 위치%2$s로 이동하여 DuckDuckGo의 위치 접근을 허용하세요."
+"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사이트 설정 > 위치%2$s로 이동하여 "
+"DuckDuckGo의 위치 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10210,9 +10019,7 @@ msgstr "이 오류가 계속되면 %1$s에 문의하세요."
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가"
-"해야 합니다."
+msgstr "만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10220,9 +10027,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이"
-"지에 직접 문의하실 수도 있습니다."
+msgstr "채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이지에 직접 문의하실 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10230,17 +10035,13 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니"
-"다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
+msgstr "기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주"
-"세요%2$s"
+msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10249,8 +10050,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
+msgstr "JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10398,8 +10198,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 "
-"서버를 통해 처리되도록 경로 변경이 필요합니다. %1$s자세히 알아보세요%2$s."
+"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 서버를 통해 처리되도록 경로 변경이 필요합니다. "
+"%1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10409,9 +10209,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동"
-"기화”로 이동하세요."
+msgstr "DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동기화”로 이동하세요."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10425,9 +10223,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개"
-"됩니다."
+msgstr "투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개됩니다."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10832,9 +10628,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 "
-"통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 연결되며, 광고와는 달리 "
-"DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
+"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 "
+"연결되며, 광고와는 달리 DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10842,8 +10637,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
+msgstr "임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11314,7 +11108,7 @@ msgstr "DuckDuckGo에서는 검색 정보를 남기지 않고 검색할 수 있�
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "검색어 보내기와 Duck.ai에 프롬프트 보내기 사이를 전환할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11390,7 +11184,7 @@ msgstr "획득한 라인아웃"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "링크가 7일 후 만료됩니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12043,8 +11837,7 @@ msgstr "미크로네시아"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
+msgstr "마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12487,7 +12280,7 @@ msgstr "20분 이상"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "팁 더 보기"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12810,10 +12603,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트"
-"와 응답을 암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성"
-"화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니"
-"다."
+"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버에 임시로 "
+"저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12980,7 +12771,7 @@ msgstr "사양합니다"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "사양합니다"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13128,8 +12919,7 @@ msgstr "검색 결과가 없습니다."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
+msgstr "음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13635,9 +13425,7 @@ msgstr "요청 시"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이"
-"콘 > 설정을 클릭하세요.%5$s"
+msgstr "Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이콘 > 설정을 클릭하세요.%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13649,7 +13437,7 @@ msgstr "설정(단, 번호 없음)"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "온보딩 완료"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13664,9 +13452,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 "
-"파일을 업로드하세요."
+msgstr "첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 파일을 업로드하세요."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13692,9 +13478,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지"
-"를 참고하세요."
+msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지를 참고하세요."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13708,8 +13492,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+msgstr "이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13866,7 +13649,7 @@ msgstr "이미지 만들기 및 편집 제안 열기"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "시작하기 체크리스트 열기"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14031,9 +13814,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 "
-"추적하지 않습니다."
+msgstr "다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 추적하지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14045,9 +13826,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr ""
-"DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공"
-"유하지 않습니다."
+msgstr "DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공유하지 않습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14055,8 +13834,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강"
-"화 등의 기능이 탑재되어 있습니다. %1$siOS 및 Android%2$s에서 다운로드하세요."
+"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강화 등의 기능이 탑재되어 있습니다. %1$siOS "
+"및 Android%2$s에서 다운로드하세요."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14308,9 +14087,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 "
-"않기 때문에 암호를 복구할 수 없습니다."
+msgstr "해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 않기 때문에 암호를 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14510,9 +14287,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 "
-"답변 수준이 높아질 수 있습니다. 이 기능을 끄고 Assist 버튼을 숨기려면 %1$s검"
-"색 설정%2$s으로 들어가세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 답변 수준이 높아질 수 있습니다. 이 기능을 끄고 "
+"Assist 버튼을 숨기려면 %1$s검색 설정%2$s으로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14521,9 +14297,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어"
-"난 답을 얻을 가능성이 높아집니다. %1$sDuckAssist 설정%2$s에서 이 기능을 끄거"
-"나 작동 방식을 조정할 수 있습니다."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어난 답을 얻을 가능성이 높아집니다. "
+"%1$sDuckAssist 설정%2$s에서 이 기능을 끄거나 작동 방식을 조정할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14533,9 +14308,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 "
-"더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 끄고 Assist 버튼을 감추려면 "
-"%1$sDuckAssist 설정%2$s을 방문하세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 "
+"끄고 Assist 버튼을 감추려면 %1$sDuckAssist 설정%2$s을 방문하세요."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14567,9 +14341,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
-"보세요."
+msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14577,9 +14349,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
-"보세요."
+msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14587,9 +14357,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보"
-"호 기능이 제공되지 않습니다."
+msgstr "목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보호 기능이 제공되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14613,7 +14381,7 @@ msgstr "핀"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "채팅 고정하기"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14625,7 +14393,7 @@ msgstr "%1$s %2$s에서 채팅을 여기에 고정"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "고정해 보세요"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14648,7 +14416,7 @@ msgstr "고정됨"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "고정된 채팅은 최근 채팅 상단에 표시돼요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14737,9 +14505,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해"
-"하거나 불법적인 이유를 설명해 주세요."
+msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해하거나 불법적인 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14747,9 +14513,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법"
-"이거나 해로운 이유를 설명해 주세요."
+msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법이거나 해로운 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14901,9 +14665,7 @@ msgstr "DuckDuckGo를 구독하면 더 많은 프리미엄 기능들도 따라�
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니"
-"다."
+msgstr "또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14965,7 +14727,7 @@ msgstr "형식이 조악함"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
+msgstr "인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo가 익명화하는 채팅입니다."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15179,7 +14941,7 @@ msgstr "이전 탭"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "이전 팁"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15402,8 +15164,7 @@ msgstr "DuckDuckGo는 절대 저장하지 않는 비공개 채팅"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr ""
-"DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
+msgstr "DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -15475,9 +15236,7 @@ msgstr "재생하기 전에 물어보기"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니"
-"다."
+msgstr "내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니다."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15495,8 +15254,7 @@ msgstr "검색과 인터넷 이용 과정에서 데이터를 보호하세요."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
+msgstr "검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15520,9 +15278,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입"
-"력]"
+msgstr "다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입력]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15727,13 +15483,13 @@ msgstr "중간 수준의 조정 기능이 내장된 추론형 AI"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "추론을 통해 복잡한 질문에 대해 더 나은 답변을 얻을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "추론 기능이 더 뛰어나지만 사용 한도가 2~5배 더 빨리 소진됩니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15774,7 +15530,7 @@ msgstr "최근 채팅 저장 공간은 %1$s에서 조정할 수 있습니다."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "최근 채팅"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15782,9 +15538,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
-"됩니다."
+msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15792,9 +15546,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
-"됩니다."
+msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15804,9 +15556,8 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 "
-"때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 "
-"DuckDuckGo 서버에 임시로 저장합니다."
+"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
+"암호화하여 DuckDuckGo 서버에 임시로 저장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15934,7 +15685,7 @@ msgstr "사용량 줄이기"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "더 효율적인 모델로 사용량을 줄여보세요"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16081,9 +15832,7 @@ msgstr "Duck.ai를 다시 불러오기"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 "
-"DuckDuckGo를 새로고침하세요."
+msgstr "안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 DuckDuckGo를 새로고침하세요."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16172,18 +15921,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 "
-"항상 자동으로 표시됩니다."
+msgstr "'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변"
-"이 항상 자동으로 표시됩니다."
+msgstr "'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16241,18 +15986,15 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. "
-"사용자님이 익명으로 보내주신 의견은 %1$s 사에도 서비스 개선을 위해 제공됩니"
-"다."
+"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. 사용자님이 익명으로 보내주신 의견은 %1$s "
+"사에도 서비스 개선을 위해 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 "
-"기재하지 마세요."
+msgstr "DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16261,9 +16003,8 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 "
-"요청하는 모든 텍스트가 들어있으며, 이 텍스트는 익명 상태입니다. 피드백에 개"
-"인 정보나 식별 정보를 기재하지 마세요."
+"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 요청하는 모든 텍스트가 들어있으며, 이 텍스트는 "
+"익명 상태입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16313,7 +16054,7 @@ msgstr "모든 설정 초기화"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "튜토리얼 재설정"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16331,7 +16072,7 @@ msgstr "해상도"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "응답"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16355,9 +16096,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. AI 지원 답변에는 %1$s서비스 약관%2$s"
-"이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. AI 지원 "
+"답변에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16366,9 +16106,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. DuckAssist에는 %1$s서비스 약관%2$s이 "
-"적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. "
+"DuckAssist에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16378,10 +16117,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 바탕으로 자동 생성된 응답"
-"이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약"
-"관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 "
+"바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16805,9 +16542,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많"
-"이 저장할 수도 있습니다."
+msgstr "최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많이 저장할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16967,9 +16702,7 @@ msgstr "아래로 스크롤하여 %1$s고급 설정 보기%2$s를 클릭하세�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변"
-"경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16977,9 +16710,7 @@ msgstr ""
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr ""
-"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 "
-"%5$s새로 추가%6$s)을 클릭하세요."
+msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17003,9 +16734,7 @@ msgstr "%1$sDuckDuckGo%2$s로 스크롤하여 사용자의 위치를 사용하�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클"
-"릭하세요."
+msgstr "아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17033,7 +16762,7 @@ msgstr "%1$s 검색으로 더 가까운 곳을 찾아볼까요?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "검색 및 Duck.ai 전환"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17059,12 +16788,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 "
-"콘텐츠를 검색한 다음 AI를 사용하여 간단한 답변을 생성합니다. 답변 표시 빈도"
-"는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클"
-"릭했을 때만), 가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 "
-"때 표시) 중 선택하세요. 현재 Search Assist는 영어를 사용하는 일부 지역에만 제"
-"공됩니다."
+"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 콘텐츠를 검색한 다음 AI를 사용하여 간단한 "
+"답변을 생성합니다. 답변 표시 빈도는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클릭했을 때만), "
+"가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 때 표시) 중 선택하세요. 현재 Search Assist는 영어를 "
+"사용하는 일부 지역에만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17072,8 +16799,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 "
-"충분히 찾지 못했습니다. 다른 검색을 시도해 보세요."
+"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 충분히 찾지 못했습니다. 다른 검색을 시도해 "
+"보세요."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17082,9 +16809,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이"
-"를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s 한 다음 AI를 사용하여 찾은 정보를 "
-"기반으로 간단한 답변을 생성합니다."
+"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s "
+"한 다음 AI를 사용하여 찾은 정보를 기반으로 간단한 답변을 생성합니다."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17205,8 +16931,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 "
-"위키피디아에서 바로 'ducks'를 바로 검색합니다."
+"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 위키피디아에서 바로 'ducks'를 바로 "
+"검색합니다."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17225,18 +16951,15 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하"
-"는 브라우저에 비공개 웹 검색 기능을 설치하거나, %1$sduckduckgo.com%2$s에서 바"
-"로 검색하세요."
+"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하는 브라우저에 비공개 웹 검색 기능을 설치하거나, "
+"%1$sduckduckgo.com%2$s에서 바로 검색하세요."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
 msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
-msgstr ""
-"검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용"
-"합니다)."
+msgstr "검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용합니다)."
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17248,10 +16971,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저"
-"장됩니다. 하지만 Cloud Save를 사용하여 클라우드 원격 서버에 설정을 익명으로 "
-"저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으"
-"며, 암호가 브라우저 밖으로 유출되지 않습니다."
+"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저장됩니다. 하지만 Cloud Save를 사용하여 클라우드 "
+"원격 서버에 설정을 익명으로 저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호가 브라우저 밖으로 "
+"유출되지 않습니다."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17353,9 +17075,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17363,9 +17083,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17373,9 +17091,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 동기화된 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 동기화된 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17383,9 +17099,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 "
-"기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17399,15 +17113,13 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데"
-"이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr "DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "암호화된 서버에 안전하게 저장됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17551,9 +17263,7 @@ msgstr "Safari 메뉴에서 %1$s'이 웹사이트의 설정'%2$s을 선택하세
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입"
-"력하세요."
+msgstr "%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입력하세요."
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17617,18 +17327,14 @@ msgstr "드롭다운 메뉴에서 %1$s추가 기능 관리%2$s를 선택하세�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설"
-"정%4$s을 선택하세요."
+msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설정%4$s을 선택하세요."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵"
-"션%4$s을 선택하세요."
+msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵션%4$s을 선택하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17692,8 +17398,7 @@ msgstr "%1$s설정%2$s을 선택한 다음 %3$s검색 엔진%4$s을 선택하세
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
+msgstr "%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17814,9 +17519,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞"
-"으로 나와 나누는 모든 대화에 적용됩니다."
+msgstr "AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞으로 나와 나누는 모든 대화에 적용됩니다."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17917,7 +17620,7 @@ msgstr "홈페이지로 설정"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Duck.ai 응답의 톤과 스타일을 설정하세요."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -17931,9 +17634,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지"
-"하세요."
+msgstr "채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지하세요."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17988,13 +17689,13 @@ msgstr "세이셸"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "공유"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "공유"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18005,9 +17706,7 @@ msgstr "공유"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세"
-"요!"
+msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세요!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18034,15 +17733,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용"
-"자의 정확한 위치를 우리에게나 AI 모델에게나 절대 공개하지 않습니다."
+"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용자의 정확한 위치를 우리에게나 AI 모델에게나 "
+"절대 공개하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "채팅 공유"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18106,7 +17805,7 @@ msgstr "긍정적인 피드백 공유"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "공유 범위"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18130,8 +17829,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
+msgstr "DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18246,7 +17944,7 @@ msgstr "상세 정보 보기"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Duck.ai 튜토리얼 표시"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18399,7 +18097,7 @@ msgstr "더 보기"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "모델 더 보기"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18440,7 +18138,7 @@ msgstr "사이드바 표시"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Duck.ai를 최대한 활용할 수 있는 단계별 팁을 표시합니다."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18495,17 +18193,15 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알"
-"림을 숨기며 검색 개인정보에는 영향을 주지 않습니다."
+"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알림을 숨기며 검색 개인정보에는 영향을 주지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림"
-"만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
+msgstr "DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18650,8 +18346,7 @@ msgstr "사이트 이름"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
+msgstr "사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18813,7 +18508,7 @@ msgstr "문제가 발생했습니다. 나중에 다시 시도해 주세요."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "문제가 발생했습니다. 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18869,8 +18564,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
+msgstr "업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18878,9 +18572,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는"
-"지 확인하세요."
+msgstr "죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는지 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18894,9 +18586,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여"
-"기를 클릭%2$s하세요."
+msgstr "죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여기를 클릭%2$s하세요."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18956,8 +18646,7 @@ msgstr "원문 지움"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
+msgstr "원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19109,7 +18798,7 @@ msgstr "주간 한도 사용 시작"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "새로운 채팅 시작"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19306,9 +18995,7 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr ""
-"DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많"
-"이 만들어 보세요."
+msgstr "DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19693,7 +19380,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "이 다른 답변으로 전환"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19809,13 +19496,11 @@ msgid ""
 msgstr ""
 "동기화 복구 코드\n"
 "\n"
-"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅"
-"을 동기화할 수 있으며, 장치에 액세스할 수 없는 경우 동기화된 데이터를 복구할 "
-"수 있습니다.\n"
+"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅을 동기화할 수 있으며, 장치에 액세스할 수 없는 "
+"경우 동기화된 데이터를 복구할 수 있습니다.\n"
 "\n"
 "이 정보를 안전하게 보관하세요.\n"
-"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니"
-"다.\n"
+"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니다.\n"
 "\n"
 "%1$s\n"
 "\n"
@@ -19824,8 +19509,8 @@ msgstr ""
 "2. \"Sync & Backup\"를 선택한 다음, \"동기화된 데이터 복구\"를 선택합니다.\n"
 "3. 위 복구 코드를 복사하여 \"여기에 코드 붙여넣기\"에 붙여넣습니다.\n"
 "\n"
-"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 "
-"않으면 서버에서 데이터가 삭제되어 복원할 수 없습니다."
+"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 않으면 서버에서 데이터가 삭제되어 "
+"복원할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19849,7 +19534,7 @@ msgstr "Sync & Backup을 일시적으로 사용할 수 없습니다."
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "여러 기기에서 채팅 동기화"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19944,7 +19629,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
+msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -19952,7 +19637,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
+msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있도록 무료 브라우저에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20190,9 +19875,8 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 "
-"가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 비밀번호 또는 결제 세부 정"
-"보가 이에 포함됩니다."
+"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 "
+"비밀번호 또는 결제 세부 정보가 이에 포함됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20200,9 +19884,7 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr ""
-"Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으"
-"로 저장할 수 있습니다."
+msgstr "Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20231,8 +19913,7 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr ""
-"암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
+msgstr "암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20311,9 +19992,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활"
-"성화되어 있는지 브라우저 설정에서 확인하세요."
+msgstr "이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활성화되어 있는지 브라우저 설정에서 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20327,8 +20006,7 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr ""
-"검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
+msgstr "검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20347,9 +20025,8 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, "
-"DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 웹사이트의 개인정보 보호를 "
-"강화하는 데 적용됩니다."
+"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 "
+"웹사이트의 개인정보 보호를 강화하는 데 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20386,9 +20063,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세"
-"요."
+msgstr "이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20396,9 +20071,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅"
-"을 시작해 보세요."
+msgstr "이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20416,7 +20089,7 @@ msgstr "이번 달"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "이 응답"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20428,7 +20101,7 @@ msgstr "이번 주"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "이 채팅은 Duck.ai 내에 유지되며, 비공개로 유지됩니다."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20437,8 +20110,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
-"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 "
+"수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20448,8 +20121,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
-"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %2$s 참조)."
+"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 "
+"있습니다(자세한 내용은 %2$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20458,8 +20131,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌"
-"한 정보를 제공할 수 있습니다(자세한 내용은 %2$s 참고)."
+"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌한 정보를 제공할 수 있습니다(자세한 내용은 "
+"%2$s 참고)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20469,9 +20142,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습"
-"니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용"
-"은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습니다. AI 채팅은 부정확하거나 "
+"공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20542,16 +20214,14 @@ msgstr "이 이미지를 만들 수 없습니다."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
+msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
+msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20564,7 +20234,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
+msgstr "샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계속 표시되도록 하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20572,7 +20242,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
+msgstr "샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20592,9 +20262,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 "
-"제공사는 데이터를 보유하지 않는 모델을 따릅니다."
+msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 제공사는 데이터를 보유하지 않는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20602,9 +20270,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공"
-"사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
+msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20640,9 +20306,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 "
-"모든 브라우저에서 접근할 수 있습니다."
+msgstr "이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 모든 브라우저에서 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20650,9 +20314,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
-"면 AI 지원 답변이 다시 표시될 수 있습니다."
+msgstr "이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20662,9 +20324,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
-"면 AI 지원 답변이 다시 표시될 수 있습니다. 하지만 AI 지원 답변이 절대 표시되"
-"지 않는 시작 페이지(%1$s)도 있습니다."
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다. "
+"하지만 AI 지원 답변이 절대 표시되지 않는 시작 페이지(%1$s)도 있습니다."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20687,17 +20348,13 @@ msgstr "이 번역은 잘못되었습니다."
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 "
-"수 있습니다."
+msgstr "아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 "
-"사용하지 않고 있습니다."
+msgstr "이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 사용하지 않고 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20707,9 +20364,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결"
-"이 끊깁니다. Sync & Backup에 연결된 다른 브라우저에서는 계속 채팅을 볼 수 있"
-"습니다."
+"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결이 끊깁니다. Sync & Backup에 "
+"연결된 다른 브라우저에서는 계속 채팅을 볼 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20717,9 +20373,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌"
-"릴 수 없습니다."
+msgstr "이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20811,9 +20465,7 @@ msgstr "팁"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니"
-"다.%2$s"
+msgstr "개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니다.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20858,9 +20510,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인"
-"쇄 아이콘을 클릭하세요.%4$s"
+msgstr "경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인쇄 아이콘을 클릭하세요.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20870,9 +20520,8 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합"
-"니다. 이 코드는 Sync를 설치할 때 원래 사용한 기기에 PDF로 저장되었을 수 있습"
-"니다."
+"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합니다. 이 코드는 Sync를 설치할 때 원래 사용한 "
+"기기에 PDF로 저장되었을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20880,18 +20529,14 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트"
-"하고 다시 시도하세요."
+msgstr "채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr ""
-"받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허"
-"용해 주세요."
+msgstr "받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허용해 주세요."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20913,7 +20558,7 @@ msgstr "오늘"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
+msgstr "전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21086,9 +20731,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되"
-"었는지 둘러보세요."
+msgstr "DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되었는지 둘러보세요."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21135,9 +20778,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
-"주세요."
+msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21145,9 +20786,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
-"주세요."
+msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21330,7 +20969,7 @@ msgstr "한번 시도해 봐"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "다른 모델을 사용해 보세요"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21341,7 +20980,7 @@ msgstr "검색해 보세요!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "제안 실행해 보기"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21409,7 +21048,7 @@ msgstr "무료 체험"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "무료 체험"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21429,7 +21068,7 @@ msgstr "안전한 VPN, 고급 & 비공개 AI, 그 밖의 기능을 무료로 체
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "7일 동안 무료로 사용해 보기"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21462,7 +21101,7 @@ msgstr "이러한 메시지가 없는 DuckDuckGo 홈페이지를 사용해 보�
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "추론 사용해 보기"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21485,9 +21124,7 @@ msgstr "위치를 수동으로 설정하세요."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 "
-"보호."
+msgstr "%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 보호."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -21579,8 +21216,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 "
-"설치하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 설치하면 설정을 기억시킬 수 "
+"있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21589,8 +21226,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 "
-"전환하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 전환하면 설정을 기억시킬 수 "
+"있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21715,7 +21352,7 @@ msgstr "타겟 광고 없이 YouTube를 시청하려면 Duck Player를 켜세요
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Duck.ai 전환 켜기"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21778,9 +21415,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표"
-"시되기까지 시간이 조금 지연될 수 있습니다."
+msgstr "DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표시되기까지 시간이 조금 지연될 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21909,30 +21544,24 @@ msgstr "장점과 단점 파악"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이"
-"지 설정%6$s을 클릭하세요."
+msgstr "%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이지 설정%6$s을 클릭하세요."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com"
-"을 입력하세요."
+msgstr "%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
+msgstr "%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
+msgstr "%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21942,8 +21571,7 @@ msgstr "%1$s검색 설정%2$s에서 %3$sDuckDuckGo%4$s를 선택하세요."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
+msgstr "%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21955,8 +21583,7 @@ msgstr "%1$s검색%2$s 섹션에서, %3$s검색 엔진 관리...%4$s를 클릭�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
+msgstr "시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22039,9 +21666,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사"
-"용 한도를 이용하세요."
+msgstr "Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사용 한도를 이용하세요."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22087,7 +21712,7 @@ msgstr "구독을 통해 고급 AI를 이용하세요!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "고급 모델 잠금 해제"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22180,9 +21805,7 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr ""
-"DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 "
-"이용하세요."
+msgstr "DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22306,9 +21929,7 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr ""
-"Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 "
-"더 많이 만들어 보세요."
+msgstr "Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -22410,8 +22031,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채"
-"팅을 보호하세요. 정보를 기밀로 유지하세요. 무료로. 계정이 없어도 괜찮습니다."
+"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채팅을 보호하세요. 정보를 기밀로 유지하세요. "
+"무료로. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22451,7 +22072,7 @@ msgstr "Safari에서 사용"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Fire Button을 사용하여 기록에서 채팅을 삭제하세요."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22459,17 +22080,14 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 "
-"보관하세요."
+msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 보관하세요."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr ""
-"기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
+msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -22618,9 +22236,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소"
-"프트의 광고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소프트의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22628,9 +22244,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 "
-"TripAdvisor의 광고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22657,9 +22271,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명"
-"을 따르세요."
+msgstr "휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명을 따르세요."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22674,8 +22286,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
-"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & Backup%4$s > "
+"%5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22685,9 +22297,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아"
-"래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF"
-"에 있는 QR을 스캔하세요."
+"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 '켜기'를 선택하고 "
+"''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22697,9 +22308,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > "
-"%3$sSync & Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선"
-"택하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
+"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22709,9 +22319,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. "
-"Sync & Backup 아래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세"
-"요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 "
+"'켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22763,8 +22372,7 @@ msgstr "음성 채팅이 끝났습니다"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr "당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22907,9 +22515,7 @@ msgstr "Duck Player에서 보기"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 "
-"YouTube 추천 영상이 달라지지 않습니다."
+msgstr "Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 YouTube 추천 영상이 달라지지 않습니다."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22929,9 +22535,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하"
-"는 웹사이트에서 사용자를 추적할 수 있습니다. DuckDuckGo는 동영상 대부분을 호"
-"스팅하는 YouTube와 무관한 독립적인 기업입니다."
+"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하는 웹사이트에서 사용자를 추적할 수 있습니다. "
+"DuckDuckGo는 동영상 대부분을 호스팅하는 YouTube와 무관한 독립적인 기업입니다."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22943,9 +22548,7 @@ msgstr "DuckDuckGo의 익명화"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니"
-"다."
+msgstr "더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22957,8 +22560,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저"
-"희가 문제를 조사하고 해결할 수 있도록 이대화를 DuckDuckGo와 공유해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저희가 문제를 조사하고 해결할 수 있도록 이대화를 "
+"DuckDuckGo와 공유해 주세요."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22970,9 +22573,8 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저"
-"희가 문제를 조사하고 해결할 수 있도록 사용하신 프롬프트와 응답 내용을 보내서 "
-"신고해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저희가 문제를 조사하고 해결할 수 있도록 사용하신 "
+"프롬프트와 응답 내용을 보내서 신고해 주세요."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23013,9 +22615,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따"
-"라다니며 광고를 게재하지 않습니다. DuckDuckGo는 사용자를 추적하지 않습니다. "
-"절대."
+"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따라다니며 광고를 게재하지 않습니다. "
+"DuckDuckGo는 사용자를 추적하지 않습니다. 절대."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23028,9 +22629,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 "
-"알려주시면 도움이 될 것 같습니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23038,9 +22637,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알"
-"려주시면 도움이 될 것 같습니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23051,9 +22648,7 @@ msgstr "DuckDuckGo는 절대로 사용자를 추적하지 않습니다."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
-"니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23082,24 +22677,19 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사"
-"용자를 추적하는 광고주에게 판매할 수 있는 어떠한 정보도 보유하고 있지 않습니"
-"다."
+"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사용자를 추적하는 광고주에게 판매할 수 있는 어떠한 "
+"정보도 보유하고 있지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하"
-"지 않습니다."
+msgstr "DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
-"니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23113,9 +22703,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않"
-"도록 보장합니다."
+msgstr "DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않도록 보장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23139,9 +22727,7 @@ msgstr "연결이 끊겼습니다. 메시지를 다시 보내 보세요."
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr ""
-"우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터"
-"를 악용하지 않습니다."
+msgstr "우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터를 악용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23149,24 +22735,18 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든"
-"지 설정을 변경할 수 있습니다."
+msgstr "익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 "
-"좋게 발전시킵니다."
+msgstr "여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 좋게 발전시킵니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 "
-"포함해서 말이죠."
+msgstr "여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 포함해서 말이죠."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23182,8 +22762,8 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s"
-"의 재량에 따라 적용됩니다. 정정 사항이 결과에 바로 나타나지 않을 수 있습니다."
+"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s의 재량에 따라 적용됩니다. 정정 사항이 결과에 "
+"바로 나타나지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23196,9 +22776,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문"
-"의하세요."
+msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문의하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23206,9 +22784,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제"
-"가 해결되는 경우도 있습니다."
+msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제가 해결되는 경우도 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23222,9 +22798,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노"
-"력 중입니다."
+msgstr "불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노력 중입니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23232,9 +22806,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr ""
-"Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치"
-"세요."
+msgstr "Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치세요."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23342,8 +22914,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
+msgstr "주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23357,8 +22928,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되"
-"며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 "
+"사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23367,8 +22938,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공"
-"개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 "
+"저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23378,9 +22949,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 "
-"세션입니다. 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저"
-"장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 세션입니다. 여기서 이루어지는 모든 "
+"채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23453,9 +23023,7 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr ""
-"정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로"
-"고침해 보세요."
+msgstr "정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로고침해 보세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23489,9 +23057,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 "
-"개 알려 주세요."
+msgstr "“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 개 알려 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23510,10 +23076,9 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? "
-"DuckDuckGo 공식 출처만 참고하세요. 답변은 명료하게 섹션을 나누어 작성하고 제"
-"목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 "
-"유무에 관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
+"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? DuckDuckGo 공식 출처만 참고하세요. "
+"답변은 명료하게 섹션을 나누어 작성하고 제목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 유무에 "
+"관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23628,7 +23193,7 @@ msgstr "오늘은 어떤 일로 돌아오셨나요?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "무엇을 할 수 있을까요?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23748,8 +23313,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
+msgstr "Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23824,8 +23388,7 @@ msgstr "무엇에 대해 피드백을 주고 싶으세요?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr "DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23850,9 +23413,7 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr ""
-"초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나"
-"요?"
+msgstr "초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나요?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24053,6 +23614,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. '%1$s' 메뉴에서 언제든지 켜거나 끌 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24325,9 +23888,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있"
-"습니다."
+msgstr "%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24335,9 +23896,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 "
-"검색할 수 있습니다."
+msgstr "%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 검색할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24350,8 +23909,7 @@ msgstr "%1$s에서 DuckDuckGo AI Chat에 바로 접속할 수 있습니다."
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr "%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24359,22 +23917,17 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr ""
-"%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니"
-"다."
+msgstr "%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr "%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr ""
-"%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 "
-"있습니다."
+msgstr "%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24387,9 +23940,7 @@ msgstr "텍스트 선택은 %1$s개까지 첨부할 수 있습니다."
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 "
-"수 있습니다."
+msgstr "%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24409,9 +23960,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트"
-"를 삭제할 수도 있습니다."
+msgstr "다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트를 삭제할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24440,8 +23989,7 @@ msgstr "월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
+msgstr "이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24484,7 +24032,7 @@ msgstr "이미지는 대화당 %1$s개만 첨부할 수 있습니다."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "탭은 한 번에 %1$s개만 첨부할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24504,9 +24052,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이"
-"트 차단을 먼저 해제해야 합니다."
+msgstr "차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이트 차단을 먼저 해제해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24562,9 +24108,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습"
-"니다."
+msgstr "이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24573,8 +24117,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 "
-"DuckDuckGo 구독 보호 기능을 이용할 수 있습니다."
+"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 DuckDuckGo 구독 보호 기능을 이용할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24596,9 +24140,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
-"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
-"다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
+"채팅이 삭제되지는 않습니다."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24608,9 +24151,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
-"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
-"다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
+"채팅이 삭제되지는 않습니다."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24629,7 +24171,7 @@ msgstr "최신 버전이 설치되면 DuckDuckGo 앱이 자동으로 업데이�
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "다 됐습니다!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24638,8 +24180,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용"
-"해 보세요. 이미 설치되어 있으며 다음과 같은 기능이 제공됩니다."
+"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 "
+"다음과 같은 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24651,9 +24193,7 @@ msgstr "이제 개인정보 보호를 받으며 검색할 수 있습니다!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 "
-"팁을 알아보세요."
+msgstr "현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 팁을 알아보세요."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24682,7 +24222,7 @@ msgstr "사이트 {0}개를 차단했습니다"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Duck.ai의 기본을 익혔습니다"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24729,9 +24269,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화"
-"를 재개하려면 가장 오래된 채팅 %1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않"
-"습니다."
+"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화를 재개하려면 가장 오래된 채팅 "
+"%1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24741,9 +24280,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 "
-"첨부 파일이 있는 채팅을 오래된 순으로 %1$s개 삭제하세요. 고정된 채팅은 삭제되"
-"지 않습니다."
+"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 첨부 파일이 있는 채팅을 오래된 순으로 "
+"%1$s개 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24757,8 +24295,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기"
-"서 YouTube 동영상을 시청하면 YouTube나 Google의 추적을 받게 됩니다."
+"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기서 YouTube 동영상을 시청하면 "
+"YouTube나 Google의 추적을 받게 됩니다."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24802,8 +24340,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
-"브라우저에서는 최근 채팅 %1$s개가 로컬 저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 %1$s개가 로컬 "
+"저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24813,8 +24351,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
-"브라우저에서는 최근 채팅 100개가 로컬 저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 100개가 로컬 저장소에 "
+"저장됩니다."
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24838,18 +24376,14 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr ""
-"가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo"
-"는 절대 이 데이터에 접근할 수 없습니다."
+msgstr "가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo는 절대 이 데이터에 접근할 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터"
-"에 절대 액세스할 수 없습니다."
+msgstr "브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터에 절대 액세스할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24857,9 +24391,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표"
-"시할 수 있습니다."
+msgstr "%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24884,36 +24416,28 @@ msgstr "사용자의 채팅은 비공개로 처리되며 AI 모델 훈련에 사
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
-"습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
-"습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
-"지 않습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
-"지 않습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24928,8 +24452,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련"
-"에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 다음과 같습니다."
+"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 "
+"다음과 같습니다."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24968,9 +24492,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. "
-"[%2$s메시지 예시%3$s]"
+msgstr "사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. [%2$s메시지 예시%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25013,10 +24535,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 "
-"키를 생성합니다. 키와 연관된 설정 파일만 브라우저 외부로 전송됩니다. "
-"DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 "
-"암호를 절대 알 수 없습니다."
+"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 키를 생성합니다. 키와 연관된 설정 파일만 "
+"브라우저 외부로 전송됩니다. DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 암호를 절대 알 수 "
+"없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25031,9 +24552,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데"
-"이터는 제거됩니다. 따라서 모델 제공사는 대화를 특정 사용자에 연결할 수 없습니"
-"다."
+"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데이터는 제거됩니다. 따라서 모델 제공사는 대화를 "
+"특정 사용자에 연결할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25078,6 +24598,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
+"사용 설정하세요."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25086,8 +24608,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
-"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 설치하세요. %3$s자세히 알아보기%4$s"
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
+"설치하세요. %3$s자세히 알아보기%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25107,9 +24629,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 "
-"DuckDuckGo 브라우저를 이용해서 더 철저하게 보호받으세요. 이미 설치되어 있으"
-"며 다음 기능이 제공됩니다."
+"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 DuckDuckGo 브라우저를 이용해서 더 철저하게 "
+"보호받으세요. 이미 설치되어 있으며 다음 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25125,9 +24646,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌"
-"러 이 대화를 지우세요."
+msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌러 이 대화를 지우세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25135,8 +24654,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
+msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25150,9 +24668,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세"
-"요."
+msgstr "하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25454,9 +24970,7 @@ msgstr "공식 웹사이트"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s "
-"문자입니다)"
+msgstr "또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s 문자입니다)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25672,4 +25186,4 @@ msgstr "년"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr "%1$s 감지됨"
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -176,8 +182,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
-"이용하거나, Plus 또는 무료 모델로 전환하세요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
+"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -187,8 +194,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
-"이용하거나, Plus 또는 무료 모델로 전환하세요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
+"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -204,8 +212,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구독을 다시 활성화해서 채팅을 계속 이용하거나, "
-"무료 모델로 전환하세요."
+"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구"
+"독을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -213,7 +221,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다시 시도하세요."
+msgstr ""
+"%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다"
+"시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -304,8 +314,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사용자의 메시지나 모델의 응답을 보거나 서버에 이 "
-"채팅을 저장할 수 없습니다."
+"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사"
+"용자의 메시지나 모델의 응답을 보거나 서버에 이 채팅을 저장할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -349,6 +359,12 @@ msgid "%s used"
 msgstr "%1$s 사용"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "조회수 %1$s"
@@ -384,7 +400,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
+msgstr ""
+"%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔"
+"서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -394,7 +412,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
+msgstr ""
+"%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채"
+"팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -406,7 +426,9 @@ msgstr "단어 %1$s개"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합니다.%7$s"
+msgstr ""
+"%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합"
+"니다.%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -414,8 +436,8 @@ msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 표시한 후 %8$s확인%9$s을 "
-"클릭합니다."
+"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 "
+"표시한 후 %8$s확인%9$s을 클릭합니다."
 
 # Firefox
 # smartling.placeholder_format=C
@@ -425,8 +447,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s에 체크 표시한 후 "
-"%8$s확인%9$s을 클릭합니다."
+"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s"
+"에 체크 표시한 후 %8$s확인%9$s을 클릭합니다."
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -434,7 +456,9 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 시도해 보세요."
+msgstr ""
+"이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 "
+"시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -452,14 +476,16 @@ msgstr "%1$s더 알아보기%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
+msgstr ""
+"%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
+msgstr ""
+"DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -477,7 +503,8 @@ msgstr "홈 화면에서 DuckDuckGo 앱 아이콘을 %1$s길게 누릅니다%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
+msgstr ""
+"%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -584,6 +611,12 @@ msgstr "지난 24시간 동안 DuckDuckGo가 1번의 시도 차단"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1일 전"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -804,14 +837,17 @@ msgstr "6시간 사용 제한에 도달했습니다."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr ""
+"6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니다."
+msgstr ""
+"6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -864,14 +900,17 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 확인하고 다시 시도하세요."
+msgstr ""
+"Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 "
+"확인하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
+msgstr ""
+"새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -922,9 +961,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능을 끄면 DuckDuckGo Search의 AI "
-"Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 %1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 "
-"이용할 수 있습니다."
+"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능"
+"을 끄면 DuckDuckGo Search의 AI Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 "
+"%1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -985,9 +1024,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 "
-"제공하는 경우는 많습니다. Duck.ai는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI "
-"기반 채팅 서비스입니다."
+"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문"
+"을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 제공하는 경우는 많습니다. Duck.ai"
+"는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI 기반 "
+"채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1171,7 +1211,9 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr "이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
+msgstr ""
+"이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전"
+"환하세요."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1206,14 +1248,18 @@ msgstr "광고"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사"
+"용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr "광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 "
+"데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1263,7 +1309,9 @@ msgstr "DuckDuckGo 확장 프로그램 추가"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세요."
+msgstr ""
+"다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세"
+"요."
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1478,6 +1526,14 @@ msgid "Advanced Models"
 msgstr "고급 모델"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "검색 광고"
@@ -1517,7 +1573,8 @@ msgstr "다운로드가 완료되고 파일이 열리면 %1$s설치%2$s를 클�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
+msgstr ""
+"다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1653,8 +1710,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 대화 내용을 채팅 모델 훈련에 사용하지 "
-"않습니다."
+"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 "
+"대화 내용을 채팅 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1686,7 +1743,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
+msgstr ""
+"모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1700,7 +1758,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니다."
+msgstr ""
+"AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니"
+"다."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1731,7 +1791,8 @@ msgstr "허용"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
+msgstr ""
+"음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1763,15 +1824,17 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 "
-"보냅니다. %2$s 모델의 프롬프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
+"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이"
+"터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 보냅니다. %2$s 모델의 프롬"
+"프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr "Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
+msgstr ""
+"Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1908,7 +1971,8 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr ""
+"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1916,7 +1980,8 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr ""
+"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1929,7 +1994,9 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택하거나 완전히 비활성화할 수 있습니다."
+msgstr ""
+"웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택"
+"하거나 완전히 비활성화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -1975,7 +2042,9 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr "Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보를 들려줘)?"
+msgstr ""
+"Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보"
+"를 들려줘)?"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2140,8 +2209,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거나 공유하지 않습니다. 모든 개인정보 보호는 "
-"사용자의 기기에서 이루어집니다."
+"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거"
+"나 공유하지 않습니다. 모든 개인정보 보호는 사용자의 기기에서 이루어집니다."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2239,6 +2308,12 @@ msgid "Ask privately"
 msgstr "비공개로 질문하기"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2271,10 +2346,11 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 생성할 수 있습니다. Assist 표시 빈도 선택 "
-"가능: 안 함(검색 결과에서 Assist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), "
-"가끔(관련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표시). 현재 AI 지원 답변은 미국(영어) "
-"지역에서만 이용 가능합니다."
+"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 "
+"생성할 수 있습니다. Assist 표시 빈도 선택 가능: 안 함(검색 결과에서 Assist UI"
+"를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), 가끔(관"
+"련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표"
+"시). 현재 AI 지원 답변은 미국(영어) 지역에서만 이용 가능합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2286,9 +2362,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 "
-"자연어 기술을 사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 "
-"자동 생성합니다."
+"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이"
+"며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관"
+"련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤"
+"링%2$s을 기반으로 자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2420,13 +2497,17 @@ msgstr "자동 응답"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다."
+msgstr ""
+"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 있습니다."
+msgstr ""
+"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2451,8 +2532,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
-"현재 Assist 서비스는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 "
+"익명으로 정보를 조회하고 요약할 수 있습니다. 현재 Assist 서비스는 영어 사용 "
+"지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2461,14 +2543,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 "
-"수 있습니다. 현재 DuckAssist 서비스는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색"
+"에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. 현재 DuckAssist 서비스"
+"는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
+msgstr ""
+"영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2668,8 +2752,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데이터와 같은 개인정보(PII)를 제거하여 대화 "
-"내용을 익명화합니다."
+"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데"
+"이터와 같은 개인정보(PII)를 제거하여 대화 내용을 익명화합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3050,16 +3134,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
-"암호화 보호 강화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 "
+"%1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 "
+"이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
-"암호화 보호 강화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확"
+"장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3067,8 +3153,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 "
-"차단, 사이트 암호화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으"
+"로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 차단, 사이트 암호화 기능을 이"
+"용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3175,9 +3262,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 Cloud Save를 사용하여 설정을 보다 영구적으로 "
-"저장할 수 있습니다(클라우드의 원격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호 또한 서버에 저장되지 "
-"않습니다."
+"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 "
+"Cloud Save를 사용하여 설정을 보다 영구적으로 저장할 수 있습니다(클라우드의 원"
+"격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암"
+"호 또한 서버에 저장되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3185,8 +3273,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s "
-"페이지를 확인하세요."
+"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
+"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3195,8 +3283,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 "
-"%1$s 페이지를 확인하세요."
+"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
+"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3231,7 +3319,8 @@ msgstr "카메룬"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
+msgstr ""
+"닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3551,7 +3640,9 @@ msgstr "전체 사이트에 적용되는 배경 색상을 변경합니다."
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경합니다."
+msgstr ""
+"검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경"
+"합니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3680,8 +3771,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 타사 AI 채팅 모델과 익명으로 대화할 "
-"수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 "
+"타사 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 DuckDuckGo "
+"Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
 "%1$shttps://duck.ai%2$s에 바로 접속해서 채팅을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
@@ -3737,14 +3829,18 @@ msgstr "비공개로 채팅하기"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅하세요."
+msgstr ""
+"DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공개로 채팅하세요."
+msgstr ""
+"DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공"
+"개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3757,6 +3853,12 @@ msgstr "%1$s 서비스와 비공개 채팅"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "AI와 비공개 채팅"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3806,7 +3908,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
+msgstr ""
+"채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채"
+"팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3818,9 +3922,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
-"암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 "
-"저장이 중단됩니다."
+"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅"
+"을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버"
+"에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로"
+"운 프롬프트와 응답의 임시 저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3843,15 +3948,17 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일은 %2$s의 콘텐츠 조정 공급자에 의한 익명 "
-"검토를 거칩니다."
+"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일"
+"은 %2$s의 콘텐츠 조정 공급자에 의한 익명 검토를 거칩니다."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr "첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화를 재개할 수 있습니다."
+msgstr ""
+"첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화"
+"를 재개할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -3904,7 +4011,8 @@ msgstr "철자 검사"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
+msgstr ""
+"DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4196,8 +4304,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무기한으로 보관하거나, AI Chat을 7일 이상 사용하지 "
-"않으면 자동으로 삭제할 수 있습니다."
+"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무"
+"기한으로 보관하거나, AI Chat을 7일 이상 사용하지 않으면 자동으로 삭제할 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4207,8 +4316,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 "
-"사용하지 않으면 자동으로 삭제될 수도 있습니다."
+"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅"
+"이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 사용하지 않으면 자동으로 "
+"삭제될 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4216,7 +4326,9 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr "브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 DuckDuckGo 무료 브라우저에"
+msgstr ""
+"브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 "
+"DuckDuckGo 무료 브라우저에"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4225,8 +4337,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 "
-"AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 후속 질문을 하세요."
+"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모"
+"델을 지원하는 DuckDuckGo의 비공개 AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 "
+"후속 질문을 하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4267,7 +4380,9 @@ msgstr "드롭다운 메뉴에서 %1$s검색 설정 변경%2$s을 클릭하세�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환경설정%4$s을 클릭하세요."
+msgstr ""
+"Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환"
+"경설정%4$s을 클릭하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4283,7 +4398,9 @@ msgstr "DuckDuckGo 확장 프로그램을 다운로드하려면 %1$s여기%2$s�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세요."
+msgstr ""
+"%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세"
+"요."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4297,7 +4414,9 @@ msgstr "왼쪽 사이드바에서 %1$s개인정보 및 서비스%2$s를 클릭�
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s기어 모양 아이콘%4$s을 클릭하세요)."
+msgstr ""
+"상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s"
+"기어 모양 아이콘%4$s을 클릭하세요)."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4326,7 +4445,8 @@ msgstr "%1$s예%2$s를 클릭하세요."
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
+msgstr ""
+"Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4388,8 +4508,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지만 브라우저에는 남아있습니다. 남아있는 데이터를 "
-"제거하려면 %3$s모든 검색 설정 초기화%4$s를 클릭하거나 누르세요."
+"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지"
+"만 브라우저에는 남아있습니다. 남아있는 데이터를 제거하려면 %3$s모든 검색 설"
+"정 초기화%4$s를 클릭하거나 누르세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4400,8 +4521,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서는 데이터가 삭제되지만, %3$s모든 설정 "
-"초기화%4$s를 클릭하거나 누를 때까지 브라우저에는 데이터가 남아 있게 됩니다."
+"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서"
+"는 데이터가 삭제되지만, %3$s모든 설정 초기화%4$s를 클릭하거나 누를 때까지 브"
+"라우저에는 데이터가 남아 있게 됩니다."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4469,14 +4591,18 @@ msgstr "검색 창에서 드롭다운을 클릭하세요."
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 %3$sDuckDuckGo%4$s를 선택하세요."
+msgstr ""
+"주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 "
+"%3$sDuckDuckGo%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr "광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리에 있습니다."
+msgstr ""
+"광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리"
+"에 있습니다."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4517,6 +4643,12 @@ msgstr "클립아트"
 #. An accessible label for a button that closes a modal dialog
 msgid "Close"
 msgstr "닫기"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4561,6 +4693,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "검색 닫기"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4664,7 +4802,9 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
+msgstr ""
+"Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 "
+"수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -4932,6 +5072,12 @@ msgid "Continue Blocking Ads"
 msgstr "광고 차단 계속하기"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4997,6 +5143,12 @@ msgid "Cookie data:"
 msgstr "쿠키 데이터:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5035,13 +5187,20 @@ msgstr "복사"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
+msgstr ""
+"주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "코드 복사"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5157,6 +5316,12 @@ msgid "Create Image"
 msgstr "이미지 만들기"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5198,6 +5363,14 @@ msgstr "만든 사람"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "%1$s 제작"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5353,6 +5526,12 @@ msgid "Customize responses"
 msgstr "응답 맞춤 설정"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "이 페이지 사용자 지정"
@@ -5417,14 +5596,17 @@ msgstr "일일 한도에 도달했습니다."
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr ""
+"일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있습니다."
+msgstr ""
+"일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5635,10 +5817,22 @@ msgid "Delete Server Data?"
 msgstr "서버 데이터를 삭제하시겠습니까?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "녹취록 삭제"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5671,6 +5865,12 @@ msgstr "이미지 삭제"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "이미지를 삭제할래?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5796,7 +5996,8 @@ msgstr "Duck.ai 받아쓰기"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr ""
+"당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5813,7 +6014,9 @@ msgstr "받아쓰기를 일시적으로 사용할 수 없습니다"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
+msgstr ""
+"받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력"
+"하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -5977,6 +6180,12 @@ msgid "Dismiss promotion"
 msgstr "프로모션 무시하기"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6081,7 +6290,9 @@ msgstr "목록에 DuckDuckGo가 보이지 않으시나요?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요.%4$s"
+msgstr ""
+"파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요."
+"%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6119,8 +6330,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 AI 이미지를 걸러냅니다. "
-"%3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 "
+"AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6129,8 +6340,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하지 않고 AI 이미지를 걸러냅니다. "
-"%3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하"
+"지 않고 AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6187,6 +6398,12 @@ msgid "Download DuckDuckGo"
 msgstr "DuckDuckGo 다운로드"
 
 # smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo Browser"
@@ -6239,7 +6456,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr "실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
+msgstr ""
+"실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하"
+"세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6247,7 +6466,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr "가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
+msgstr ""
+"가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 "
+"작성하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6267,7 +6488,9 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성하세요."
+msgstr ""
+"다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6275,7 +6498,9 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr "팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써보세요."
+msgstr ""
+"팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써"
+"보세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6394,6 +6619,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai - DuckDuckGo가 선보이는 비공개 무료 AI 채팅"
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6401,8 +6632,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있습니다. 페이지 내용은 사용자가 첨부할 때만 "
-"포함됩니다. 또는 설정에서 페이지 자동 첨부를 선택하세요."
+"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있"
+"습니다. 페이지 내용은 사용자가 첨부할 때만 포함됩니다. 또는 설정에서 페이지 "
+"자동 첨부를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6412,8 +6644,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 "
-"시도하세요."
+"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 "
+"설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6421,13 +6653,16 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr "Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
+msgstr ""
+"Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합니다!"
+msgstr ""
+"Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합"
+"니다!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6436,7 +6671,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사람들을 위한 독립된 온라인 보호 기업입니다."
+msgstr ""
+"Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사"
+"람들을 위한 독립된 온라인 보호 기업입니다."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6450,7 +6687,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기억하기 쉽게 바뀌었습니다."
+msgstr ""
+"Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기"
+"억하기 쉽게 바뀌었습니다."
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6464,14 +6703,18 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr ""
+"Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)"
+"를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
+msgstr ""
+"Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6485,8 +6728,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄면 Duck.ai 버튼과 링크가 숨겨지지만 "
-"%1$sduck.ai%2$s에 들어가서 직접 기능을 이용할 수 있습니다."
+"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄"
+"면 Duck.ai 버튼과 링크가 숨겨지지만 %1$sduck.ai%2$s에 들어가서 직접 기능을 이"
+"용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6497,9 +6741,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 "
-"DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
-"%1$shttps://duck.ai%2$s에 바로 접속해서 Duck.ai를 이용할 수 있습니다."
+"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화"
+"할 수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보"
+"이지 않습니다. 하지만 이 설정이 꺼져 있어도 %1$shttps://duck.ai%2$s에 바로 접"
+"속해서 Duck.ai를 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6513,7 +6758,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr "Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하실 수 있습니다."
+msgstr ""
+"Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하"
+"실 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6527,6 +6774,12 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr "Duck.ai 답변은 특정 자료에 근거하거나 정확성을 확인하지 않습니다."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6544,7 +6797,8 @@ msgstr "Duck.ai가 업그레이드되었습니다!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
+msgstr ""
+"Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6554,8 +6808,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필요 없는 AI 채팅, "
-"OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이버시 중심 AI, 계정 필요 없는 AI 채팅"
+"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필"
+"요 없는 AI 채팅, OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이"
+"버시 중심 AI, 계정 필요 없는 AI 채팅"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6583,9 +6838,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. DuckAssist 표시 빈도 선택 가능: 안 "
-"함(검색 결과에서 DuckAssist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 "
-"표시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영어) 지역에서만 제공됩니다."
+"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
+"DuckAssist 표시 빈도 선택 가능: 안 함(검색 결과에서 DuckAssist UI를 완전히 제"
+"거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 표"
+"시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영"
+"어) 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6594,8 +6851,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
+"지원하는 비공개 AI 기반 채팅 서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니"
+"다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6604,8 +6862,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
+"지원하는 비공개 AI 기반 채팅 서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니"
+"다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6617,9 +6876,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 관련 사이트에서 의미있는 콘텐츠를 검색한 "
-"다음 AI 기반 자연어 기술을 사용하여 해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용을 기반으로 "
-"답변을 제공하며 정확성 검사는 하지 않습니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 "
+"관련 사이트에서 의미있는 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여 "
+"해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용"
+"을 기반으로 답변을 제공하며 정확성 검사는 하지 않습니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6633,17 +6893,21 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 "
-"사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 바로 링크하고 "
-"답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 "
-"기반으로 자동 생성합니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관"
+"련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관련 정보를 바"
+"탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 "
+"바로 링크하고 답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정"
+"보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 자"
+"동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr "DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습니다."
+msgstr ""
+"DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6651,7 +6915,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
+msgstr ""
+"하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채"
+"팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6660,8 +6926,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
+"개 AI 기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6670,8 +6936,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
+"개 AI 기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6679,7 +6945,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr "DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있습니다."
+msgstr ""
+"DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6687,7 +6955,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 "
+"코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6695,13 +6965,16 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다"
+"시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -6820,15 +7093,17 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정보(PII)를 자동으로 제거해 이러한 보고서를 "
-"익명화합니다."
+"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정"
+"보(PII)를 자동으로 제거해 이러한 보고서를 익명화합니다."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동의합니다."
+msgstr ""
+"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동"
+"의합니다."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6836,7 +7111,9 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s에 동의합니다."
+msgstr ""
+"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s"
+"에 동의합니다."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6845,8 +7122,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에서 사용자 추적을 시도하는 Google과 "
-"Facebook 등의 추적기도 차단합니다."
+"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에"
+"서 사용자 추적을 시도하는 Google과 Facebook 등의 추적기도 차단합니다."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6858,10 +7135,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위치 정보는 로컬 기기에만 저장됩니다. 사용자가 "
-"검색을 하면 사용자의 기기는 해당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 데 사용한 "
-"후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 "
-"알아보세요%2$s."
+"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위"
+"치 정보는 로컬 기기에만 저장됩니다. 사용자가 검색을 하면 사용자의 기기는 해"
+"당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 "
+"데 사용한 후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보"
+"를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6881,8 +7159,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋은 결과를 제공할 수 있습니다. %1$s자세히 "
-"알아보세요%2$s."
+"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋"
+"은 결과를 제공할 수 있습니다. %1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6968,8 +7246,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 목록을 받습니다. 그러 다음 브라우저에서 목록에 "
-"포함된 4~5개의 무작위 단어를 선택하여 최소 18~20자 이상의 암호를 만듭니다."
+"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 "
+"목록을 받습니다. 그러 다음 브라우저에서 목록에 포함된 4~5개의 무작위 단어를 "
+"선택하여 최소 18~20자 이상의 암호를 만듭니다."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7136,6 +7415,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "가장 많이 방문한 사이트 활성화"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7170,7 +7455,9 @@ msgstr "웹 검색 활성화"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변경할 수 있습니다."
+msgstr ""
+"보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변"
+"경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7212,7 +7499,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위치는 DuckDuckGo에 공개하지 않을 수 있습니다."
+msgstr ""
+"익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위"
+"치는 DuckDuckGo에 공개하지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7373,7 +7662,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이터가 새 암호로 저장됩니다."
+msgstr ""
+"새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이"
+"터가 새 암호로 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7398,7 +7689,9 @@ msgstr "번역할 내용 입력하기"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네임%6$s: d%7$s"
+msgstr ""
+"다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네"
+"임%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7423,6 +7716,12 @@ msgstr "설정을 불러오려면 암호를 입력하세요."
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "엔터테인먼트 가이드"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7492,7 +7791,9 @@ msgstr "지도 확장하기"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습니다."
+msgstr ""
+"개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7584,6 +7885,18 @@ msgstr "선정적인 콘텐츠"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "노골적인 가사"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7687,6 +8000,12 @@ msgid "FREE"
 msgstr "무료"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7742,7 +8061,8 @@ msgstr "피드백이 성공적으로 전송되었습니다."
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
+msgstr ""
+"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7750,7 +8070,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
+msgstr ""
+"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사"
+"용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7840,13 +8162,16 @@ msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니�
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
+msgstr ""
+"이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세요%2$s"
+msgstr ""
+"이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세"
+"요%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -7887,7 +8212,8 @@ msgstr "다운로드 폴더에서 <b>%1$s</b> 파일을 찾으세요"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
+msgstr ""
+"표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -7924,7 +8250,8 @@ msgstr "여러분과 보다 관련있는 결과를 찾아보세요."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
+msgstr ""
+"내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -7987,7 +8314,9 @@ msgstr "안개"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 클릭해야 할 수도 있습니다."
+msgstr ""
+"안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 "
+"클릭해야 할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8089,6 +8418,12 @@ msgid "Free Up Storage"
 msgstr "저장 공간 확보하기"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8098,7 +8433,8 @@ msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
+msgstr ""
+"DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8209,8 +8545,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 "
-"확인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
+"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 확"
+"인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8560,7 +8896,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr ""
+"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 "
+"Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8570,7 +8908,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr ""
+"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 "
+"Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8596,6 +8936,12 @@ msgid "Get computer help"
 msgstr "컴퓨터 도움 받기"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8604,7 +8950,9 @@ msgstr "설정이 사라지지 않도록 DuckDuckGo 브라우저를 이용하세
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 수 있습니다."
+msgstr ""
+"다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8631,6 +8979,18 @@ msgid "Get the Latest Version"
 msgstr "최신 버전 다운로드"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8651,6 +9011,12 @@ msgstr "이 노래 듣기:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "더 많은 사람들에게 추천해서 DuckDuckGo의 성장을 도와주세요!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8681,8 +9047,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8691,8 +9057,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8702,8 +9068,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device%4$s로 들어가서 코드 스캔:"
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8713,8 +9079,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR"
+"을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8728,7 +9095,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr "%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비스'가 켜져 있는지 확인합니다."
+msgstr ""
+"%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비"
+"스'가 켜져 있는지 확인합니다."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8736,7 +9105,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 %3$sDuckDuckGo%4$s를 찾습니다."
+msgstr ""
+"%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 "
+"%3$sDuckDuckGo%4$s를 찾습니다."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9329,6 +9700,12 @@ msgid "Hide Tips"
 msgstr "팁 숨기기"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9412,7 +9789,9 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 강조 표시합니다."
+msgstr ""
+"중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 "
+"강조 표시합니다."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9439,8 +9818,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그런 다음 %5$s기본값으로 "
-"설정%6$s을 클릭하세요"
+"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그"
+"런 다음 %5$s기본값으로 설정%6$s을 클릭하세요"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9453,7 +9832,9 @@ msgstr "몽족어"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 보호 기능을 사용할 수 없게 됩니다."
+msgstr ""
+"잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 "
+"보호 기능을 사용할 수 없게 됩니다."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9502,7 +9883,9 @@ msgstr "더움"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr "호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수"
+"집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9764,7 +10147,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으며, 그 이유는 무엇인가요?"
+msgstr ""
+"바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으"
+"며, 그 이유는 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9798,7 +10183,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 및 개인정보 보호 재설정%2$s으로 이동하세요."
+msgstr ""
+"여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 "
+"및 개인정보 보호 재설정%2$s으로 이동하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9808,8 +10195,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사이트 설정 > 위치%2$s로 이동하여 "
-"DuckDuckGo의 위치 접근을 허용하세요."
+"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사"
+"이트 설정 > 위치%2$s로 이동하여 DuckDuckGo의 위치 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9823,7 +10210,9 @@ msgstr "이 오류가 계속되면 %1$s에 문의하세요."
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가해야 합니다."
+msgstr ""
+"만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가"
+"해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9831,7 +10220,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이지에 직접 문의하실 수도 있습니다."
+msgstr ""
+"채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이"
+"지에 직접 문의하실 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9839,13 +10230,17 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
+msgstr ""
+"기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니"
+"다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
+msgstr ""
+"저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주"
+"세요%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -9854,7 +10249,8 @@ msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
+msgstr ""
+"JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10002,8 +10398,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 서버를 통해 처리되도록 경로 변경이 필요합니다. "
-"%1$s자세히 알아보세요%2$s."
+"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 "
+"서버를 통해 처리되도록 경로 변경이 필요합니다. %1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10013,7 +10409,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동기화”로 이동하세요."
+msgstr ""
+"DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동"
+"기화”로 이동하세요."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10027,7 +10425,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개됩니다."
+msgstr ""
+"투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개"
+"됩니다."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10432,8 +10832,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 "
-"연결되며, 광고와는 달리 DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
+"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 "
+"통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 연결되며, 광고와는 달리 "
+"DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10441,7 +10842,8 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
+msgstr ""
+"임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10908,6 +11310,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "DuckDuckGo에서는 검색 정보를 남기지 않고 검색할 수 있습니다"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "라이베리아"
 
@@ -10976,6 +11385,12 @@ msgstr "선 그림"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "획득한 라인아웃"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11628,7 +12043,8 @@ msgstr "미크로네시아"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
+msgstr ""
+"마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12068,6 +12484,12 @@ msgid "More than 20 minutes"
 msgstr "20분 이상"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12388,8 +12810,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버에 임시로 "
-"저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니다."
+"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트"
+"와 응답을 암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성"
+"화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니"
+"다."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12553,6 +12977,12 @@ msgid "No Thanks"
 msgstr "사양합니다"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "절대. 추적하지 않습니다."
@@ -12698,7 +13128,8 @@ msgstr "검색 결과가 없습니다."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
+msgstr ""
+"음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13204,13 +13635,21 @@ msgstr "요청 시"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이콘 > 설정을 클릭하세요.%5$s"
+msgstr ""
+"Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이"
+"콘 > 설정을 클릭하세요.%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "설정(단, 번호 없음)"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13225,7 +13664,9 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 파일을 업로드하세요."
+msgstr ""
+"첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 "
+"파일을 업로드하세요."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13251,7 +13692,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지를 참고하세요."
+msgstr ""
+"사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지"
+"를 참고하세요."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13265,7 +13708,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+msgstr ""
+"이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13417,6 +13861,12 @@ msgstr "채팅 제안 열기"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "이미지 만들기 및 편집 제안 열기"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -13581,7 +14031,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 추적하지 않습니다."
+msgstr ""
+"다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 "
+"추적하지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13593,7 +14045,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr "DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공유하지 않습니다."
+msgstr ""
+"DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공"
+"유하지 않습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13601,8 +14055,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강화 등의 기능이 탑재되어 있습니다. %1$siOS "
-"및 Android%2$s에서 다운로드하세요."
+"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강"
+"화 등의 기능이 탑재되어 있습니다. %1$siOS 및 Android%2$s에서 다운로드하세요."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13854,7 +14308,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 않기 때문에 암호를 복구할 수 없습니다."
+msgstr ""
+"해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 "
+"않기 때문에 암호를 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14054,8 +14510,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 답변 수준이 높아질 수 있습니다. 이 기능을 끄고 "
-"Assist 버튼을 숨기려면 %1$s검색 설정%2$s으로 들어가세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 "
+"답변 수준이 높아질 수 있습니다. 이 기능을 끄고 Assist 버튼을 숨기려면 %1$s검"
+"색 설정%2$s으로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14064,8 +14521,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어난 답을 얻을 가능성이 높아집니다. "
-"%1$sDuckAssist 설정%2$s에서 이 기능을 끄거나 작동 방식을 조정할 수 있습니다."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어"
+"난 답을 얻을 가능성이 높아집니다. %1$sDuckAssist 설정%2$s에서 이 기능을 끄거"
+"나 작동 방식을 조정할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14075,8 +14533,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 "
-"끄고 Assist 버튼을 감추려면 %1$sDuckAssist 설정%2$s을 방문하세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 "
+"더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 끄고 Assist 버튼을 감추려면 "
+"%1$sDuckAssist 설정%2$s을 방문하세요."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14108,7 +14567,9 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
+msgstr ""
+"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
+"보세요."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14116,7 +14577,9 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
+msgstr ""
+"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
+"보세요."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14124,7 +14587,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보호 기능이 제공되지 않습니다."
+msgstr ""
+"목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보"
+"호 기능이 제공되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14145,10 +14610,22 @@ msgid "Pin"
 msgstr "핀"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "%1$s %2$s에서 채팅을 여기에 고정"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14166,6 +14643,12 @@ msgstr "분홍색"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "고정됨"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14254,7 +14737,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해하거나 불법적인 이유를 설명해 주세요."
+msgstr ""
+"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해"
+"하거나 불법적인 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14262,7 +14747,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법이거나 해로운 이유를 설명해 주세요."
+msgstr ""
+"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법"
+"이거나 해로운 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14414,7 +14901,9 @@ msgstr "DuckDuckGo를 구독하면 더 많은 프리미엄 기능들도 따라�
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr ""
+"또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14471,6 +14960,12 @@ msgstr "폴란드어"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "형식이 조악함"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -14679,6 +15174,12 @@ msgstr "이전 이미지"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "이전 탭"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -14901,7 +15402,8 @@ msgstr "DuckDuckGo는 절대 저장하지 않는 비공개 채팅"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr "DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
+msgstr ""
+"DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -14973,7 +15475,9 @@ msgstr "재생하기 전에 물어보기"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니다."
+msgstr ""
+"내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니"
+"다."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -14991,7 +15495,8 @@ msgstr "검색과 인터넷 이용 과정에서 데이터를 보호하세요."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
+msgstr ""
+"검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15015,7 +15520,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입력]"
+msgstr ""
+"다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입"
+"력]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15217,6 +15724,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "중간 수준의 조정 기능이 내장된 추론형 AI"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15252,12 +15771,20 @@ msgid "Recent chat storage can be adjusted in %s."
 msgstr "최근 채팅 저장 공간은 %1$s에서 조정할 수 있습니다."
 
 # smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
 msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
+msgstr ""
+"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
+"됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15265,7 +15792,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
+msgstr ""
+"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
+"됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15275,8 +15804,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
-"암호화하여 DuckDuckGo 서버에 임시로 저장합니다."
+"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 "
+"때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 "
+"DuckDuckGo 서버에 임시로 저장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15399,6 +15929,12 @@ msgstr "이 사이트 없이 다시 검색"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "사용량 줄이기"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15545,7 +16081,9 @@ msgstr "Duck.ai를 다시 불러오기"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 DuckDuckGo를 새로고침하세요."
+msgstr ""
+"안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 "
+"DuckDuckGo를 새로고침하세요."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15634,14 +16172,18 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
+msgstr ""
+"'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 "
+"항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
+msgstr ""
+"'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변"
+"이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15699,15 +16241,18 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. 사용자님이 익명으로 보내주신 의견은 %1$s "
-"사에도 서비스 개선을 위해 제공됩니다."
+"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. "
+"사용자님이 익명으로 보내주신 의견은 %1$s 사에도 서비스 개선을 위해 제공됩니"
+"다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
+msgstr ""
+"DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 "
+"기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15716,8 +16261,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 요청하는 모든 텍스트가 들어있으며, 이 텍스트는 "
-"익명 상태입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
+"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 "
+"요청하는 모든 텍스트가 들어있으며, 이 텍스트는 익명 상태입니다. 피드백에 개"
+"인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15764,6 +16310,12 @@ msgid "Reset All Settings"
 msgstr "모든 설정 초기화"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -15774,6 +16326,12 @@ msgstr "%1$s 후 초기화"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "해상도"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -15797,8 +16355,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. AI 지원 "
-"답변에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. AI 지원 답변에는 %1$s서비스 약관%2$s"
+"이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15807,8 +16366,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. "
-"DuckAssist에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. DuckAssist에는 %1$s서비스 약관%2$s이 "
+"적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15818,8 +16378,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 "
-"바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 바탕으로 자동 생성된 응답"
+"이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약"
+"관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16243,7 +16805,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많이 저장할 수도 있습니다."
+msgstr ""
+"최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많"
+"이 저장할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16403,7 +16967,9 @@ msgstr "아래로 스크롤하여 %1$s고급 설정 보기%2$s를 클릭하세�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변"
+"경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16411,7 +16977,9 @@ msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 "
+"%5$s새로 추가%6$s)을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16435,7 +17003,9 @@ msgstr "%1$sDuckDuckGo%2$s로 스크롤하여 사용자의 위치를 사용하�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클"
+"릭하세요."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16458,6 +17028,12 @@ msgstr "검색"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "%1$s 검색으로 더 가까운 곳을 찾아볼까요?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16483,10 +17059,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 콘텐츠를 검색한 다음 AI를 사용하여 간단한 "
-"답변을 생성합니다. 답변 표시 빈도는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클릭했을 때만), "
-"가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 때 표시) 중 선택하세요. 현재 Search Assist는 영어를 "
-"사용하는 일부 지역에만 제공됩니다."
+"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 "
+"콘텐츠를 검색한 다음 AI를 사용하여 간단한 답변을 생성합니다. 답변 표시 빈도"
+"는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클"
+"릭했을 때만), 가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 "
+"때 표시) 중 선택하세요. 현재 Search Assist는 영어를 사용하는 일부 지역에만 제"
+"공됩니다."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16494,8 +17072,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 충분히 찾지 못했습니다. 다른 검색을 시도해 "
-"보세요."
+"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 "
+"충분히 찾지 못했습니다. 다른 검색을 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16504,8 +17082,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s "
-"한 다음 AI를 사용하여 찾은 정보를 기반으로 간단한 답변을 생성합니다."
+"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이"
+"를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s 한 다음 AI를 사용하여 찾은 정보를 "
+"기반으로 간단한 답변을 생성합니다."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16626,8 +17205,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 위키피디아에서 바로 'ducks'를 바로 "
-"검색합니다."
+"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 "
+"위키피디아에서 바로 'ducks'를 바로 검색합니다."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16646,15 +17225,18 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하는 브라우저에 비공개 웹 검색 기능을 설치하거나, "
-"%1$sduckduckgo.com%2$s에서 바로 검색하세요."
+"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하"
+"는 브라우저에 비공개 웹 검색 기능을 설치하거나, %1$sduckduckgo.com%2$s에서 바"
+"로 검색하세요."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
 msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
-msgstr "검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용합니다)."
+msgstr ""
+"검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용"
+"합니다)."
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -16666,9 +17248,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저장됩니다. 하지만 Cloud Save를 사용하여 클라우드 "
-"원격 서버에 설정을 익명으로 저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호가 브라우저 밖으로 "
-"유출되지 않습니다."
+"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저"
+"장됩니다. 하지만 Cloud Save를 사용하여 클라우드 원격 서버에 설정을 익명으로 "
+"저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으"
+"며, 암호가 브라우저 밖으로 유출되지 않습니다."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16770,7 +17353,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16778,7 +17363,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16786,7 +17373,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 동기화된 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 동기화된 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16794,7 +17383,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 "
+"기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16808,7 +17399,15 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr ""
+"DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데"
+"이터는 본인 외에 누구도 볼 수 없습니다."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16952,7 +17551,9 @@ msgstr "Safari 메뉴에서 %1$s'이 웹사이트의 설정'%2$s을 선택하세
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입력하세요."
+msgstr ""
+"%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입"
+"력하세요."
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17016,14 +17617,18 @@ msgstr "드롭다운 메뉴에서 %1$s추가 기능 관리%2$s를 선택하세�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설정%4$s을 선택하세요."
+msgstr ""
+"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설"
+"정%4$s을 선택하세요."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵션%4$s을 선택하세요."
+msgstr ""
+"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵"
+"션%4$s을 선택하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17087,7 +17692,8 @@ msgstr "%1$s설정%2$s을 선택한 다음 %3$s검색 엔진%4$s을 선택하세
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
+msgstr ""
+"%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17208,7 +17814,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞으로 나와 나누는 모든 대화에 적용됩니다."
+msgstr ""
+"AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞"
+"으로 나와 나누는 모든 대화에 적용됩니다."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17306,6 +17914,12 @@ msgid "Set as Homepage"
 msgstr "홈페이지로 설정"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17317,7 +17931,9 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지하세요."
+msgstr ""
+"채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17369,6 +17985,18 @@ msgid "Seychelles"
 msgstr "세이셸"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17377,7 +18005,9 @@ msgstr "공유"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세요!"
+msgstr ""
+"DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세"
+"요!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17404,8 +18034,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용자의 정확한 위치를 우리에게나 AI 모델에게나 "
-"절대 공개하지 않습니다."
+"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용"
+"자의 정확한 위치를 우리에게나 AI 모델에게나 절대 공개하지 않습니다."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17466,6 +18103,12 @@ msgid "Share positive feedback"
 msgstr "긍정적인 피드백 공유"
 
 # smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17487,7 +18130,8 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
+msgstr ""
+"DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17597,6 +18241,12 @@ msgstr "북마클릿 및 설정 데이터 표시"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "상세 정보 보기"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17746,6 +18396,12 @@ msgid "Show more"
 msgstr "더 보기"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -17779,6 +18435,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "사이드바 표시"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -17833,15 +18495,17 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알림을 숨기며 검색 개인정보에는 영향을 주지 "
-"않습니다."
+"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알"
+"림을 숨기며 검색 개인정보에는 영향을 주지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
+msgstr ""
+"DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림"
+"만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17986,7 +18650,8 @@ msgstr "사이트 이름"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
+msgstr ""
+"사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18145,6 +18810,12 @@ msgid "Something went wrong, please try again later."
 msgstr "문제가 발생했습니다. 나중에 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18198,7 +18869,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
+msgstr ""
+"업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18206,7 +18878,9 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는지 확인하세요."
+msgstr ""
+"죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는"
+"지 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18220,7 +18894,9 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여기를 클릭%2$s하세요."
+msgstr ""
+"죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여"
+"기를 클릭%2$s하세요."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18280,7 +18956,8 @@ msgstr "원문 지움"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
+msgstr ""
+"원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18427,6 +19104,12 @@ msgstr "월 한도 사용 시작"
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "주간 한도 사용 시작"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -18623,7 +19306,9 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr "DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
+msgstr ""
+"DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많"
+"이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19003,6 +19688,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "절대 사용자를 추적하지 않는 검색 엔진으로 전환하세요."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19116,11 +19809,13 @@ msgid ""
 msgstr ""
 "동기화 복구 코드\n"
 "\n"
-"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅을 동기화할 수 있으며, 장치에 액세스할 수 없는 "
-"경우 동기화된 데이터를 복구할 수 있습니다.\n"
+"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅"
+"을 동기화할 수 있으며, 장치에 액세스할 수 없는 경우 동기화된 데이터를 복구할 "
+"수 있습니다.\n"
 "\n"
 "이 정보를 안전하게 보관하세요.\n"
-"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니다.\n"
+"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니"
+"다.\n"
 "\n"
 "%1$s\n"
 "\n"
@@ -19129,8 +19824,8 @@ msgstr ""
 "2. \"Sync & Backup\"를 선택한 다음, \"동기화된 데이터 복구\"를 선택합니다.\n"
 "3. 위 복구 코드를 복사하여 \"여기에 코드 붙여넣기\"에 붙여넣습니다.\n"
 "\n"
-"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 않으면 서버에서 데이터가 삭제되어 "
-"복원할 수 없습니다."
+"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 "
+"않으면 서버에서 데이터가 삭제되어 복원할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19149,6 +19844,12 @@ msgstr "다른 장치와 동기화"
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sync & Backup을 일시적으로 사용할 수 없습니다."
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19236,6 +19937,22 @@ msgstr "타지키스탄"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "개인정보를 완벽하게 보호하세요!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19473,8 +20190,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 "
-"비밀번호 또는 결제 세부 정보가 이에 포함됩니다."
+"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 "
+"가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 비밀번호 또는 결제 세부 정"
+"보가 이에 포함됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19482,7 +20200,9 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr "Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으로 저장할 수 있습니다."
+msgstr ""
+"Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으"
+"로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19511,7 +20231,8 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr "암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
+msgstr ""
+"암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -19590,7 +20311,9 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활성화되어 있는지 브라우저 설정에서 확인하세요."
+msgstr ""
+"이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활"
+"성화되어 있는지 브라우저 설정에서 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19604,7 +20327,8 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr "검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
+msgstr ""
+"검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -19623,8 +20347,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 "
-"웹사이트의 개인정보 보호를 강화하는 데 적용됩니다."
+"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, "
+"DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 웹사이트의 개인정보 보호를 "
+"강화하는 데 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19661,7 +20386,9 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세요."
+msgstr ""
+"이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -19669,7 +20396,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅을 시작해 보세요."
+msgstr ""
+"이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅"
+"을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -19684,10 +20413,22 @@ msgid "This Month"
 msgstr "이번 달"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "이번 주"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19696,8 +20437,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 "
-"수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
+"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19707,8 +20448,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 "
-"있습니다(자세한 내용은 %2$s 참조)."
+"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
+"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %2$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19717,8 +20458,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌한 정보를 제공할 수 있습니다(자세한 내용은 "
-"%2$s 참고)."
+"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌"
+"한 정보를 제공할 수 있습니다(자세한 내용은 %2$s 참고)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19728,8 +20469,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습니다. AI 채팅은 부정확하거나 "
-"공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습"
+"니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용"
+"은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19800,19 +20542,37 @@ msgstr "이 이미지를 만들 수 없습니다."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
+msgstr ""
+"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
+msgstr ""
+"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "이 정보는 유용하지 않습니다."
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -19832,7 +20592,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 제공사는 데이터를 보유하지 않는 모델을 따릅니다."
+msgstr ""
+"이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 "
+"제공사는 데이터를 보유하지 않는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19840,7 +20602,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
+msgstr ""
+"이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공"
+"사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19876,7 +20640,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 모든 브라우저에서 접근할 수 있습니다."
+msgstr ""
+"이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 "
+"모든 브라우저에서 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19884,7 +20650,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다."
+msgstr ""
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
+"면 AI 지원 답변이 다시 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19894,8 +20662,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다. "
-"하지만 AI 지원 답변이 절대 표시되지 않는 시작 페이지(%1$s)도 있습니다."
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
+"면 AI 지원 답변이 다시 표시될 수 있습니다. 하지만 AI 지원 답변이 절대 표시되"
+"지 않는 시작 페이지(%1$s)도 있습니다."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19918,13 +20687,17 @@ msgstr "이 번역은 잘못되었습니다."
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 수 있습니다."
+msgstr ""
+"아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 사용하지 않고 있습니다."
+msgstr ""
+"이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 "
+"사용하지 않고 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -19934,8 +20707,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결이 끊깁니다. Sync & Backup에 "
-"연결된 다른 브라우저에서는 계속 채팅을 볼 수 있습니다."
+"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결"
+"이 끊깁니다. Sync & Backup에 연결된 다른 브라우저에서는 계속 채팅을 볼 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19943,7 +20717,9 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+msgstr ""
+"이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌"
+"릴 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20035,7 +20811,9 @@ msgstr "팁"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니다.%2$s"
+msgstr ""
+"개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니"
+"다.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20080,7 +20858,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인쇄 아이콘을 클릭하세요.%4$s"
+msgstr ""
+"경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인"
+"쇄 아이콘을 클릭하세요.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20090,8 +20870,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합니다. 이 코드는 Sync를 설치할 때 원래 사용한 "
-"기기에 PDF로 저장되었을 수 있습니다."
+"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합"
+"니다. 이 코드는 Sync를 설치할 때 원래 사용한 기기에 PDF로 저장되었을 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20099,14 +20880,18 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트하고 다시 시도하세요."
+msgstr ""
+"채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트"
+"하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr "받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허용해 주세요."
+msgstr ""
+"받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허"
+"용해 주세요."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20123,6 +20908,12 @@ msgstr "오늘"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "오늘"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20295,7 +21086,9 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되었는지 둘러보세요."
+msgstr ""
+"DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되"
+"었는지 둘러보세요."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20342,7 +21135,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
+msgstr ""
+"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
+"주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20350,7 +21145,9 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
+msgstr ""
+"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
+"주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20530,9 +21327,21 @@ msgid "Try Them Out"
 msgstr "한번 시도해 봐"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "검색해 보세요!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -20597,6 +21406,12 @@ msgid "Try for free"
 msgstr "무료 체험"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -20609,6 +21424,12 @@ msgstr "무료 체험"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "안전한 VPN, 고급 & 비공개 AI, 그 밖의 기능을 무료로 체험해 보세요!"
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20638,6 +21459,12 @@ msgid "Try our homepage that never shows these messages:"
 msgstr "이러한 메시지가 없는 DuckDuckGo 홈페이지를 사용해 보세요."
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
 msgid "Try related keywords"
@@ -20658,7 +21485,9 @@ msgstr "위치를 수동으로 설정하세요."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 보호."
+msgstr ""
+"%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 "
+"보호."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -20750,8 +21579,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 설치하면 설정을 기억시킬 수 "
-"있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 "
+"설치하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20760,8 +21589,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 전환하면 설정을 기억시킬 수 "
-"있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 "
+"전환하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20883,6 +21712,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "타겟 광고 없이 YouTube를 시청하려면 Duck Player를 켜세요"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -20943,7 +21778,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표시되기까지 시간이 조금 지연될 수 있습니다."
+msgstr ""
+"DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표"
+"시되기까지 시간이 조금 지연될 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21072,24 +21909,30 @@ msgstr "장점과 단점 파악"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이지 설정%6$s을 클릭하세요."
+msgstr ""
+"%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이"
+"지 설정%6$s을 클릭하세요."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com을 입력하세요."
+msgstr ""
+"%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com"
+"을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
+msgstr ""
+"%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
+msgstr ""
+"%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21099,7 +21942,8 @@ msgstr "%1$s검색 설정%2$s에서 %3$sDuckDuckGo%4$s를 선택하세요."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
+msgstr ""
+"%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21111,7 +21955,8 @@ msgstr "%1$s검색%2$s 섹션에서, %3$s검색 엔진 관리...%4$s를 클릭�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
+msgstr ""
+"시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21194,7 +22039,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사용 한도를 이용하세요."
+msgstr ""
+"Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사"
+"용 한도를 이용하세요."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21235,6 +22082,12 @@ msgstr "DuckDuckGo 구독으로 고급 AI 모델을 잠금 해제하세요"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "구독을 통해 고급 AI를 이용하세요!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -21327,7 +22180,9 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr "DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 이용하세요."
+msgstr ""
+"DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 "
+"이용하세요."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21451,7 +22306,9 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr "Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
+msgstr ""
+"Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 "
+"더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -21553,8 +22410,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채팅을 보호하세요. 정보를 기밀로 유지하세요. "
-"무료로. 계정이 없어도 괜찮습니다."
+"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채"
+"팅을 보호하세요. 정보를 기밀로 유지하세요. 무료로. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21591,19 +22448,28 @@ msgid "Use in Safari"
 msgstr "Safari에서 사용"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 보관하세요."
+msgstr ""
+"기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 "
+"보관하세요."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
+msgstr ""
+"기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -21752,7 +22618,9 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소프트의 광고 네트워크에서 관리합니다."
+msgstr ""
+"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소"
+"프트의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21760,7 +22628,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 TripAdvisor의 광고 네트워크에서 관리합니다."
+msgstr ""
+"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 "
+"TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21787,7 +22657,9 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명을 따르세요."
+msgstr ""
+"휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명"
+"을 따르세요."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -21802,8 +22674,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & Backup%4$s > "
-"%5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
+"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21813,8 +22685,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 '켜기'를 선택하고 "
-"''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아"
+"래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF"
+"에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21824,8 +22697,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
-"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > "
+"%3$sSync & Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선"
+"택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21835,8 +22709,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 "
-"'켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. "
+"Sync & Backup 아래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세"
+"요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21888,7 +22763,8 @@ msgstr "음성 채팅이 끝났습니다"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr ""
+"당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22031,7 +22907,9 @@ msgstr "Duck Player에서 보기"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 YouTube 추천 영상이 달라지지 않습니다."
+msgstr ""
+"Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 "
+"YouTube 추천 영상이 달라지지 않습니다."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22051,8 +22929,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하는 웹사이트에서 사용자를 추적할 수 있습니다. "
-"DuckDuckGo는 동영상 대부분을 호스팅하는 YouTube와 무관한 독립적인 기업입니다."
+"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하"
+"는 웹사이트에서 사용자를 추적할 수 있습니다. DuckDuckGo는 동영상 대부분을 호"
+"스팅하는 YouTube와 무관한 독립적인 기업입니다."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22064,7 +22943,9 @@ msgstr "DuckDuckGo의 익명화"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니다."
+msgstr ""
+"더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22076,8 +22957,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저희가 문제를 조사하고 해결할 수 있도록 이대화를 "
-"DuckDuckGo와 공유해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저"
+"희가 문제를 조사하고 해결할 수 있도록 이대화를 DuckDuckGo와 공유해 주세요."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22089,8 +22970,9 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저희가 문제를 조사하고 해결할 수 있도록 사용하신 "
-"프롬프트와 응답 내용을 보내서 신고해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저"
+"희가 문제를 조사하고 해결할 수 있도록 사용하신 프롬프트와 응답 내용을 보내서 "
+"신고해 주세요."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22131,8 +23013,9 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따라다니며 광고를 게재하지 않습니다. "
-"DuckDuckGo는 사용자를 추적하지 않습니다. 절대."
+"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따"
+"라다니며 광고를 게재하지 않습니다. DuckDuckGo는 사용자를 추적하지 않습니다. "
+"절대."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22145,7 +23028,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 알려주시면 도움이 될 것 같습니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 "
+"알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22153,7 +23038,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알려주시면 도움이 될 것 같습니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알"
+"려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22164,7 +23051,9 @@ msgstr "DuckDuckGo는 절대로 사용자를 추적하지 않습니다."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
+"니다."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22193,19 +23082,24 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사용자를 추적하는 광고주에게 판매할 수 있는 어떠한 "
-"정보도 보유하고 있지 않습니다."
+"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사"
+"용자를 추적하는 광고주에게 판매할 수 있는 어떠한 정보도 보유하고 있지 않습니"
+"다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
+msgstr ""
+"DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
+"니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22219,7 +23113,9 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않도록 보장합니다."
+msgstr ""
+"DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않"
+"도록 보장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22243,7 +23139,9 @@ msgstr "연결이 끊겼습니다. 메시지를 다시 보내 보세요."
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr "우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터를 악용하지 않습니다."
+msgstr ""
+"우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터"
+"를 악용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22251,18 +23149,24 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든지 설정을 변경할 수 있습니다."
+msgstr ""
+"익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든"
+"지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 좋게 발전시킵니다."
+msgstr ""
+"여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 "
+"좋게 발전시킵니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 포함해서 말이죠."
+msgstr ""
+"여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 "
+"포함해서 말이죠."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22278,8 +23182,8 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s의 재량에 따라 적용됩니다. 정정 사항이 결과에 "
-"바로 나타나지 않을 수 있습니다."
+"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s"
+"의 재량에 따라 적용됩니다. 정정 사항이 결과에 바로 나타나지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22292,7 +23196,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문의하세요."
+msgstr ""
+"현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문"
+"의하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22300,7 +23206,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제가 해결되는 경우도 있습니다."
+msgstr ""
+"현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제"
+"가 해결되는 경우도 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22314,7 +23222,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노력 중입니다."
+msgstr ""
+"불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노"
+"력 중입니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22322,7 +23232,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr "Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치세요."
+msgstr ""
+"Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치"
+"세요."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22430,7 +23342,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
+msgstr ""
+"주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22444,8 +23357,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 "
-"사용되지 않습니다."
+"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되"
+"며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22454,8 +23367,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 "
-"저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공"
+"개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22465,8 +23378,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 세션입니다. 여기서 이루어지는 모든 "
-"채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 "
+"세션입니다. 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저"
+"장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22539,7 +23453,9 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr "정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로고침해 보세요."
+msgstr ""
+"정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로"
+"고침해 보세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -22573,7 +23489,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 개 알려 주세요."
+msgstr ""
+"“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 "
+"개 알려 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -22592,9 +23510,10 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? DuckDuckGo 공식 출처만 참고하세요. "
-"답변은 명료하게 섹션을 나누어 작성하고 제목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 유무에 "
-"관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
+"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? "
+"DuckDuckGo 공식 출처만 참고하세요. 답변은 명료하게 섹션을 나누어 작성하고 제"
+"목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 "
+"유무에 관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22704,6 +23623,12 @@ msgstr "어떤 점이 가장 불편하셨나요?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "오늘은 어떤 일로 돌아오셨나요?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -22823,7 +23748,8 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
+msgstr ""
+"Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -22898,7 +23824,8 @@ msgstr "무엇에 대해 피드백을 주고 싶으세요?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr ""
+"DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -22923,7 +23850,9 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr "초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나요?"
+msgstr ""
+"초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나"
+"요?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23116,6 +24045,14 @@ msgstr "승"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "진눈깨비"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -23388,7 +24325,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
+msgstr ""
+"%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23396,7 +24335,9 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 검색할 수 있습니다."
+msgstr ""
+"%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 "
+"검색할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23409,7 +24350,8 @@ msgstr "%1$s에서 DuckDuckGo AI Chat에 바로 접속할 수 있습니다."
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23417,17 +24359,22 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr "%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr ""
+"%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr "%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr ""
+"%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -23440,7 +24387,9 @@ msgstr "텍스트 선택은 %1$s개까지 첨부할 수 있습니다."
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23460,7 +24409,9 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트를 삭제할 수도 있습니다."
+msgstr ""
+"다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트"
+"를 삭제할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23489,7 +24440,8 @@ msgstr "월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
+msgstr ""
+"이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -23528,6 +24480,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "이미지는 대화당 %1$s개만 첨부할 수 있습니다."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -23545,7 +24504,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이트 차단을 먼저 해제해야 합니다."
+msgstr ""
+"차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이"
+"트 차단을 먼저 해제해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -23601,7 +24562,9 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습니다."
+msgstr ""
+"이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23610,8 +24573,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 DuckDuckGo 구독 보호 기능을 이용할 "
-"수 있습니다."
+"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 "
+"DuckDuckGo 구독 보호 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23633,8 +24596,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
-"채팅이 삭제되지는 않습니다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
+"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23644,8 +24608,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
-"채팅이 삭제되지는 않습니다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
+"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23661,14 +24626,20 @@ msgid ""
 msgstr "최신 버전이 설치되면 DuckDuckGo 앱이 자동으로 업데이트됩니다."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 "
-"다음과 같은 기능이 제공됩니다."
+"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용"
+"해 보세요. 이미 설치되어 있으며 다음과 같은 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23680,7 +24651,9 @@ msgstr "이제 개인정보 보호를 받으며 검색할 수 있습니다!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 팁을 알아보세요."
+msgstr ""
+"현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 "
+"팁을 알아보세요."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -23704,6 +24677,12 @@ msgstr "사이트 %1$s개를 차단했습니다"
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "사이트 {0}개를 차단했습니다"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -23750,8 +24729,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화를 재개하려면 가장 오래된 채팅 "
-"%1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
+"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화"
+"를 재개하려면 가장 오래된 채팅 %1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23761,8 +24741,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 첨부 파일이 있는 채팅을 오래된 순으로 "
-"%1$s개 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
+"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 "
+"첨부 파일이 있는 채팅을 오래된 순으로 %1$s개 삭제하세요. 고정된 채팅은 삭제되"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23776,8 +24757,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기서 YouTube 동영상을 시청하면 "
-"YouTube나 Google의 추적을 받게 됩니다."
+"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기"
+"서 YouTube 동영상을 시청하면 YouTube나 Google의 추적을 받게 됩니다."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23821,8 +24802,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 %1$s개가 로컬 "
-"저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
+"브라우저에서는 최근 채팅 %1$s개가 로컬 저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23832,8 +24813,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 100개가 로컬 저장소에 "
-"저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
+"브라우저에서는 최근 채팅 100개가 로컬 저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23857,14 +24838,18 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr "가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo는 절대 이 데이터에 접근할 수 없습니다."
+msgstr ""
+"가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo"
+"는 절대 이 데이터에 접근할 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터에 절대 액세스할 수 없습니다."
+msgstr ""
+"브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터"
+"에 절대 액세스할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -23872,7 +24857,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
+msgstr ""
+"%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표"
+"시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -23897,28 +24884,36 @@ msgstr "사용자의 채팅은 비공개로 처리되며 AI 모델 훈련에 사
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -23933,8 +24928,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 "
-"다음과 같습니다."
+"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련"
+"에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 다음과 같습니다."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -23973,7 +24968,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. [%2$s메시지 예시%3$s]"
+msgstr ""
+"사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. "
+"[%2$s메시지 예시%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24016,9 +25013,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 키를 생성합니다. 키와 연관된 설정 파일만 "
-"브라우저 외부로 전송됩니다. DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 암호를 절대 알 수 "
-"없습니다."
+"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 "
+"키를 생성합니다. 키와 연관된 설정 파일만 브라우저 외부로 전송됩니다. "
+"DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 "
+"암호를 절대 알 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24033,8 +25031,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데이터는 제거됩니다. 따라서 모델 제공사는 대화를 "
-"특정 사용자에 연결할 수 없습니다."
+"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데"
+"이터는 제거됩니다. 따라서 모델 제공사는 대화를 특정 사용자에 연결할 수 없습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24073,14 +25072,22 @@ msgid "Your searches can’t be tied back to you"
 msgstr "사용자의 검색 내용이 사용자에 연결되지 않습니다"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
-"설치하세요. %3$s자세히 알아보기%4$s"
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
+"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 설치하세요. %3$s자세히 알아보기%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -24100,8 +25107,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 DuckDuckGo 브라우저를 이용해서 더 철저하게 "
-"보호받으세요. 이미 설치되어 있으며 다음 기능이 제공됩니다."
+"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 "
+"DuckDuckGo 브라우저를 이용해서 더 철저하게 보호받으세요. 이미 설치되어 있으"
+"며 다음 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24117,7 +25125,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌러 이 대화를 지우세요."
+msgstr ""
+"이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌"
+"러 이 대화를 지우세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24125,7 +25135,8 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
+msgstr ""
+"이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24139,7 +25150,9 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
+msgstr ""
+"하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -24441,7 +25454,9 @@ msgstr "공식 웹사이트"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s 문자입니다)"
+msgstr ""
+"또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s "
+"문자입니다)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -24652,3 +25667,9 @@ msgstr "년"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "년"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/ku/LC_MESSAGES/duckduckgo.po
+++ b/locales/ku/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%s hate dîtin"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr "%s hewldanên şopandinê hate astengkirin"
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -488,6 +498,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 roj berê"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1229,6 +1244,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Reklam li ser Lêgerînê"
@@ -1855,6 +1877,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3107,6 +3134,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3715,6 +3747,11 @@ msgstr "Klîpart"
 msgid "Close"
 msgstr "Bigire"
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3750,6 +3787,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4057,6 +4099,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4111,6 +4158,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr "Daneyê kiloran:"
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4150,6 +4202,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4246,6 +4303,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4280,6 +4342,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4405,6 +4474,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4641,9 +4715,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4671,6 +4755,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4924,6 +5013,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5090,6 +5184,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5265,6 +5364,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5372,6 +5476,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5871,6 +5980,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Malperên Pir Têne Serdankirin Çalak bike"
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6116,6 +6230,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6249,6 +6368,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6330,6 +6459,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6661,6 +6795,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7082,6 +7221,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7113,6 +7257,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7130,6 +7284,11 @@ msgstr "Vê stranê bistîne li ser:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Hevalên xwe vexwîne û alîkariya me bike da ku em mezin bibin!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr "Gana"
@@ -7680,6 +7839,11 @@ msgstr "Gavan Veşêre"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -9005,6 +9169,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Dihêle ku tu bi awayekî nenas bigerî bi DuckDuckGo re"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9060,6 +9230,11 @@ msgstr "Xêzkirina Nigarî"
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9958,6 +10133,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Bêtirî 20 xulekan"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10352,6 +10532,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10902,6 +11087,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Veketî lê jimar tune"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11074,6 +11264,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11679,9 +11874,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11696,6 +11901,11 @@ msgstr "Gulî"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11954,6 +12164,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12123,6 +12338,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12567,6 +12787,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12594,6 +12824,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12716,6 +12951,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -13023,6 +13263,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Hemû Sazkariyan Ji nû ve Saz bike"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -13031,6 +13276,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13592,6 +13842,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr "%s bigere bo ku encamên nêzîkî xwe bibîne?"
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Nenas Bigere"
 
@@ -13876,6 +14131,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14282,6 +14542,11 @@ msgstr "Wekî Motora Lêgerînê ya Berdest Saz bike"
 msgid "Set as Homepage"
 msgstr "Wekî Rûpela Sereke Saz bike"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14334,6 +14599,16 @@ msgstr "Sazkarî hatin rojanekirin"
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14364,6 +14639,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14413,6 +14694,11 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Paşragihandinê erênî parve bike"
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
@@ -14524,6 +14810,11 @@ msgstr "Şûnpel û Daneyê Sazkariyan Nîşan bide"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Hûrgiliyan Nîşan bide"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14647,6 +14938,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14675,6 +14971,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14975,6 +15276,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15209,6 +15515,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15687,6 +15998,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Bo Motora lêgerîna biguherîne ya ku te naşopîne. Ti car."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15799,6 +16117,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15869,6 +16192,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Taybetiya Xwe Vegerîne!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16246,9 +16583,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16350,6 +16697,20 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Ev zanyarî ne alîkar e"
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
@@ -16608,6 +16969,11 @@ msgstr "Îro"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16947,9 +17313,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Lêgerînekê bicerbîne"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -17003,6 +17379,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -17013,6 +17394,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -17036,6 +17422,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Serrûpela me bicerbîne ku van peyaman nîşan nadin:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17235,6 +17626,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17527,6 +17923,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17825,6 +18226,11 @@ msgstr "Di Firefox de bi kar bîne"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Di Safari de bi kar bîne"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18763,6 +19169,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Çi te îro vegerand?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19105,6 +19516,13 @@ msgstr "Serketin"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Tevlîhev"
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
@@ -19451,6 +19869,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19559,6 +19983,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19597,6 +20026,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19905,6 +20339,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20379,6 +20820,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "sl"
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
 
 #~ msgctxt "SERP footer content"
 #~ msgid "%s Billion Searches"

--- a/locales/kw_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/kw_GB/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -483,6 +493,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1223,6 +1238,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1844,6 +1866,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3078,6 +3105,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3674,6 +3706,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3709,6 +3746,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4014,6 +4056,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4068,6 +4115,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4105,6 +4157,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4201,6 +4258,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4235,6 +4297,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4360,6 +4429,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4596,9 +4670,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4626,6 +4710,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4879,6 +4968,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5045,6 +5139,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5220,6 +5319,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5327,6 +5431,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5815,6 +5924,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6054,6 +6168,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6187,6 +6306,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6268,6 +6397,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6597,6 +6731,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7018,6 +7157,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7047,6 +7191,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7063,6 +7217,11 @@ msgstr "Kavos an gan ma war:"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7614,6 +7773,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8911,6 +9075,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8966,6 +9136,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9862,6 +10037,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10256,6 +10436,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10804,6 +10989,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Skwychys yn fyw mes heb niverow"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10972,6 +11162,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11568,9 +11763,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11585,6 +11790,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11841,6 +12051,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12010,6 +12225,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12452,6 +12672,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12479,6 +12709,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12601,6 +12836,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12903,6 +13143,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Dassettya Settyans Oll"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12911,6 +13156,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13468,6 +13718,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13748,6 +14003,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14145,6 +14405,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Settya avel gwiasva-dre"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14197,6 +14462,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14226,6 +14501,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14274,6 +14555,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14385,6 +14671,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14509,6 +14800,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14537,6 +14833,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14835,6 +15136,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15067,6 +15373,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15545,6 +15856,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15657,6 +15975,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15726,6 +16049,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16095,9 +16432,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16198,6 +16545,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16454,6 +16815,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16791,8 +17157,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16847,6 +17223,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16857,6 +17238,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16879,6 +17265,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17079,6 +17470,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17363,6 +17759,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17658,6 +18059,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18571,6 +18977,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18910,6 +19321,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19254,6 +19672,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19362,6 +19786,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19396,6 +19825,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19693,6 +20127,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20165,6 +20606,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/ky_KG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ky_KG/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4013,6 +4055,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4067,6 +4114,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4104,6 +4156,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4200,6 +4257,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4234,6 +4296,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4359,6 +4428,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4595,9 +4669,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4625,6 +4709,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4878,6 +4967,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5044,6 +5138,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5219,6 +5318,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5326,6 +5430,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5814,6 +5923,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6053,6 +6167,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6186,6 +6305,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6267,6 +6396,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6596,6 +6730,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7017,6 +7156,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7046,6 +7190,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7062,6 +7216,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7613,6 +7772,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8908,6 +9072,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8963,6 +9133,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9859,6 +10034,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10253,6 +10433,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10801,6 +10986,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Номерге, бирок"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10969,6 +11159,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11565,9 +11760,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11582,6 +11787,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11838,6 +12048,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12007,6 +12222,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12449,6 +12669,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12476,6 +12706,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12598,6 +12833,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12900,6 +13140,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12908,6 +13153,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13465,6 +13715,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13745,6 +14000,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14142,6 +14402,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Үй барак кылып орнотуу"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14194,6 +14459,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14223,6 +14498,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14271,6 +14552,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14382,6 +14668,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14506,6 +14797,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14534,6 +14830,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14832,6 +15133,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15064,6 +15370,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15542,6 +15853,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15654,6 +15972,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15723,6 +16046,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16092,9 +16429,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16195,6 +16542,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16451,6 +16812,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16788,8 +17154,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16844,6 +17220,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16854,6 +17235,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16876,6 +17262,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17076,6 +17467,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17360,6 +17756,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17655,6 +18056,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18568,6 +18974,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18907,6 +19318,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19251,6 +19669,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19359,6 +19783,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19393,6 +19822,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19690,6 +20124,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20162,6 +20603,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/ln_CD/LC_MESSAGES/duckduckgo.po
+++ b/locales/ln_CD/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -483,6 +493,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1223,6 +1238,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1844,6 +1866,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3078,6 +3105,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3674,6 +3706,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3709,6 +3746,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4014,6 +4056,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4068,6 +4115,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4105,6 +4157,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4201,6 +4258,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4235,6 +4297,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4360,6 +4429,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4596,9 +4670,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4626,6 +4710,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4879,6 +4968,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5045,6 +5139,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5220,6 +5319,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5327,6 +5431,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5815,6 +5924,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6054,6 +6168,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6187,6 +6306,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6268,6 +6397,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6597,6 +6731,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7018,6 +7157,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7047,6 +7191,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7063,6 +7217,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7614,6 +7773,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8909,6 +9073,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8964,6 +9134,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9860,6 +10035,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10254,6 +10434,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10802,6 +10987,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr ""
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10970,6 +11160,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11566,9 +11761,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11583,6 +11788,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11839,6 +12049,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12008,6 +12223,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12450,6 +12670,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12477,6 +12707,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12599,6 +12834,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12901,6 +13141,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12909,6 +13154,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13466,6 +13716,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13746,6 +14001,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14143,6 +14403,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14195,6 +14460,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14224,6 +14499,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14272,6 +14553,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14383,6 +14669,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14507,6 +14798,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14535,6 +14831,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14833,6 +15134,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15065,6 +15371,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15543,6 +15854,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15655,6 +15973,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15724,6 +16047,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16093,9 +16430,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16196,6 +16543,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16452,6 +16813,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16789,8 +17155,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16845,6 +17221,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16855,6 +17236,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16877,6 +17263,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17077,6 +17468,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17361,6 +17757,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17656,6 +18057,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18569,6 +18975,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18908,6 +19319,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19252,6 +19670,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19360,6 +19784,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19394,6 +19823,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19691,6 +20125,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20163,6 +20604,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Nearby"

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"(n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -128,7 +127,7 @@ msgstr "%1$s aptikta"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Panaudota failų: %1$s"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,7 +364,7 @@ msgstr "%1$s išnaudota"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -494,8 +493,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
+msgstr "%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -621,7 +619,7 @@ msgstr "Prieš 1 dieną"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "Panaudotas 1 failas"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -913,16 +911,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
+msgstr "Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
+msgstr "Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1539,6 +1535,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Pažangesni modeliai gali išnaudoti limitus 2-5x greičiau nei kiti modeliai. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1580,8 +1578,7 @@ msgstr "Kai atsisiųsi ir atidarysi, spustelėk %1$sĮdiegti%2$s"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
+msgstr "Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1823,8 +1820,7 @@ msgstr "Leisti anonimiškai peržiūrėti šio pokalbio failus?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
+msgstr "Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1876,8 +1872,7 @@ msgstr "Jau sinchronizuota."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
+msgstr "Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2330,7 +2325,7 @@ msgstr "Klauskite privačiai"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Klausti privačiai"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2521,8 +2516,7 @@ msgstr "Automatinis atsakymas"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
+msgstr "Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3666,8 +3660,7 @@ msgstr "Pakeičia fono spalvą visoje svetainėje"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
+msgstr "Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3884,7 +3877,7 @@ msgstr "Privatus pokalbis su DI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Kalbėtis privačiai su populiariais DI modeliais"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3976,9 +3969,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į Duck."
-"ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų teikėjas, "
-"ieškantis tokio turinio: %2$s."
+"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į "
+"Duck.ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų "
+"teikėjas, ieškantis tokio turinio: %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4438,8 +4431,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
+msgstr "Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4466,8 +4458,7 @@ msgstr "Išskleidžiamajame meniu spustelėk %1$sNustatymai%2$s."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
+msgstr "Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4534,8 +4525,7 @@ msgstr "Paieškos juostoje spustelėk %1$sdidinamąjį stiklą%2$s"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr ""
-"Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
+msgstr "Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4684,7 +4674,7 @@ msgstr "Uždaryti"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Uždaryti"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4734,7 +4724,7 @@ msgstr "Uždaryti paiešką"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Uždaryti antrąją nuomonę"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5112,6 +5102,8 @@ msgstr "Tęsti reklamų blokavimą"
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
+"Tęskite pastaruosius pokalbius čia. Arba ištrinkite juos naudodami mygtuką "
+"„Fire Button“."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5182,7 +5174,7 @@ msgstr "Slapukų duomenys:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Nukopijuota"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5223,8 +5215,7 @@ msgstr "Kopijuoti"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
+msgstr "Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5236,7 +5227,7 @@ msgstr "Kopijuoti kodą"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopijuoti nuorodą"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5355,7 +5346,7 @@ msgstr "Kurti vaizdą"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Kurti bendrinimo nuorodą"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5407,6 +5398,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Sukūrus nuorodą padaroma pokalbio kopija, kurią gali peržiūrėti visi, kas ją "
+"atidarys."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5565,7 +5558,7 @@ msgstr "Tinkinti atsakymus"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Tinkinti atsakymus"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5855,7 +5848,7 @@ msgstr "Ar trinti duomenis serveryje?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Trinti bendrintą nuorodą"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5867,7 +5860,7 @@ msgstr "Ištrinti nuorašą"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Trinti pokalbį"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5905,7 +5898,7 @@ msgstr "Ištrinti vaizdą?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Trink mane"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6031,8 +6024,7 @@ msgstr "Diktavimas „Duck.ai“"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
+msgstr "Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6218,7 +6210,7 @@ msgstr "Atsisakyti reklamos"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Atmesti turą"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6434,7 +6426,7 @@ msgstr "Atsisiųsk „DuckDuckGo“."
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Atsisiųsti „DuckDuckGo“"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6657,7 +6649,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "„Duck.ai“ dabar gali analizuoti PDF failus. Išbandyk!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6820,7 +6812,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "„Duck.ai“ palaiko „Anthropic“, „OpenAI“ ir kitus modelius."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6977,8 +6969,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
-"„%3$s“ „%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
+"„%4$s“."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6988,8 +6980,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
-"„%3$s“ „%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
+"„%4$s“."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7025,8 +7017,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
+msgstr "„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7155,8 +7146,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su „Duck."
-"ai“ %2$s."
+"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su "
+"„Duck.ai“ %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7301,9 +7292,9 @@ msgid ""
 "characters long."
 msgstr ""
 "Kiekvieną kartą, kai paprašai pasiūlyti slaptafrazę, naudojame didelį "
-"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame 4–"
-"5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent 18–"
-"20 simbolių ilgio."
+"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame "
+"4–5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent "
+"18–20 simbolių ilgio."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7475,7 +7466,7 @@ msgstr "Įjungti Lankomiausias Svetaines"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Įjunk dabar"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7636,15 +7627,13 @@ msgstr "Ar tau patinka „Duck.ai“?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
+msgstr "Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
+msgstr "Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7782,7 +7771,7 @@ msgstr "Pramogų vadovas"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Visas pokalbis"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7792,8 +7781,7 @@ msgstr "Pusiaujo Gvinėja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
+msgstr "Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7884,8 +7872,7 @@ msgstr "Paprastais žodžiais paaiškink priimtą atsakymą."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
+msgstr "Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7951,20 +7938,19 @@ msgstr "Suaugusiesiems skirti dainų tekstai"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Naršyti „Duck.ai“"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Naršyti „Duck.ai“"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
+msgstr "Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8065,7 +8051,7 @@ msgstr "Nemokamai"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "NEMOKAMA IR NEPRIVALOMA"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8143,8 +8129,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
+msgstr "Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8266,8 +8251,7 @@ msgstr "Finansų konsultantas"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
+msgstr "Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8391,8 +8375,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
+msgstr "Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8491,7 +8474,7 @@ msgstr "Atlaisvink vietos"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Nemokama ir visada privatu"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8503,8 +8486,7 @@ msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
+msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8955,8 +8937,7 @@ msgstr "Pradėti"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
+msgstr "Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9015,20 +8996,18 @@ msgstr "Reikia pagalbos dėl kompiuterio"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Gauk didesnius naudojimo limitus su „DuckDuckGo“ prenumerata."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
-msgstr ""
-"Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
+msgstr "Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
+msgstr "Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9058,13 +9037,15 @@ msgstr "Gaukite naujausią versiją"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Gauti programą"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas "
+"„YouTube“.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9092,7 +9073,7 @@ msgstr "Pakviesk draugus ir padėk mums augti!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Darbo pradžios kontrolinis sąrašas"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9783,7 +9764,7 @@ msgstr "Slėpti patarimus"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Slėpti pamoką"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10239,8 +10220,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
+msgstr "Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10473,8 +10453,7 @@ msgstr "Pagerink argumentus"
 msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
-msgstr ""
-"Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
+msgstr "Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10906,8 +10885,7 @@ msgstr "Ji greita, nemokama ir užtikrina dar daugiau apsaugos internete."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
+msgstr "Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11410,7 +11388,7 @@ msgstr "Leidžia ieškoti anonimiškai su „DuckDuckGo“"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11486,7 +11464,7 @@ msgstr "Laimėtos užribio grumtynės"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Nuoroda baigia galioti po 7 dienų."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11502,8 +11480,7 @@ msgstr "Nuorodos:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
+msgstr "Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11614,8 +11591,7 @@ msgstr "Įkeliama daugiau vaizdų slenkant"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
+msgstr "Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12586,7 +12562,7 @@ msgstr "Ilgiau nei 20 minučių"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Daugiau patarimų"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13079,7 +13055,7 @@ msgstr "Ne, ačiū"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Ne, ačiū"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13696,8 +13672,7 @@ msgstr "Omanas"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
+msgstr "Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13748,7 +13723,7 @@ msgstr "Įjungta, bet be skaičių"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Supažindinimas baigtas"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13860,8 +13835,7 @@ msgstr "Atidaryti %1$s svetainę"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
+msgstr "Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13965,7 +13939,7 @@ msgstr "Atidaryti vaizdų kūrimo ir redagavimo pasiūlymus"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Atidaryti darbo pradžios kontrolinį sąrašą"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14030,8 +14004,7 @@ msgstr "Atidaryti skydelį „Kaip veikia Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
+msgstr "Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14719,7 +14692,7 @@ msgstr "Prisegti"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Prisegti pokalbį"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14731,7 +14704,7 @@ msgstr "Prisekite pokalbius čia iš %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Prisegti mane"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14754,7 +14727,7 @@ msgstr "Prisegta"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Prisegti pokalbiai bus rodomi pastarųjų pokalbių viršuje."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14819,8 +14792,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
+msgstr "Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15008,8 +14980,7 @@ msgstr "Luktelk..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr ""
-"„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
+msgstr "„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
@@ -15081,6 +15052,8 @@ msgstr "Prastas formatavimas"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Pasiekiami populiarūs DI modeliai. Paskyros nereikia. Mūsų nuasmeninti "
+"pokalbiai."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15294,7 +15267,7 @@ msgstr "Ankstesnės kortelės"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Ankstesni patarimai"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15589,8 +15562,7 @@ msgstr "Paraginti mane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
+msgstr "Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15840,12 +15812,16 @@ msgstr "Loginis DI su vidutinio lygio integruotu moderavimu"
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
 msgstr ""
+"Samprotavimo funkcija gali pateikti geresnius atsakymus į sudėtingus "
+"klausimus."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Samprotavimo funkcijos rezultatai yra išsamesni, bet išnaudoja limitus 2–5 "
+"k. greičiau. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15886,7 +15862,7 @@ msgstr "Naujausią pokalbių saugyklą galima koreguoti %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Pastarieji pokalbiai"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16046,7 +16022,7 @@ msgstr "Sumažinti naudojimą"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Naudok efektyvesnį modelį, kad sumažintum sunaudojimą"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16431,7 +16407,7 @@ msgstr "Atkurti Visus Nustatymus"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Atkurti pamoką"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16449,7 +16425,7 @@ msgstr "Rezoliucija"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Atsakymas"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -17117,8 +17093,7 @@ msgstr "Slink žemyn ir sąraše rask %1$ssavo naršyklę%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
+msgstr "Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17154,7 +17129,7 @@ msgstr "Ieškoti %1$s, kad rastum arčiau tavęs esančių rezultatų?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Paieškos ir „Duck.ai“ perjungiklis"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17509,8 +17484,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. <em>end-to-"
-"end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
+"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. "
+"<em>end-to-end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17532,7 +17507,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Saugiai saugoma mūsų šifruotame serveryje."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17677,27 +17652,24 @@ msgstr "„Safari“ meniu pasirink %1$s„Šios svetainės nustatymas...“%2$s
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk %3$shttps://"
-"duckduckgo.com%4$s"
+"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17711,8 +17683,7 @@ msgstr ""
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
+msgstr "Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17724,8 +17695,7 @@ msgstr "Paieškos teikėjų sąraše pasirink %1$s„DuckDuckGo“%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17736,8 +17706,7 @@ msgstr "Pasirink %1$s„DuckDuckGo“%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
+msgstr "Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17811,8 +17780,7 @@ msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sIšplėstiniai nustatymai%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
+msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17834,8 +17802,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
+msgstr "Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17907,8 +17874,7 @@ msgstr "Pažymėtas tekstas iš %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
+msgstr "Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18054,7 +18020,7 @@ msgstr "Padaryti pradžios puslapiu"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Nustatykite „Duck.ai“ atsakymų toną ir stilių."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18127,13 +18093,13 @@ msgstr "Seišeliai"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Bendrinti"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Bendrinti"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18180,7 +18146,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Bendrinti pokalbį"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18244,7 +18210,7 @@ msgstr "Bendrinti teigiamus atsiliepimus"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Bendrinimo apimtis"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18385,7 +18351,7 @@ msgstr "Rodyti Išsamią Informaciją"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Rodyti „Duck.ai“ pamoką"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18396,8 +18362,7 @@ msgstr "Rodyti „DuckAssist“ <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
+msgstr "Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18539,7 +18504,7 @@ msgstr "Rodyti daugiau"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Rodyti daugiau modelių"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18580,7 +18545,7 @@ msgstr "Rodyk šoninę juostą"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18656,8 +18621,7 @@ msgstr "Rodomos horizontalios linijos ties rezultatų puslapio lūžiais"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
+msgstr "Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18724,8 +18688,7 @@ msgstr "Rodomas sveikinamasis pranešimas paieškos rezultatų viršuje"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
+msgstr "Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18961,7 +18924,7 @@ msgstr "Kažkas nepavyko, bandyk vėliau"
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Įvyko klaida. Bandykite dar kartą."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19053,8 +19016,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
+msgstr "Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19262,7 +19224,7 @@ msgstr "Pradėti naudoti savaitės limitą"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Pradėti naują pokalbį"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19323,15 +19285,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19369,14 +19329,12 @@ msgstr "Sustabdyti generavimą"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
+msgstr "Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
+msgstr "Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19549,8 +19507,7 @@ msgstr "Pasiūlyk tinklaraščio įrašo pavadinimą"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
+msgstr "Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19855,7 +19812,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Perjungti į šią antrąją nuomonę"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20016,7 +19973,7 @@ msgstr "Sinchronizavimas ir atsarginės kopijos kūrimas laikinai nepasiekiami"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sinchronizuoti pokalbius įrenginiuose"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20112,6 +20069,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Pasiimkite „Duck.ai“ visur su savimi. Įtraukite jį į mūsų nemokamą programą, "
+"kad galėtumėte greičiau pasiekti."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20120,6 +20079,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Pasiimkite „Duck.ai“ visur su savimi. Naudokitės mūsų nemokamoje naršyklėje "
+"ir pasiekite greičiau, kad ir kur benaršytumėte."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20594,7 +20555,7 @@ msgstr "Šis mėnuo"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Šis atsakymas"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20606,7 +20567,7 @@ msgstr "Ši savaitė"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Šis pokalbis lieka „Duck.ai“ ir išlieka jums privatus."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20744,6 +20705,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Tai tik pokalbio pavyzdys. Atidaryk jo meniu (trys taškai), tada pasirink "
+"„Prisegti“, kad jis liktų pokalbių viršuje!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20752,6 +20715,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Tai tik pokalbio pavyzdys. Norėdami jį trinti, paspauskite šoniniame meniu "
+"esantį mygtuką „Fire Button“!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21096,6 +21061,8 @@ msgstr "Šiandien"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Perjunkite, kad išbandytumėte privatų pokalbį su DI, arba %1$sišjunkite jį "
+"mygtuko %2$s meniu.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21443,8 +21410,7 @@ msgstr "Pabandyk %1$s, kad daugiau nematytum tokių pranešimų."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
+msgstr "Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21513,7 +21479,7 @@ msgstr "Išbandyk juos"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Išbandyti kitą modelį"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21524,7 +21490,7 @@ msgstr "Išmėgink paiešką!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Išbandyti pasiūlymą"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21596,7 +21562,7 @@ msgstr "Išbandyti nemokamai"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Išbandyti nemokamai"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21610,14 +21576,13 @@ msgstr "Išbandyti nemokamai"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
+msgstr "Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Išbandyti nemokamai 7 dienas"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21644,14 +21609,13 @@ msgstr "Išbandyk mūsų naršyklę,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
+msgstr "Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Išbandyti samprotavimą"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21898,14 +21862,13 @@ msgstr "Norėdami gauti tikslesnius rezultatus, įjunkite %1$sTiksli vieta%2$s"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
+msgstr "Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Įjungti „Duck.ai“ perjungiklį"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21917,8 +21880,7 @@ msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Tiksli vietovė
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
+msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22123,8 +22085,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
+msgstr "Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22134,15 +22095,13 @@ msgstr "Laukelyje %1$sPaieškos nustatymai%2$s pasirink %3$s„DuckDuckGo“%4$s
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
+msgstr "Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
+msgstr "Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22285,7 +22244,7 @@ msgstr "Atrakinkite pažangų dirbtinį intelektą su savo prenumerata!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Atrakinti pažangius modelius"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22299,8 +22258,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
+msgstr "Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22655,7 +22613,7 @@ msgstr "Naudoti „Safari“ naršyklėje"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Trinti pokalbį iš istorijos galite mygtuku „Fire Button“."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22975,8 +22933,7 @@ msgstr "Balso pokalbis baigtas"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
+msgstr "Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23202,8 +23159,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
+msgstr "Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23305,8 +23261,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
+msgstr "Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -23592,9 +23547,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia "
-"„%1$s“ „%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų "
-"niekada nesaugo ir nenaudoja DI modeliams mokyti."
+"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia „%1$s“ "
+"„%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų niekada "
+"nesaugo ir nenaudoja DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23608,8 +23563,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
+msgstr "Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23700,8 +23654,7 @@ msgstr "Į kokius veiksnius reikia atsižvelgti perkant kompiuterio monitorių?"
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
+msgstr "Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23850,7 +23803,7 @@ msgstr "Dėl ko šiandien sugrįžote?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Ką gali daryti?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23962,8 +23915,7 @@ msgstr "Kokia informacija yra išsaugoma?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
+msgstr "Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -24048,8 +24000,7 @@ msgstr "Apie ką norėtum pateikti atsiliepimą?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
+msgstr "Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24279,6 +24230,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Su „Duck.ai“ jūsų pokalbiai yra anonimizuojami ir niekada nenaudojami "
+"dirbtinio intelekto mokymui. Bet kuriuo metu įjungti arba išjungti meniu "
+"„%1$s“."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24532,8 +24486,7 @@ msgstr "Taip, naujas naudotojas!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
+msgstr "Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24712,7 +24665,7 @@ msgstr "Viename pokalbyje galima pridėti iki %1$s vaizdų."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Vienu metu gali pridėti tik %1$s korteles (-ių)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24860,7 +24813,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Viskas paruošta!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24913,7 +24866,7 @@ msgstr "Užblokavote 1 svetainę"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Įvaldėte „Duck.ai“ pagrindus"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24933,8 +24886,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
+msgstr "Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25122,16 +25074,14 @@ msgstr ""
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25317,6 +25267,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Nuostatos išsaugotos, tačiau išvalius slapukus jos bus atkurtos. Įjunk "
+"%1$s„DuckDuckGo No AI“%2$s plėtinį, kad jas išsaugotum visam laikui."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25483,8 +25435,7 @@ msgstr "sukurta %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
+msgstr "kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25915,4 +25866,4 @@ msgstr "m."
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -122,6 +123,12 @@ msgstr "Prieš %1$s d."
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s aptikta"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +362,12 @@ msgid "%s used"
 msgstr "%1$s išnaudota"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s peržiūra"
@@ -481,7 +494,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
+msgstr ""
+"%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -602,6 +616,12 @@ msgstr "„DuckDuckGo“ užblokavo 1 bandymą per pastarąsias 24 valandas"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Prieš 1 dieną"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -893,14 +913,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
+msgstr ""
+"Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
+msgstr ""
+"Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1511,6 +1533,14 @@ msgid "Advanced Models"
 msgstr "Pažangūs modeliai"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Reklamuoti paieškoje"
@@ -1550,7 +1580,8 @@ msgstr "Kai atsisiųsi ir atidarysi, spustelėk %1$sĮdiegti%2$s"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
+msgstr ""
+"Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1792,7 +1823,8 @@ msgstr "Leisti anonimiškai peržiūrėti šio pokalbio failus?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
+msgstr ""
+"Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1844,7 +1876,8 @@ msgstr "Jau sinchronizuota."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
+msgstr ""
+"Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2294,6 +2327,12 @@ msgid "Ask privately"
 msgstr "Klauskite privačiai"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2482,7 +2521,8 @@ msgstr "Automatinis atsakymas"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
+msgstr ""
+"Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3626,7 +3666,8 @@ msgstr "Pakeičia fono spalvą visoje svetainėje"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
+msgstr ""
+"Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3840,6 +3881,12 @@ msgid "Chat privately with AI"
 msgstr "Privatus pokalbis su DI"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3929,9 +3976,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į "
-"Duck.ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų "
-"teikėjas, ieškantis tokio turinio: %2$s."
+"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į Duck."
+"ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų teikėjas, "
+"ieškantis tokio turinio: %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4391,7 +4438,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
+msgstr ""
+"Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4418,7 +4466,8 @@ msgstr "Išskleidžiamajame meniu spustelėk %1$sNustatymai%2$s."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
+msgstr ""
+"Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4485,7 +4534,8 @@ msgstr "Paieškos juostoje spustelėk %1$sdidinamąjį stiklą%2$s"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr "Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
+msgstr ""
+"Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4631,6 +4681,12 @@ msgid "Close"
 msgstr "Uždaryti"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4673,6 +4729,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Uždaryti paiešką"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5046,6 +5108,12 @@ msgid "Continue Blocking Ads"
 msgstr "Tęsti reklamų blokavimą"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5111,6 +5179,12 @@ msgid "Cookie data:"
 msgstr "Slapukų duomenys:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5149,13 +5223,20 @@ msgstr "Kopijuoti"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
+msgstr ""
+"Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopijuoti kodą"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5271,6 +5352,12 @@ msgid "Create Image"
 msgstr "Kurti vaizdą"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5312,6 +5399,14 @@ msgstr "Sukurta"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Sukurė „%1$s“"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5465,6 +5560,12 @@ msgstr "Tinkinti atsakymus"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Tinkinti atsakymus"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5751,10 +5852,22 @@ msgid "Delete Server Data?"
 msgstr "Ar trinti duomenis serveryje?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Ištrinti nuorašą"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5787,6 +5900,12 @@ msgstr "Ištrinti vaizdą"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Ištrinti vaizdą?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5912,7 +6031,8 @@ msgstr "Diktavimas „Duck.ai“"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
+msgstr ""
+"Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6093,6 +6213,12 @@ msgstr "Atmesti visam laikui"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Atsisakyti reklamos"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6303,6 +6429,12 @@ msgstr "Atsisiuntimas baigtas"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Atsisiųsk „DuckDuckGo“."
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6522,6 +6654,12 @@ msgstr ""
 "Nemokama."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6679,6 +6817,12 @@ msgstr ""
 "netikrinamas."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6833,8 +6977,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
-"„%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
+"„%3$s“ „%4$s“."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6844,8 +6988,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
-"„%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
+"„%3$s“ „%4$s“."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6881,7 +7025,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
+msgstr ""
+"„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7010,8 +7155,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su "
-"„Duck.ai“ %2$s."
+"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su „Duck."
+"ai“ %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7156,9 +7301,9 @@ msgid ""
 "characters long."
 msgstr ""
 "Kiekvieną kartą, kai paprašai pasiūlyti slaptafrazę, naudojame didelį "
-"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame "
-"4–5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent "
-"18–20 simbolių ilgio."
+"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame 4–"
+"5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent 18–"
+"20 simbolių ilgio."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7327,6 +7472,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Įjungti Lankomiausias Svetaines"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7485,13 +7636,15 @@ msgstr "Ar tau patinka „Duck.ai“?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
+msgstr ""
+"Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
+msgstr ""
+"Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7626,6 +7779,12 @@ msgid "Entertainment guide"
 msgstr "Pramogų vadovas"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Pusiaujo Gvinėja"
 
@@ -7633,7 +7792,8 @@ msgstr "Pusiaujo Gvinėja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
+msgstr ""
+"Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7724,7 +7884,8 @@ msgstr "Paprastais žodžiais paaiškink priimtą atsakymą."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
+msgstr ""
+"Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7787,10 +7948,23 @@ msgid "Explicit lyrics"
 msgstr "Suaugusiesiems skirti dainų tekstai"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
+msgstr ""
+"Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7888,6 +8062,12 @@ msgid "FREE"
 msgstr "Nemokamai"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7963,7 +8143,8 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
+msgstr ""
+"Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8085,7 +8266,8 @@ msgstr "Finansų konsultantas"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
+msgstr ""
+"Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8209,7 +8391,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
+msgstr ""
+"Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8305,6 +8488,12 @@ msgid "Free Up Storage"
 msgstr "Atlaisvink vietos"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8314,7 +8503,8 @@ msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
+msgstr ""
+"Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8765,7 +8955,8 @@ msgstr "Pradėti"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
+msgstr ""
+"Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8821,15 +9012,23 @@ msgid "Get computer help"
 msgstr "Reikia pagalbos dėl kompiuterio"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
-msgstr "Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
+msgstr ""
+"Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
+msgstr ""
+"Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8856,6 +9055,18 @@ msgid "Get the Latest Version"
 msgstr "Gaukite naujausią versiją"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8876,6 +9087,12 @@ msgstr "Gauti šią dainą:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Pakviesk draugus ir padėk mums augti!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9563,6 +9780,12 @@ msgid "Hide Tips"
 msgstr "Slėpti patarimus"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -10016,7 +10239,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
+msgstr ""
+"Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10249,7 +10473,8 @@ msgstr "Pagerink argumentus"
 msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
-msgstr "Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
+msgstr ""
+"Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10681,7 +10906,8 @@ msgstr "Ji greita, nemokama ir užtikrina dar daugiau apsaugos internete."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
+msgstr ""
+"Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11180,6 +11406,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Leidžia ieškoti anonimiškai su „DuckDuckGo“"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberija"
 
@@ -11250,6 +11483,12 @@ msgid "Lineouts Won"
 msgstr "Laimėtos užribio grumtynės"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Nuorodos šriftas:"
@@ -11263,7 +11502,8 @@ msgstr "Nuorodos:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
+msgstr ""
+"Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11374,7 +11614,8 @@ msgstr "Įkeliama daugiau vaizdų slenkant"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
+msgstr ""
+"Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12342,6 +12583,12 @@ msgid "More than 20 minutes"
 msgstr "Ilgiau nei 20 minučių"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12827,6 +13074,12 @@ msgstr "Ne, dėkoju"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Ne, ačiū"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13443,7 +13696,8 @@ msgstr "Omanas"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
+msgstr ""
+"Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13489,6 +13743,12 @@ msgstr ""
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Įjungta, bet be skaičių"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13600,7 +13860,8 @@ msgstr "Atidaryti %1$s svetainę"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
+msgstr ""
+"Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13701,6 +13962,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Atidaryti vaizdų kūrimo ir redagavimo pasiūlymus"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13763,7 +14030,8 @@ msgstr "Atidaryti skydelį „Kaip veikia Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
+msgstr ""
+"Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14448,10 +14716,22 @@ msgid "Pin"
 msgstr "Prisegti"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Prisekite pokalbius čia iš %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14469,6 +14749,12 @@ msgstr "Rožinė"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Prisegta"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14533,7 +14819,8 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
+msgstr ""
+"Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14721,7 +15008,8 @@ msgstr "Luktelk..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr "„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
+msgstr ""
+"„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
@@ -14787,6 +15075,12 @@ msgstr "Lenkų"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Prastas formatavimas"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -14995,6 +15289,12 @@ msgstr "Ankstesnis vaizdas"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Ankstesnės kortelės"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15289,7 +15589,8 @@ msgstr "Paraginti mane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
+msgstr ""
+"Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15535,6 +15836,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Loginis DI su vidutinio lygio integruotu moderavimu"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15568,6 +15881,12 @@ msgstr "Naujausi skirtukai"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Naujausią pokalbių saugyklą galima koreguoti %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15722,6 +16041,12 @@ msgstr "Pakartoti paiešką be šios svetainės"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Sumažinti naudojimą"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16103,6 +16428,12 @@ msgid "Reset All Settings"
 msgstr "Atkurti Visus Nustatymus"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16113,6 +16444,12 @@ msgstr "Atsinaujins po %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Rezoliucija"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16780,7 +17117,8 @@ msgstr "Slink žemyn ir sąraše rask %1$ssavo naršyklę%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
+msgstr ""
+"Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16811,6 +17149,12 @@ msgstr "Paieška"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Ieškoti %1$s, kad rastum arčiau tavęs esančių rezultatų?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17165,8 +17509,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. "
-"<em>end-to-end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
+"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. <em>end-to-"
+"end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17183,6 +17527,12 @@ msgid ""
 msgstr ""
 "Saugiai saugoma „DuckDuckGo“ serveryje su ištisiniu (angl. „end-to-end“) "
 "šifravimu. Niekas, išskyrus jus, negali matyti jūsų duomenų – net mes."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17327,24 +17677,27 @@ msgstr "„Safari“ meniu pasirink %1$s„Šios svetainės nustatymas...“%2$s
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk "
-"%3$shttps://duckduckgo.com%4$s"
+"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk %3$shttps://"
+"duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17358,7 +17711,8 @@ msgstr ""
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
+msgstr ""
+"Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17370,7 +17724,8 @@ msgstr "Paieškos teikėjų sąraše pasirink %1$s„DuckDuckGo“%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17381,7 +17736,8 @@ msgstr "Pasirink %1$s„DuckDuckGo“%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
+msgstr ""
+"Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17455,7 +17811,8 @@ msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sIšplėstiniai nustatymai%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
+msgstr ""
+"Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17477,7 +17834,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
+msgstr ""
+"Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17549,7 +17907,8 @@ msgstr "Pažymėtas tekstas iš %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
+msgstr ""
+"Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17692,6 +18051,12 @@ msgid "Set as Homepage"
 msgstr "Padaryti pradžios puslapiu"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17759,6 +18124,18 @@ msgid "Seychelles"
 msgstr "Seišeliai"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17797,6 +18174,13 @@ msgstr ""
 "Bendrinti miesto lygio vietą su DI modeliais, kad pagerintumėte atsakymų "
 "aktualumą. „Duck.ai“ niekada neatskleidžia tikslios buvimo vietos mums ar DI "
 "modeliams."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17855,6 +18239,12 @@ msgstr "Bendrinti puslapio URL"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Bendrinti teigiamus atsiliepimus"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17992,6 +18382,12 @@ msgid "Show Detail"
 msgstr "Rodyti Išsamią Informaciją"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "Rodyti „DuckAssist“ <sup>BETA</sup>"
@@ -18000,7 +18396,8 @@ msgstr "Rodyti „DuckAssist“ <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
+msgstr ""
+"Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18139,6 +18536,12 @@ msgid "Show more"
 msgstr "Rodyti daugiau"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18172,6 +18575,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Rodyk šoninę juostą"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18247,7 +18656,8 @@ msgstr "Rodomos horizontalios linijos ties rezultatų puslapio lūžiais"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
+msgstr ""
+"Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18314,7 +18724,8 @@ msgstr "Rodomas sveikinamasis pranešimas paieškos rezultatų viršuje"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
+msgstr ""
+"Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18547,6 +18958,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Kažkas nepavyko, bandyk vėliau"
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18636,7 +19053,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
+msgstr ""
+"Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18841,6 +19259,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Pradėti naudoti savaitės limitą"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Pradėti paiešką!"
@@ -18899,13 +19323,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr ""
+"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr ""
+"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -18943,12 +19369,14 @@ msgstr "Sustabdyti generavimą"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
+msgstr ""
+"Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
+msgstr ""
+"Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19121,7 +19549,8 @@ msgstr "Pasiūlyk tinklaraščio įrašo pavadinimą"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
+msgstr ""
+"Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19421,6 +19850,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Naudokis paieškos sistema, kuri tavęs nestebi. Niekada."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19576,6 +20013,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sinchronizavimas ir atsarginės kopijos kūrimas laikinai nepasiekiami"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19661,6 +20104,22 @@ msgstr "Tadžikistanas"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Susigrąžink Privatumą!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20132,10 +20591,22 @@ msgid "This Month"
 msgstr "Šis mėnuo"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Ši savaitė"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20265,6 +20736,22 @@ msgstr "Šis vaizdo tipas nepalaikomas. Pridėk JPG, PNG, WebP arba GIF."
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Ši informacija nėra naudinga"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20603,6 +21090,12 @@ msgstr "Šiandien"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Šiandien"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20950,7 +21443,8 @@ msgstr "Pabandyk %1$s, kad daugiau nematytum tokių pranešimų."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
+msgstr ""
+"Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21016,9 +21510,21 @@ msgid "Try Them Out"
 msgstr "Išbandyk juos"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Išmėgink paiešką!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21087,6 +21593,12 @@ msgid "Try for free"
 msgstr "Išbandyti nemokamai"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21098,7 +21610,14 @@ msgstr "Išbandyti nemokamai"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
+msgstr ""
+"Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21125,7 +21644,14 @@ msgstr "Išbandyk mūsų naršyklę,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
+msgstr ""
+"Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21372,7 +21898,14 @@ msgstr "Norėdami gauti tikslesnius rezultatus, įjunkite %1$sTiksli vieta%2$s"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
+msgstr ""
+"Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21384,7 +21917,8 @@ msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Tiksli vietovė
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
+msgstr ""
+"Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21589,7 +22123,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
+msgstr ""
+"Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21599,13 +22134,15 @@ msgstr "Laukelyje %1$sPaieškos nustatymai%2$s pasirink %3$s„DuckDuckGo“%4$s
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
+msgstr ""
+"Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
+msgstr ""
+"Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21745,6 +22282,12 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "Atrakinkite pažangų dirbtinį intelektą su savo prenumerata!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -21756,7 +22299,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
+msgstr ""
+"Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22108,6 +22652,12 @@ msgid "Use in Safari"
 msgstr "Naudoti „Safari“ naršyklėje"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22425,7 +22975,8 @@ msgstr "Balso pokalbis baigtas"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
+msgstr ""
+"Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22651,7 +23202,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
+msgstr ""
+"Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22753,7 +23305,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
+msgstr ""
+"Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -23039,9 +23592,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia „%1$s“ "
-"„%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų niekada "
-"nesaugo ir nenaudoja DI modeliams mokyti."
+"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia "
+"„%1$s“ „%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų "
+"niekada nesaugo ir nenaudoja DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23055,7 +23608,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
+msgstr ""
+"Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23146,7 +23700,8 @@ msgstr "Į kokius veiksnius reikia atsižvelgti perkant kompiuterio monitorių?"
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
+msgstr ""
+"Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23292,6 +23847,12 @@ msgid "What brought you back today?"
 msgstr "Dėl ko šiandien sugrįžote?"
 
 # smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -23401,7 +23962,8 @@ msgstr "Kokia informacija yra išsaugoma?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr "Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
+msgstr ""
+"Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -23486,7 +24048,8 @@ msgstr "Apie ką norėtum pateikti atsiliepimą?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
+msgstr ""
+"Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23708,6 +24271,14 @@ msgstr "Pergalės"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Šlapdriba"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -23961,7 +24532,8 @@ msgstr "Taip, naujas naudotojas!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
+msgstr ""
+"Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24136,6 +24708,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Viename pokalbyje galima pridėti iki %1$s vaizdų."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24278,6 +24857,12 @@ msgstr ""
 "naujausią versiją."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24325,6 +24910,12 @@ msgid "You've blocked 1 site"
 msgstr "Užblokavote 1 svetainę"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24342,7 +24933,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
+msgstr ""
+"Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24530,14 +25122,16 @@ msgstr ""
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr ""
+"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr ""
+"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24717,6 +25311,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Jūsų paieškos negali būti susietos su jumis"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24881,7 +25483,8 @@ msgstr "sukurta %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
+msgstr ""
+"kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25307,3 +25910,9 @@ msgstr "metai"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "m."
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "Noteikta %1$s valoda"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Izmantoti %1$s faili"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -364,7 +364,7 @@ msgstr "%1$s izmantots"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -621,7 +621,7 @@ msgstr "Pirms 1 dienas"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "Izmantots 1 fails"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -915,16 +915,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
+msgstr "Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
+msgstr "Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1541,6 +1539,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Izmantojot jaudīgākus modeļus, lietojuma limits var tikt patērēts 2–5 reizes "
+"ātrāk nekā ar citiem modeļiem. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1705,8 +1705,7 @@ msgstr "Visas tērzēšanas sarunas ir %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr ""
-"Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
+msgstr "Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -2160,8 +2159,7 @@ msgstr "Vai tu joprojām esi tur?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
+msgstr "Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2173,8 +2171,7 @@ msgstr "Vai tiešām vēlies notīrīt šo sarunu un sākt jaunu?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
+msgstr "Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2335,7 +2332,7 @@ msgstr "Pajautāt privāti"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Pajautāt privāti"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -3351,8 +3348,7 @@ msgstr "Kamerūna"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
+msgstr "Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3672,8 +3668,7 @@ msgstr "Maina fona krāsu visā vietnē"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
+msgstr "Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3806,8 +3801,8 @@ msgstr ""
 "ar trešo pušu mākslīgā intelekta tērzēšanas modeļiem, kas atbalsta OpenAI, "
 "Anthropic un citus rīkus. Izslēdzot šo iestatījumu tiks paslēptas tērzēšanas "
 "pogas un saites DuckDuckGo Search platformā. Taču tu joprojām vari piekļūt "
-"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot %1$shttps://duck."
-"ai%2$s tieši."
+"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot "
+"%1$shttps://duck.ai%2$s tieši."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3891,7 +3886,7 @@ msgstr "Privāti tērzēt ar MI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Tērzē privāti ar populāriem MI"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4411,8 +4406,7 @@ msgstr "Nospied %1$sAtļaut%2$s, pēc tam %3$sPievienot%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr ""
-"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4513,8 +4507,7 @@ msgstr "Sānjoslā noklikšķini uz %1$sPārlūks%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4534,8 +4527,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
+msgstr "Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4664,8 +4656,7 @@ msgstr "Noklikšķini uz palielināmā stikla ikonas meklēšanas lodziņā"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
+msgstr "Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -4698,7 +4689,7 @@ msgstr "Aizvērt"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Aizvērt"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4748,7 +4739,7 @@ msgstr "Aizvērt meklēšanu"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Aizvērt otro viedokli"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5125,7 +5116,7 @@ msgstr "Turpināt bloķēt reklāmas"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5196,7 +5187,7 @@ msgstr "Sīkdatņu dati:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Nokopēts"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5249,7 +5240,7 @@ msgstr "Kopēt kodu"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopēt saiti"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5319,8 +5310,7 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
+msgstr "Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5369,7 +5359,7 @@ msgstr "Izveidot attēlu"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Izveidot kopīgošanas saiti"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5421,6 +5411,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Izveidojot saiti, tiek izveidota tērzēšanas kopija, ko var skatīt ikviens, "
+"kas to atver."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5579,7 +5571,7 @@ msgstr "Pielāgo atbildes"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Pielāgo atbildes"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5871,7 +5863,7 @@ msgstr "Dzēst servera datus?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Dzēst kopīgoto saiti"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5883,7 +5875,7 @@ msgstr "Dzēst transkripciju"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Dzēst tērzēšanas sarunu"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5921,7 +5913,7 @@ msgstr "Dzēst attēlu?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Dzēs mani"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6150,8 +6142,7 @@ msgstr "Atspējot un atvienot"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
+msgstr "Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6238,7 +6229,7 @@ msgstr "Noraidīt akciju"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Aizvērt pamācību"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6345,8 +6336,7 @@ msgstr "Neredzi DuckDuckGo sarakstā?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
+msgstr "Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6456,7 +6446,7 @@ msgstr "Lejupielādēt DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Lejupielādēt DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6677,7 +6667,7 @@ msgstr "Duck.ai by DuckDuckGo. Privāta MI tērzēšana. Bezmaksas."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai tagad var analizēt PDF failus. Izmēģini!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6770,8 +6760,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
+msgstr "Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6786,8 +6775,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai ļauj tev privāti tērzēt ar populāriem MI modeļiem. Atspējošana "
-"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt %1$sduck."
-"ai%2$s tieši."
+"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt "
+"%1$sduck.ai%2$s tieši."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6839,7 +6828,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai atbalsta modeļus no Anthropic, OpenAI un citiem."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6857,8 +6846,7 @@ msgstr "Duck.ai atjaunināts!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
+msgstr "Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7392,8 +7380,7 @@ msgstr "Rediģē attēlu..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
+msgstr "Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7493,7 +7480,7 @@ msgstr "Iespējot visvairāk apmeklētās vietnes"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Iespējot tagad"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7715,15 +7702,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
+msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
+msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7807,7 +7792,7 @@ msgstr "Izklaides ceļvedis"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Visa tērzēšana"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7817,8 +7802,7 @@ msgstr "Ekvatoriālā Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
+msgstr "Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7909,8 +7893,7 @@ msgstr "Izskaidro pieņemto atbildi vienkāršā valodā."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
+msgstr "Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7976,13 +7959,13 @@ msgstr "Necenzēti dziesmu vārdi"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Izpēti Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Izpēti Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8089,7 +8072,7 @@ msgstr "Bezmaksas"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "BEZMAKSAS UN IZVĒLES"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8147,8 +8130,7 @@ msgstr "Atsauksme sekmīgi iesniegta"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
+msgstr "Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8289,8 +8271,7 @@ msgstr "Finanšu konsultants"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
+msgstr "Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8513,7 +8494,7 @@ msgstr "Atbrīvot vietu krātuvē"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Bez maksas un vienmēr privāts"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8641,9 +8622,9 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac datorā lietotnes izvēlnes joslā izvēlies <strong>DuckDuckGo</strong> "
-"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt atjauninājumus..."
-"&quot;) un tad <strong>Install Update</strong> (&quot;Instalēt "
-"atjauninājumu&quot;)."
+"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt "
+"atjauninājumus...&quot;) un tad <strong>Install Update</strong> "
+"(&quot;Instalēt atjauninājumu&quot;)."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9038,7 +9019,7 @@ msgstr "Saņemt palīdzību datoru jautājumos"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Iegūsti lielāku pieejamo lietojuma apjomu ar DuckDuckGo abonementu."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9081,13 +9062,13 @@ msgstr "Iegūt jaunāko versiju"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Iegūt lietotni"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
+msgstr "Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9115,7 +9096,7 @@ msgstr "Pārliecini draugus pieslēgties un palīdzi mums attīstīties!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Darba sākšanas kontrolsaraksts"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9189,8 +9170,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
+msgstr "Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9807,7 +9787,7 @@ msgstr "Slēpt padomus"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Paslēpt pamācību"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9857,8 +9837,8 @@ msgstr "Slēp savu e-pasta adresi"
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
 msgstr ""
-"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas cilnē/"
-"vēsturē"
+"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas "
+"cilnē/vēsturē"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10106,8 +10086,7 @@ msgstr "Cik daudz tu vēlies, lai parādītos MI atbalstītas atbildes?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
+msgstr "Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10264,8 +10243,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
+msgstr "Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10352,8 +10330,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
+msgstr "Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10371,8 +10348,7 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
+msgstr "Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10930,8 +10906,7 @@ msgstr "Tas varētu aizņemt dažas minūtes"
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
+msgstr "Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11440,7 +11415,7 @@ msgstr "Ļauj meklēt anonīmi ar DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Ļauj pārslēgties starp meklēšanas vaicājumiem un Duck.ai uzvednēm"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11516,7 +11491,7 @@ msgstr "Uzvarētās līnijas"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Saites derīguma termiņš beigsies pēc 7 dienām."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12406,8 +12381,7 @@ msgstr "Tu esi sasniedzis mēneša limitu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
+msgstr "Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12619,7 +12593,7 @@ msgstr "Vairāk nekā 20 minūtes"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Vairāk padomu"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13113,7 +13087,7 @@ msgstr "Nē, paldies"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nē, paldies"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13291,8 +13265,7 @@ msgstr "Tikai meklēšana – bez izsekošanas un mērķētas reklāmas!"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
+msgstr "Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13782,7 +13755,7 @@ msgstr "Ieslēgts, bet bez numerācijas"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Ievads pabeigts"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13918,8 +13891,7 @@ msgstr "Atver %1$sIestatījumi%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
+msgstr "Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14003,7 +13975,7 @@ msgstr "Atvērt izveidot un rediģēt attēlus ieteikumus"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Atver darba sākšanas kontrolsarakstu"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14755,7 +14727,7 @@ msgstr "Piespraude"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Piespraust tērzēšanu"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14767,7 +14739,7 @@ msgstr "Piespraud tērzēšanas sarunas šeit no %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Piespraud mani"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14790,7 +14762,7 @@ msgstr "Piesprausts"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Piespraustās sarunas parādīsies tavu neseno sarunu augšgalā."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14831,8 +14803,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
+msgstr "Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14840,8 +14811,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
+msgstr "Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15052,8 +15022,7 @@ msgstr "Plus vēl citas premium funkcijas ar DuckDuckGo abonementu."
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
+msgstr "Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15116,6 +15085,8 @@ msgstr "Slikta formatēšana"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Pieejami populāri MI modeļi. Nav nepieciešams konts. Mūsu anonimizētas "
+"tērzēšanas sarunas."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15329,7 +15300,7 @@ msgstr "Iepriekšējās cilnes"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Iepriekšējie padomi"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15644,8 +15615,7 @@ msgstr "Aizsargā savus datus meklēšanas un pārlūkošanas laikā."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
+msgstr "Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15876,13 +15846,15 @@ msgstr "Saprātīgs MI ar vidēja līmeņa iebūvētu moderēšanu"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Spriešana var sniegt labākas atbildes uz sarežģītiem jautājumiem."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Spriestspējas režīmā modelis spriež rūpīgāk, taču lietojuma ierobežojumi "
+"tiek patērēti 2–5 reizes ātrāk. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15923,7 +15895,7 @@ msgstr "Pēdējo tērzēšanas sarunu krātuvi var pielāgot %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Pēdējās tērzēšanas sarunas"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16084,7 +16056,7 @@ msgstr "Samazināt lietojumu"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Samazini lietojumu, izmantojot efektīvāku modeli"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16245,8 +16217,7 @@ msgstr "Atcerēties manu izvēli"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
+msgstr "Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16468,7 +16439,7 @@ msgstr "Atiestatīt visus iestatījumus"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Atiestatīt pamācību"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16486,7 +16457,7 @@ msgstr "Izšķirtspēja"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Atbilde"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -17158,8 +17129,7 @@ msgstr "Ritini uz leju un sarakstā atrodi %1$ssavu pārlūkprogrammu%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
+msgstr "Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17195,7 +17165,7 @@ msgstr "Meklēt %1$s, lai meklētu tuvākajā apkārtnē?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Meklēšanas un Duck.ai pārslēgs"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17572,7 +17542,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Droši glabāts mūsu šifrētajā serverī."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17683,8 +17653,7 @@ msgstr "Apskati dažus no mūsu pēdējiem atjauninājumiem"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
+msgstr "Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17718,20 +17687,18 @@ msgstr "Safari izvēlnē atlasi %1$s“Šīs vietnes iestatījumi...”%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Atlasi %1$sPielāgots%2$s un ievades laukā raksti %3$shttps://duckduckgo."
-"com%4$s"
+"Atlasi %1$sPielāgots%2$s un ievades laukā raksti "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
+msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
+msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17743,8 +17710,7 @@ msgstr "Atlasi %1$sDuckDuckGo%2$s un nospied %3$sIestatīt kā noklusējumu%4$s.
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
+msgstr "Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17764,8 +17730,7 @@ msgstr "Meklēšanas pakalpojumu sniedzēju sarakstā atlasi %1$sDuckDuckGo%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
+msgstr "Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17798,8 +17763,7 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
+msgstr "Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18093,7 +18057,7 @@ msgstr "Iestatīt kā sākumlapu"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Iestati Duck.ai atbilžu toni un stilu."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18166,13 +18130,13 @@ msgstr "Seišelas"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Kopīgot"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Kopīgot"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18219,7 +18183,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Kopīgot tērzēšanu"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18283,7 +18247,7 @@ msgstr "Sniegt pozitīvu atsauksmi"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Kopīgošanas apjoms"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18424,7 +18388,7 @@ msgstr "Rādīt sīkāku informāciju"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Rādīt Duck.ai pamācību"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18577,7 +18541,7 @@ msgstr "Parādīt vairāk"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Parādīt vairāk modeļu"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18618,7 +18582,7 @@ msgstr "Parādīt sānjoslu"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Rādīt padomus soli pa solim, lai maksimāli izmantotu Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18693,8 +18657,7 @@ msgstr "Parāda horizontālas līnijas rezultātu lapu pārtraukumos"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
+msgstr "Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18715,8 +18678,7 @@ msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu pārlūk
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
+msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18978,15 +18940,13 @@ msgstr "Kaut kas notika nepareizi"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
+msgstr "Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
+msgstr "Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18998,7 +18958,7 @@ msgstr "Kaut kas nogāja greizi. Lūdzu, vēlāk mēģini vēlreiz."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Kaut kas nogājis greizi. Lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19073,8 +19033,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt Duck."
-"ai."
+"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19090,8 +19050,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
+msgstr "Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19299,7 +19258,7 @@ msgstr "Sākot lietot nedēļas limitu"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Sāc jaunu tērzēšanu"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19352,22 +19311,19 @@ msgstr "Paliec DuckDuckGo platformā"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19569,8 +19525,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
+msgstr "Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19887,7 +19842,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Pārslēgties uz šo otro viedokli"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20047,7 +20002,7 @@ msgstr "Sinhronizācija un dublēšana uz laiku nav pieejamas"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sinhronizēt tērzēšanas sarunas visās ierīcēs"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20143,6 +20098,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Ņem Duck.ai sev līdzi visur. Iegūsti to mūsu bezmaksas lietotnē, lai "
+"piekļūtu ātrāk, lai kur tu atrastos."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20151,6 +20108,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Ņem Duck.ai sev līdzi visur. Iegūsti to iebūvētu mūsu bezmaksas pārlūkā "
+"ātrākai piekļuvei, lai kur tu to lietotu."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20173,8 +20132,7 @@ msgstr "Esi noteicējs pār saviem personīgajiem datiem!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
+msgstr "Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20623,7 +20581,7 @@ msgstr "Šomēnes"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Šī atbilde"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20635,7 +20593,7 @@ msgstr "Šonedēļ"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Šī tērzēšana paliek ar Duck.ai un privāta."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20777,6 +20735,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Šī ir tikai parauga tērzēšana. Atver tās izvēlni (trīs punktus), pēc tam "
+"izvēlies Piespraust, lai saglabātu to savu tērzēšanas sarunu augšgalā!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20785,6 +20745,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Šī ir tikai parauga tērzēšana. Izmanto Fire Button sānu izvēlnē, lai to "
+"izdzēstu!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21127,6 +21089,8 @@ msgstr "Šodien"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Pārslēdzies, lai izmēģinātu privātu MI tērzēšanu, vai %1$sizslēdz to izvēlnē "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21174,8 +21138,7 @@ msgstr "Pārāk daudz reklāmu"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr ""
-"Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
+msgstr "Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21544,7 +21507,7 @@ msgstr "Izmēģini tos"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Pamēģini citu modeli"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21555,7 +21518,7 @@ msgstr "Izmēģini meklēšanu!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Izmēģini ieteikumu"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21598,8 +21561,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
+msgstr "Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21626,7 +21588,7 @@ msgstr "Izmēģini bez maksas"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Izmēģini bez maksas"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21648,7 +21610,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Izmēģini 7 dienas bez maksas"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21681,7 +21643,7 @@ msgstr "Izmēģini mūsu mājaslapu, kas nekad nerāda šīs ziņas:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Izmēģini spriešanu"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21936,7 +21898,7 @@ msgstr "Ieslēdz Duck Player, lai skatītos YouTube bez mērķētām reklāmām"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Ieslēgt Duck.ai pārslēgu"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21948,8 +21910,7 @@ msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Precīza atrašanās v
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
+msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22100,8 +22061,7 @@ msgstr "Nevar iesniegt atsauksmi"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
+msgstr "Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22142,8 +22102,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: https://"
-"duckduckgo.com"
+"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22169,15 +22129,13 @@ msgstr "Zem %1$sMeklēt adreses joslā ar%2$s nospied %3$sPievienot jaunu%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
+msgstr "Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
+msgstr "Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22285,8 +22243,7 @@ msgstr "Atbloķē ar DuckDuckGo abonementu"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
+msgstr "Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22311,7 +22268,7 @@ msgstr "Piekļūsti uzlabotajam MI ar savu abonementu!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Piekļūsti padziļinātajiem modeļiem"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22680,7 +22637,7 @@ msgstr "Lietot ar Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Izmanto Fire Button, lai dzēstu tērzēšanu no vēstures."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22705,8 +22662,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
+msgstr "Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22945,8 +22901,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver Duck."
-"ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
+"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver "
+"Duck.ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
 "“Sinhronizēt ar citu ierīci”. Vai arī noskenē kvadrātkodu savā atkopšanas "
 "PDF failā."
 
@@ -23228,8 +23184,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
+msgstr "Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23245,8 +23200,7 @@ msgstr "Mēs neglabājam lietotājvārdus un personu identificējošu informāci
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
+msgstr "Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23369,8 +23323,7 @@ msgstr "Mēs zaudējām savienojumu, lūdzu, vēlāk mēģini vēlreiz."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
+msgstr "Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23402,8 +23355,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
+msgstr "Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23628,8 +23580,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
+msgstr "Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23877,7 +23828,7 @@ msgstr "Kāpēc Tu atgriezies atpakaļ?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Ko tu proti?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24074,8 +24025,7 @@ msgstr "Par ko tu vēlētos sniegt atsauksmes?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
+msgstr "Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24165,8 +24115,7 @@ msgstr "Kas mēs esam"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
+msgstr "Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24304,6 +24253,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Ar Duck.ai tavas tērzēšanas sarunas tiek anonimizētas un nekad netiek "
+"izmantotas MI apmācībai. Ieslēdz vai izslēdz to jebkurā laikā izvēlnē '%1$s'."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24557,8 +24508,7 @@ msgstr "Jā, jauns lietotājs!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
+msgstr "Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24655,8 +24605,7 @@ msgstr "Tu vari mainīt to jebkurā laikā sadaļā %1$sMeklēšanas iestatījum
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
+msgstr "Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24695,8 +24644,7 @@ msgstr "Tu vari turpināt tērzēt, izmantojot savu mēneša limitu."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
+msgstr "Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24739,7 +24687,7 @@ msgstr "Katrai sarunai vari pievienot tikai %1$s attēlus."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Vienlaikus vari pievienot ne vairāk kā %1$s cilnes."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24870,8 +24818,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
+msgstr "Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24887,7 +24834,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Viss gatavs!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24938,7 +24885,7 @@ msgstr "Tu esi bloķējis 1 vietni"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Tu esi apguvis Duck.ai pamatus"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24980,8 +24927,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
+msgstr "Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25142,8 +25088,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
+msgstr "Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25350,6 +25295,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Tavi iestatījumi ir saglabāti, taču sīkfailu izdzēšana tos atiestatīs. "
+"Pastāvīgai lietošanai iespējo %1$sDuckDuckGo No AI%2$s paplašinājumu."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25433,8 +25380,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
+msgstr "Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25732,8 +25678,7 @@ msgstr "oficiālā vietne"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
+msgstr "vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25949,4 +25894,4 @@ msgstr "g."
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "Pirms %1$s dienām"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Noteikta %1$s valoda"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -353,6 +359,12 @@ msgstr "Bloķēti %1$s izsekošanas mēģinājumi"
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
 msgstr "%1$s izmantots"
+
+# smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -604,6 +616,12 @@ msgstr "Pēdējo 24 stundu laikā DuckDuckGo bloķēja 1 mēģinājumu"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Pirms 1 dienas"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -897,14 +915,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
+msgstr ""
+"Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
+msgstr ""
+"Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1515,6 +1535,14 @@ msgid "Advanced Models"
 msgstr "Uzlaboti modeļi"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Reklamēt meklēšanā"
@@ -1677,7 +1705,8 @@ msgstr "Visas tērzēšanas sarunas ir %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr "Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
+msgstr ""
+"Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -2131,7 +2160,8 @@ msgstr "Vai tu joprojām esi tur?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
+msgstr ""
+"Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2143,7 +2173,8 @@ msgstr "Vai tiešām vēlies notīrīt šo sarunu un sākt jaunu?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
+msgstr ""
+"Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2299,6 +2330,12 @@ msgstr "Pajautāt privāti"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask privately"
 msgstr "Pajautāt privāti"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -3314,7 +3351,8 @@ msgstr "Kamerūna"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
+msgstr ""
+"Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3634,7 +3672,8 @@ msgstr "Maina fona krāsu visā vietnē"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
+msgstr ""
+"Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3767,8 +3806,8 @@ msgstr ""
 "ar trešo pušu mākslīgā intelekta tērzēšanas modeļiem, kas atbalsta OpenAI, "
 "Anthropic un citus rīkus. Izslēdzot šo iestatījumu tiks paslēptas tērzēšanas "
 "pogas un saites DuckDuckGo Search platformā. Taču tu joprojām vari piekļūt "
-"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot "
-"%1$shttps://duck.ai%2$s tieši."
+"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot %1$shttps://duck."
+"ai%2$s tieši."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3847,6 +3886,12 @@ msgstr "Privāti tērzēt ar %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Privāti tērzēt ar MI"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4366,7 +4411,8 @@ msgstr "Nospied %1$sAtļaut%2$s, pēc tam %3$sPievienot%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr ""
+"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4467,7 +4513,8 @@ msgstr "Sānjoslā noklikšķini uz %1$sPārlūks%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr ""
+"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4487,7 +4534,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
+msgstr ""
+"Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4616,7 +4664,8 @@ msgstr "Noklikšķini uz palielināmā stikla ikonas meklēšanas lodziņā"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
+msgstr ""
+"Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -4644,6 +4693,12 @@ msgstr "Klipkopa"
 #. An accessible label for a button that closes a modal dialog
 msgid "Close"
 msgstr "Aizvērt"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4688,6 +4743,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Aizvērt meklēšanu"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5061,6 +5122,12 @@ msgid "Continue Blocking Ads"
 msgstr "Turpināt bloķēt reklāmas"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5126,6 +5193,12 @@ msgid "Cookie data:"
 msgstr "Sīkdatņu dati:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5171,6 +5244,12 @@ msgstr "Nokopē un ielīmē %1$sabout:preferences#search%2$s adreses joslā"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopēt kodu"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5240,7 +5319,8 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
+msgstr ""
+"Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5286,6 +5366,12 @@ msgid "Create Image"
 msgstr "Izveidot attēlu"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5327,6 +5413,14 @@ msgstr "Izveidoja"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Izveidoja %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5480,6 +5574,12 @@ msgstr "Pielāgo atbildes"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Pielāgo atbildes"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5768,10 +5868,22 @@ msgid "Delete Server Data?"
 msgstr "Dzēst servera datus?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Dzēst transkripciju"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5804,6 +5916,12 @@ msgstr "Dzēst attēlu"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Dzēst attēlu?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6032,7 +6150,8 @@ msgstr "Atspējot un atvienot"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
+msgstr ""
+"Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6114,6 +6233,12 @@ msgstr "Vairs nerādīt"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Noraidīt akciju"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6220,7 +6345,8 @@ msgstr "Neredzi DuckDuckGo sarakstā?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
+msgstr ""
+"Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6325,6 +6451,12 @@ msgstr "Lejupielāde pabeigta"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Lejupielādēt DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6542,6 +6674,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai by DuckDuckGo. Privāta MI tērzēšana. Bezmaksas."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6632,7 +6770,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
+msgstr ""
+"Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6647,8 +6786,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai ļauj tev privāti tērzēt ar populāriem MI modeļiem. Atspējošana "
-"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt "
-"%1$sduck.ai%2$s tieši."
+"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt %1$sduck."
+"ai%2$s tieši."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6697,6 +6836,12 @@ msgstr ""
 "netiek pārbaudīta."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6712,7 +6857,8 @@ msgstr "Duck.ai atjaunināts!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
+msgstr ""
+"Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7246,7 +7392,8 @@ msgstr "Rediģē attēlu..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
+msgstr ""
+"Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7341,6 +7488,12 @@ msgstr "Iespējot visvairāk apmeklētās vietnes"
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Iespējot visvairāk apmeklētās vietnes"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7562,13 +7715,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
+msgstr ""
+"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
+msgstr ""
+"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7649,6 +7804,12 @@ msgid "Entertainment guide"
 msgstr "Izklaides ceļvedis"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Ekvatoriālā Gvineja"
 
@@ -7656,7 +7817,8 @@ msgstr "Ekvatoriālā Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
+msgstr ""
+"Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7747,7 +7909,8 @@ msgstr "Izskaidro pieņemto atbildi vienkāršā valodā."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
+msgstr ""
+"Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7808,6 +7971,18 @@ msgstr "Necenzēts saturs"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Necenzēti dziesmu vārdi"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7911,6 +8086,12 @@ msgid "FREE"
 msgstr "Bezmaksas"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7966,7 +8147,8 @@ msgstr "Atsauksme sekmīgi iesniegta"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
+msgstr ""
+"Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8107,7 +8289,8 @@ msgstr "Finanšu konsultants"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
+msgstr ""
+"Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8327,6 +8510,12 @@ msgid "Free Up Storage"
 msgstr "Atbrīvot vietu krātuvē"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8452,9 +8641,9 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac datorā lietotnes izvēlnes joslā izvēlies <strong>DuckDuckGo</strong> "
-"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt "
-"atjauninājumus...&quot;) un tad <strong>Install Update</strong> "
-"(&quot;Instalēt atjauninājumu&quot;)."
+"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt atjauninājumus..."
+"&quot;) un tad <strong>Install Update</strong> (&quot;Instalēt "
+"atjauninājumu&quot;)."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8846,6 +9035,12 @@ msgid "Get computer help"
 msgstr "Saņemt palīdzību datoru jautājumos"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8883,6 +9078,18 @@ msgid "Get the Latest Version"
 msgstr "Iegūt jaunāko versiju"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8903,6 +9110,12 @@ msgstr "Iegūt šo dziesmu šeit:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Pārliecini draugus pieslēgties un palīdzi mums attīstīties!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8976,7 +9189,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
+msgstr ""
+"Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9590,6 +9804,12 @@ msgid "Hide Tips"
 msgstr "Slēpt padomus"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9637,8 +9857,8 @@ msgstr "Slēp savu e-pasta adresi"
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
 msgstr ""
-"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas "
-"cilnē/vēsturē"
+"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas cilnē/"
+"vēsturē"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9886,7 +10106,8 @@ msgstr "Cik daudz tu vēlies, lai parādītos MI atbalstītas atbildes?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
+msgstr ""
+"Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10043,7 +10264,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
+msgstr ""
+"Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10130,7 +10352,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
+msgstr ""
+"Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10148,7 +10371,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
+msgstr ""
+"Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10706,7 +10930,8 @@ msgstr "Tas varētu aizņemt dažas minūtes"
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
+msgstr ""
+"Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -11211,6 +11436,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Ļauj meklēt anonīmi ar DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Libērija"
 
@@ -11279,6 +11511,12 @@ msgstr "Līniju zīmējums"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Uzvarētās līnijas"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12168,7 +12406,8 @@ msgstr "Tu esi sasniedzis mēneša limitu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
+msgstr ""
+"Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12375,6 +12614,12 @@ msgstr "Vairāk statistikas šeit: %1$s"
 msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Vairāk nekā 20 minūtes"
+
+# smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12865,6 +13110,12 @@ msgid "No Thanks"
 msgstr "Nē, paldies"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "Bez izsekošanas. Vienmēr."
@@ -13040,7 +13291,8 @@ msgstr "Tikai meklēšana – bez izsekošanas un mērķētas reklāmas!"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
+msgstr ""
+"Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -13527,6 +13779,12 @@ msgid "On but no numbers"
 msgstr "Ieslēgts, bet bez numerācijas"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13660,7 +13918,8 @@ msgstr "Atver %1$sIestatījumi%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
+msgstr ""
+"Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13739,6 +13998,12 @@ msgstr "Atvērt tērzēšanas ieteikumus"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Atvērt izveidot un rediģēt attēlus ieteikumus"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14487,10 +14752,22 @@ msgid "Pin"
 msgstr "Piespraude"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Piespraud tērzēšanas sarunas šeit no %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14508,6 +14785,12 @@ msgstr "Rozā"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Piesprausts"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14548,7 +14831,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
+msgstr ""
+"Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14556,7 +14840,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
+msgstr ""
+"Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14767,7 +15052,8 @@ msgstr "Plus vēl citas premium funkcijas ar DuckDuckGo abonementu."
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
+msgstr ""
+"Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14824,6 +15110,12 @@ msgstr "Poļu"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Slikta formatēšana"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15032,6 +15324,12 @@ msgstr "Iepriekšējais attēls"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Iepriekšējās cilnes"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15346,7 +15644,8 @@ msgstr "Aizsargā savus datus meklēšanas un pārlūkošanas laikā."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
+msgstr ""
+"Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15574,6 +15873,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Saprātīgs MI ar vidēja līmeņa iebūvētu moderēšanu"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15607,6 +15918,12 @@ msgstr "Nesen izmantotās cilnes"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Pēdējo tērzēšanas sarunu krātuvi var pielāgot %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15762,6 +16079,12 @@ msgstr "Mēģini meklēt vēlreiz bez šīs vietnes"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Samazināt lietojumu"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15922,7 +16245,8 @@ msgstr "Atcerēties manu izvēli"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
+msgstr ""
+"Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16141,6 +16465,12 @@ msgid "Reset All Settings"
 msgstr "Atiestatīt visus iestatījumus"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16151,6 +16481,12 @@ msgstr "Tiks atiestatīts pēc %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Izšķirtspēja"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16822,7 +17158,8 @@ msgstr "Ritini uz leju un sarakstā atrodi %1$ssavu pārlūkprogrammu%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
+msgstr ""
+"Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16853,6 +17190,12 @@ msgstr "Meklēt"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Meklēt %1$s, lai meklētu tuvākajā apkārtnē?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17226,6 +17569,12 @@ msgstr ""
 "tevi, nevar redzēt tavus datus, pat ne mēs."
 
 # smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "Security issue"
 msgstr "Drošības problēma"
@@ -17334,7 +17683,8 @@ msgstr "Apskati dažus no mūsu pēdējiem atjauninājumiem"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
+msgstr ""
+"Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17368,18 +17718,20 @@ msgstr "Safari izvēlnē atlasi %1$s“Šīs vietnes iestatījumi...”%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Atlasi %1$sPielāgots%2$s un ievades laukā raksti "
-"%3$shttps://duckduckgo.com%4$s"
+"Atlasi %1$sPielāgots%2$s un ievades laukā raksti %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
+msgstr ""
+"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
+msgstr ""
+"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17391,7 +17743,8 @@ msgstr "Atlasi %1$sDuckDuckGo%2$s un nospied %3$sIestatīt kā noklusējumu%4$s.
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
+msgstr ""
+"Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17411,7 +17764,8 @@ msgstr "Meklēšanas pakalpojumu sniedzēju sarakstā atlasi %1$sDuckDuckGo%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
+msgstr ""
+"Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17444,7 +17798,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
+msgstr ""
+"Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17735,6 +18090,12 @@ msgid "Set as Homepage"
 msgstr "Iestatīt kā sākumlapu"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17802,6 +18163,18 @@ msgid "Seychelles"
 msgstr "Seišelas"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17840,6 +18213,13 @@ msgstr ""
 "Kopīgo pilsētas līmeņa atrašanās vietu ar mākslīgā intelekta modeļiem, lai "
 "uzlabotu atbilstību. Duck.ai nenorāda precīzu atrašanās vietu mums vai "
 "mākslīgā intelekta modeļiem."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17898,6 +18278,12 @@ msgstr "Kopīgo lapas URL"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Sniegt pozitīvu atsauksmi"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18033,6 +18419,12 @@ msgstr "Parādīt grāmatzīmes un iestatījumu datus"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Rādīt sīkāku informāciju"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18182,6 +18574,12 @@ msgid "Show more"
 msgstr "Parādīt vairāk"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18215,6 +18613,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Parādīt sānjoslu"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18289,7 +18693,8 @@ msgstr "Parāda horizontālas līnijas rezultātu lapu pārtraukumos"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
+msgstr ""
+"Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18310,7 +18715,8 @@ msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu pārlūk
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
+msgstr ""
+"Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18572,19 +18978,27 @@ msgstr "Kaut kas notika nepareizi"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
+msgstr ""
+"Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
+msgstr ""
+"Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Kaut kas nogāja greizi. Lūdzu, vēlāk mēģini vēlreiz."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18659,8 +19073,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt "
-"Duck.ai."
+"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18676,7 +19090,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
+msgstr ""
+"Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18881,6 +19296,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Sākot lietot nedēļas limitu"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Sāc meklēt!"
@@ -18931,19 +19352,22 @@ msgstr "Paliec DuckDuckGo platformā"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19145,7 +19569,8 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
+msgstr ""
+"Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19457,6 +19882,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Sāc lietot meklētājprogrammu, kas tevi neizseko."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19611,6 +20044,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sinhronizācija un dublēšana uz laiku nav pieejamas"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19698,6 +20137,22 @@ msgid "Take Back Your Privacy!"
 msgstr "Atgūsti savu privātumu!"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19718,7 +20173,8 @@ msgstr "Esi noteicējs pār saviem personīgajiem datiem!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
+msgstr ""
+"Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20164,10 +20620,22 @@ msgid "This Month"
 msgstr "Šomēnes"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Šonedēļ"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20301,6 +20769,22 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Šī informācija nav noderīga"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20639,6 +21123,12 @@ msgid "Today"
 msgstr "Šodien"
 
 # smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Togo"
 msgstr "Togo"
 
@@ -20684,7 +21174,8 @@ msgstr "Pārāk daudz reklāmu"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr "Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
+msgstr ""
+"Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -21050,9 +21541,21 @@ msgid "Try Them Out"
 msgstr "Izmēģini tos"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Izmēģini meklēšanu!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21095,7 +21598,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
+msgstr ""
+"Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21119,6 +21623,12 @@ msgid "Try for free"
 msgstr "Izmēģini bez maksas"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21133,6 +21643,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Izmēģini bez maksas! Drošs VPN, uzlabots un privāts mākslīgais intelekts un "
 "vēl vairāk."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21160,6 +21676,12 @@ msgstr "Izmēģini mūsu pārlūkprogrammu,"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Izmēģini mūsu mājaslapu, kas nekad nerāda šīs ziņas:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21411,6 +21933,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Ieslēdz Duck Player, lai skatītos YouTube bez mērķētām reklāmām"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21420,7 +21948,8 @@ msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Precīza atrašanās v
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
+msgstr ""
+"Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21571,7 +22100,8 @@ msgstr "Nevar iesniegt atsauksmi"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
+msgstr ""
+"Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -21612,8 +22142,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: "
-"https://duckduckgo.com"
+"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21639,13 +22169,15 @@ msgstr "Zem %1$sMeklēt adreses joslā ar%2$s nospied %3$sPievienot jaunu%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
+msgstr ""
+"Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
+msgstr ""
+"Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21753,7 +22285,8 @@ msgstr "Atbloķē ar DuckDuckGo abonementu"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
+msgstr ""
+"Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21773,6 +22306,12 @@ msgstr "Atbloķē uzlabotus MI modeļus ar DuckDuckGo abonementu"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Piekļūsti uzlabotajam MI ar savu abonementu!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22138,6 +22677,12 @@ msgid "Use in Safari"
 msgstr "Lietot ar Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22160,7 +22705,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
+msgstr ""
+"Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22399,8 +22945,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver "
-"Duck.ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
+"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver Duck."
+"ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
 "“Sinhronizēt ar citu ierīci”. Vai arī noskenē kvadrātkodu savā atkopšanas "
 "PDF failā."
 
@@ -22682,7 +23228,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
+msgstr ""
+"Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22698,7 +23245,8 @@ msgstr "Mēs neglabājam lietotājvārdus un personu identificējošu informāci
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
+msgstr ""
+"Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22821,7 +23369,8 @@ msgstr "Mēs zaudējām savienojumu, lūdzu, vēlāk mēģini vēlreiz."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
+msgstr ""
+"Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -22853,7 +23402,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
+msgstr ""
+"Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23078,7 +23628,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
+msgstr ""
+"Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23323,6 +23874,12 @@ msgid "What brought you back today?"
 msgstr "Kāpēc Tu atgriezies atpakaļ?"
 
 # smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -23517,7 +24074,8 @@ msgstr "Par ko tu vēlētos sniegt atsauksmes?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
+msgstr ""
+"Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23607,7 +24165,8 @@ msgstr "Kas mēs esam"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr "Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
+msgstr ""
+"Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23737,6 +24296,14 @@ msgstr "Uzvaras"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Slapjš sniegs"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -23990,7 +24557,8 @@ msgstr "Jā, jauns lietotājs!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
+msgstr ""
+"Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24087,7 +24655,8 @@ msgstr "Tu vari mainīt to jebkurā laikā sadaļā %1$sMeklēšanas iestatījum
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
+msgstr ""
+"Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24126,7 +24695,8 @@ msgstr "Tu vari turpināt tērzēt, izmantojot savu mēneša limitu."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
+msgstr ""
+"Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24163,6 +24733,13 @@ msgstr "Katrai sarunai var pievienot tikai %1$s attēlus"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Katrai sarunai vari pievienot tikai %1$s attēlus."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24293,7 +24870,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
+msgstr ""
+"Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24304,6 +24882,12 @@ msgid ""
 msgstr ""
 "Tu saņemsi automātiskus DuckDuckGo lietotnes atjauninājumus, kad tev būs "
 "jaunākā versija."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24351,6 +24935,12 @@ msgid "You've blocked 1 site"
 msgstr "Tu esi bloķējis 1 vietni"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24390,7 +24980,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
+msgstr ""
+"Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24551,7 +25142,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
+msgstr ""
+"Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24752,6 +25344,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Tavas meklēšanas vaicājumus nevar sasaistīt ar tevi"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24833,7 +25433,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
+msgstr ""
+"Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25131,7 +25732,8 @@ msgstr "oficiālā vietne"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
+msgstr ""
+"vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25342,3 +25944,9 @@ msgstr "gadiem"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "g."
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s കണ്ടെത്തി"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s ഫയലുകൾ ഉപയോഗിച്ചു"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -182,8 +182,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
+"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -193,8 +194,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
+"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -210,8 +212,9 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് തുടരാൻ, നിങ്ങളുടെ "
-"സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് "
+"തുടരാൻ, നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
+"മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -220,8 +223,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും "
-"ശ്രമിക്കുക."
+"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ "
+"പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -312,9 +315,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് പോലും "
-"നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് അവരുടെ സെർവറുകളിൽ "
-"സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
+"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് "
+"പോലും നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് "
+"അവരുടെ സെർവറുകളിൽ സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -361,7 +364,7 @@ msgstr "%1$s ഉപയോഗിച്ചു"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കുന്നു %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -400,8 +403,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ ചാറ്റ് "
-"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ "
+"ചാറ്റ് തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -412,8 +415,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് തുടരുന്നതിന് "
-"നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് "
+"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -426,8 +429,8 @@ msgstr "%1$s വാക്കുകൾ"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, തുടർന്ന് "
-"%6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, "
+"തുടർന്ന് %6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -435,8 +438,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s "
-"ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് "
+"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -446,8 +449,9 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s ക്ലിക്ക് "
-"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s "
+"ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s "
+"ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -456,8 +460,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ "
-"കരുതുന്നുണ്ടെങ്കിൽ."
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ "
+"ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ കരുതുന്നുണ്ടെങ്കിൽ."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -476,7 +480,8 @@ msgstr "%1$sകൂടുതലറിയുക%2$s ."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക%2$s."
+"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
+"മനസ്സിലാക്കുക%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -484,16 +489,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
+"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
+"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -506,7 +511,8 @@ msgstr "ഹോം സ്ക്രീനിൽ DuckDuckGo ആപ്പ് ഐക�
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s വീണ്ടും ശ്രമിക്കുക."
+"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -618,7 +624,7 @@ msgstr "1 ദിവസം മുമ്പ്"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 ഫയൽ ഉപയോഗിച്ചു"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -846,7 +852,9 @@ msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -900,8 +908,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. നിങ്ങളുടെ കണക്ഷൻ "
-"പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. "
+"നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -959,10 +967,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
-"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത മറയ്ക്കും. %1$sduckduckgo.com/"
-"aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ "
-"കഴിയും."
+"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത "
+"മറയ്ക്കും. %1$sduckduckgo.com/aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് "
+"ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1023,10 +1031,11 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് പിന്തുണയ്ക്കുന്നില്ല. "
-"എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി %1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും "
-"പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് "
-"മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് "
+"പിന്തുണയ്ക്കുന്നില്ല. എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി "
+"%1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, "
+"ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1211,8 +1220,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
-"മോഡലിലേക്ക് മാറുക."
+"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു "
+"സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1248,8 +1257,8 @@ msgstr "പരസ്യം"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ നിങ്ങളെ "
-"തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
+"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ "
+"നിങ്ങളെ തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1257,8 +1266,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ "
-"ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
+"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1309,8 +1318,8 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ചേർക്കുക"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy Essentials "
-"ചേർക്കുക:"
+"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy "
+"Essentials ചേർക്കുക:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1531,6 +1540,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ "
+"കഴിഞ്ഞേക്കാം. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1566,15 +1577,17 @@ msgstr "ആഫ്രികാൻസ്"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
 msgstr ""
-"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് ഡബിൾ ക്ലിക്ക് "
-"ചെയ്യുക"
+"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് "
+"ഡബിൾ ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1710,8 +1723,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ DuckDuckGo "
-"അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല"
+"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ "
+"DuckDuckGo അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1744,8 +1758,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ ദാതാക്കളെയും "
-"അനുവദിക്കില്ല."
+"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ "
+"ദാതാക്കളെയും അനുവദിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1760,8 +1774,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും (ഉദാഹരണത്തിന്, "
-"നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
+"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും "
+"(ഉദാഹരണത്തിന്, നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1793,7 +1807,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ ആക്സസ് അനുവദിക്കുക."
+"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ "
+"ആക്സസ് അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1825,10 +1840,11 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ %1$s-നെ "
-"അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച "
-"ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ "
-"ദൃശ്യപരത പൂജ്യം ആണ്%4$s."
+"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ "
+"%1$s-നെ അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് "
+"എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള "
+"പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ ദൃശ്യപരത പൂജ്യം "
+"ആണ്%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1975,8 +1991,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
-"അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
+"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1985,8 +2001,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
-"അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
+"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2000,8 +2016,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്നു. ഇത് "
-"എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
+"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
+"സൃഷ്ടിക്കുന്നു. ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, "
+"അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2169,8 +2186,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ "
-"ചാറ്റുകളും ഇല്ലാതാക്കും."
+"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത "
+"ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ ചാറ്റുകളും ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2179,8 +2196,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് ചെയ്ത സമീപകാല "
-"ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
+"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് "
+"ചെയ്ത സമീപകാല ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2218,8 +2235,9 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും ശേഖരിക്കുകയോ "
-"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും "
+"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2320,7 +2338,7 @@ msgstr "സ്വകാര്യമായി ചോദിക്കുക"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "സ്വകാര്യമായി ചോദിക്കുക"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2355,13 +2373,15 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ ഉത്തരങ്ങൾ അജ്ഞാതമായി "
-"സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
-"ഒരിക്കലും ഇല്ല (തിരയൽ ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
-"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ചിലപ്പോൾ "
-"(വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ "
-"തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. "
-"(ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
+"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ "
+"ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ "
+"പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും ഇല്ല (തിരയൽ "
+"ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
+"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
+"കാണിക്കൂ), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
+"കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി "
+"കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. (ഇംഗ്ലീഷ്) മേഖലയിൽ "
+"മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2373,13 +2393,14 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
-"അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ %1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് "
-"പ്രധാനമാണ്."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. "
+"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
+"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
+"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2512,15 +2533,16 @@ msgstr "സ്വയമേവയുള്ള-ഉത്തരം"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ "
+"അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. പ്രതികരണങ്ങളിൽ അപാകതകൾ "
-"അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. "
+"പ്രതികരണങ്ങളിൽ അപാകതകൾ അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2545,9 +2567,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി തിരയാനും ചില "
-"സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ "
-"മാത്രമേ Assist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി "
+"തിരയാനും ചില സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. "
+"ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2556,16 +2578,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് അജ്ഞാതമായി "
-"തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് "
-"പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് "
+"അജ്ഞാതമായി തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
+"കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
 msgstr ""
-"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ സ്വയമേവ പ്ലേ ചെയ്യുക."
+"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ "
+"സ്വയമേവ പ്ലേ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2597,7 +2620,9 @@ msgstr "ശരാശരി വോളിയം"
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr "നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് ഒഴിവാക്കുക."
+msgstr ""
+"നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് "
+"ഒഴിവാക്കുക."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2765,8 +2790,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ "
-"എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
+"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, "
+"തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo "
+"നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3147,18 +3173,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
-"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
-"ഒരുമിച്ചുചേർത്തു."
+"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ "
+"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
+"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
-"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
-"ഒരുമിച്ചുചേർത്തു."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ "
+"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
+"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3166,9 +3192,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. %1$sപ്രധാന "
-"ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ "
-"മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. "
+"%1$sപ്രധാന ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, "
+"സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3254,7 +3280,9 @@ msgstr "'%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നി�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം അംഗീകരിക്കുന്നു."
+msgstr ""
+"“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം "
+"അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3275,10 +3303,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), ക്രമീകരണം "
-"സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ "
-"ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി "
-"തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
+"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), "
+"ക്രമീകരണം സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു "
+"വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത "
+"Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
+"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
 "നിങ്ങളുടെ ബ്രൗസറിൽ നിന്ന് പുറത്തുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -3287,8 +3316,9 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ ശബ്ദ ഡാറ്റ "
-"OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
+"നിങ്ങളുടെ ശബ്ദ ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
+"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3297,9 +3327,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ വോയ്സ് "
-"ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s "
-"കാണൂ."
+"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
+"നിങ്ങളുടെ വോയ്സ് ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
+"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3335,8 +3365,8 @@ msgstr "കാമറൂൺ"
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
 msgstr ""
-"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ പാചകക്കുറിപ്പുകൾ "
-"സൃഷ്ടിക്കാൻ കഴിയുമോ?"
+"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ "
+"പാചകക്കുറിപ്പുകൾ സൃഷ്ടിക്കാൻ കഴിയുമോ?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3638,7 +3668,8 @@ msgstr "ഫലങ്ങളുടെ URL-കൾ എങ്ങനെ പ്രദ�
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
 msgstr ""
-"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ പെരുമാറ്റവും മാറുന്നു"
+"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ "
+"പെരുമാറ്റവും മാറുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3657,13 +3688,17 @@ msgstr "മുഴുവൻ സൈറ്റിലും പശ്ചാത്ത�
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം മാറ്റുന്നു"
+msgstr ""
+"ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം "
+"മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം മാറ്റുന്നു"
+msgstr ""
+"ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം "
+"മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3786,10 +3821,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ ചാറ്റ് (Duck.ai "
-"സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. "
-"ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. "
-"എന്നിരുന്നാലും, %1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
+"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ "
+"ചാറ്റ് (Duck.ai സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic "
+"തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo "
+"Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, "
+"%1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
 "നിങ്ങൾക്ക് ചാറ്റ് ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
@@ -3846,8 +3882,8 @@ msgstr "സ്വകാര്യമായി ചാറ്റ് ചെയ്യ�
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
-"ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
+"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3855,8 +3891,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
-"ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
+"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3874,7 +3910,7 @@ msgstr "AI-യുമായി സ്വകാര്യമായി ചാറ്�
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "ജനപ്രിയ AI-കളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3925,9 +3961,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത "
-"ചാറ്റുകൾ നീക്കം ചെയ്യും."
+"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത ചാറ്റുകൾ നീക്കം ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3939,11 +3975,13 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും "
-"അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് "
-"നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും "
-"പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ "
+"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
+"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3966,8 +4004,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ അപ്‌ലോഡ് ചെയ്യുന്ന "
-"എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് അജ്ഞാതമായി പരിശോധിക്കുന്നു."
+"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ "
+"അപ്‌ലോഡ് ചെയ്യുന്ന എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് "
+"അജ്ഞാതമായി പരിശോധിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -3975,8 +4014,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. സമന്വയം പുനരാരംഭിക്കാൻ "
-"സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
+"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. "
+"സമന്വയം പുനരാരംഭിക്കാൻ സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4029,7 +4068,9 @@ msgstr "സ്പെല്ലിംഗ് പരിശോധിക്കുക"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് പരിശോധിക്കുക."
+msgstr ""
+"ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് "
+"പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4100,7 +4141,9 @@ msgstr "%1$s , %2$s എന്നിവ ഉൾപ്പെടെ AI മോഡല�
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s തിരഞ്ഞെടുക്കുക."
+msgstr ""
+"നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4141,8 +4184,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് ആപ്പ് "
-"ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
+"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് "
+"ആപ്പ് ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4323,9 +4366,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ നടന്ന ചാറ്റുകൾ "
-"അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി "
-"ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ "
+"നടന്ന ചാറ്റുകൾ അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 "
+"ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4335,9 +4378,10 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ Duck.ai "
-"ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ "
-"ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ ആശ്രയിച്ചിരിക്കുന്നു."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ "
+"Duck.ai ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ "
+"യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ "
+"ആശ്രയിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4346,8 +4390,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് "
-"ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. "
+"നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4356,9 +4400,10 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ %1$sDuck.ai%2$s "
-"വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI ചാറ്റ് സേവനം."
+"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ "
+"%1$sDuck.ai%2$s വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic "
+"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI "
+"ചാറ്റ് സേവനം."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4417,7 +4462,9 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ച�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4434,8 +4481,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ വലതുവശത്തുള്ള "
-"%3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
+"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ "
+"വലതുവശത്തുള്ള %3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4453,7 +4500,8 @@ msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sക്രമീകരണം%
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
 msgstr ""
-"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി ക്ലിക്ക് ചെയ്യുക%4$s."
+"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി "
+"ക്ലിക്ക് ചെയ്യുക%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4466,7 +4514,8 @@ msgstr "%1$sഉവ്വ്%2$s ക്ലിക്ക് ചെയ്യുക"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് ചെയ്യുക."
+"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4528,9 +4577,10 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
-"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s "
-"ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
+"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ "
+"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
+"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4541,9 +4591,10 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
-"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/"
-"ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
+"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ "
+"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
+"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4612,8 +4663,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ "
-"ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
+"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ "
+"മെനുവിൽ ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4621,8 +4672,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ ബ്രൗസറിന്റെ "
-"മുകളിൽ വലത് കോണിലായിരിക്കും."
+"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ "
+"ബ്രൗസറിന്റെ മുകളിൽ വലത് കോണിലായിരിക്കും."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4668,7 +4719,7 @@ msgstr "അടയ്ക്കുക"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "അടയ്ക്കുക"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4718,7 +4769,7 @@ msgstr "തിരയൽ അടയ്ക്കുക"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "രണ്ടാമത്തെ അഭിപ്രായം അടയ്ക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4823,8 +4874,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി സംരക്ഷിക്കാൻ അനുവദിക്കും. "
-"ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
+"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി "
+"സംരക്ഷിക്കാൻ അനുവദിക്കും. ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5096,6 +5147,8 @@ msgstr "പരസ്യങ്ങൾ തടയുന്നത് തുടരു�
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
+"സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ "
+"ഇല്ലാതാക്കുക."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5166,7 +5219,7 @@ msgstr "കുക്കി ഡാറ്റ:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "പകർത്തി"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5219,7 +5272,7 @@ msgstr "കോഡ് പകർത്തുക"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "ലിങ്ക് പകർത്തുക"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5289,7 +5342,9 @@ msgstr "കോസ്റ്റാ റിക്ക"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും ശ്രമിക്കു."
+msgstr ""
+"നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും "
+"ശ്രമിക്കു."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5338,7 +5393,7 @@ msgstr "ചിത്രം സൃഷ്ടിക്കുക"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "പങ്കിടൽ ലിങ്ക് സൃഷ്ടിക്കുക"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5390,6 +5445,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് "
+"തുറക്കുന്ന ആർക്കും അത് കാണാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5548,7 +5605,7 @@ msgstr "പ്രതികരണങ്ങൾ ഇഷ്ടാനുസൃതമ�
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "പ്രതികരണങ്ങൾ ഇഷ്ടാനുസൃതമാക്കുക"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5622,7 +5679,9 @@ msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞ
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5836,7 +5895,7 @@ msgstr "സെർവർ ഡാറ്റ ഇല്ലാതാക്കുക?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "പങ്കുവെച്ച ലിങ്ക് ഇല്ലാതാക്കുക"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5848,7 +5907,7 @@ msgstr "ട്രാൻസ്ക്രിപ്റ്റ് ഇല്ലാത�
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "ഒരു ചാറ്റ് ഇല്ലാതാക്കുക"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5886,7 +5945,7 @@ msgstr "ചിത്രം ഇല്ലാതാക്കണോ?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "എന്നെ ഇല്ലാതാക്കുക"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5898,7 +5957,9 @@ msgstr "സംഭരണ സ്ഥലം ശൂന്യമാക്കാൻ ഏ
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കണോ?"
+msgstr ""
+"സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ "
+"ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6013,8 +6074,8 @@ msgstr "Duck.ai-യിലെ ഡിക്റ്റേഷൻ"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിക്കാറില്ല."
+"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6032,8 +6093,9 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ ഉപയോഗിക്കുന്നു, "
-"അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് ചെയ്യാൻ സാധിക്കും."
+"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ "
+"ഉപയോഗിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് "
+"ചെയ്യാൻ സാധിക്കും."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6200,7 +6262,7 @@ msgstr "പ്രൊമോഷൻ ഒഴിവാക്കുക"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "ടൂർ നിരസിക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6307,7 +6369,9 @@ msgstr "പട്ടികയിൽ DuckDuckGo കാണുന്നില്ല
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് ചെയ്യുക%4$s"
+msgstr ""
+"അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് "
+"ചെയ്യുക%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6345,8 +6409,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI ചിത്രങ്ങൾ "
-"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
+"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI "
+"ചിത്രങ്ങൾ ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6416,7 +6480,7 @@ msgstr "DuckDuckGo ഡൗൺലോഡ് ചെയ്യുക"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "DuckDuckGo ഡൗൺലോഡ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6472,8 +6536,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടറിന് "
-"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു "
+"വെണ്ടറിന് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6482,8 +6546,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് "
-"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ "
+"അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6504,8 +6568,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ പോസ്റ്റിന് കുറച്ച് "
-"ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
+"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ "
+"പോസ്റ്റിന് കുറച്ച് ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6514,8 +6578,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു പോസ്റ്റിന്റെ "
-"തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
+"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു "
+"പോസ്റ്റിന്റെ തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6585,7 +6649,9 @@ msgstr "നിങ്ങളുടെ ഫോട്ടോകളോ PDF ഫയലു
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ അനുവദിക്കുന്നു"
+msgstr ""
+"ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ "
+"അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6637,7 +6703,7 @@ msgstr "Duck.ai DuckDuckGo-യുടെതാണ്. സ്വകാര്യ AI
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വിശകലനം ചെയ്യാൻ കഴിയും. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6647,9 +6713,10 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് ഉത്തരം നൽകാൻ "
-"സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ നിങ്ങൾ "
-"തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
+"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് "
+"ഉത്തരം നൽകാൻ സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ "
+"നിങ്ങൾ തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് "
+"ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6659,9 +6726,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. "
-"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ "
-"ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് "
+"ചെയ്യാൻ കഴിയില്ല. നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും "
+"എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6670,14 +6737,16 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. ദയവായി നാളെ ഈ "
-"ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. "
+"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും മികച്ചത്!"
+msgstr ""
+"ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും "
+"മികച്ചത്!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6687,8 +6756,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ നിയന്ത്രണം തിരികെ "
-"നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
+"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ "
+"നിയന്ത്രണം തിരികെ നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര "
+"ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6703,8 +6773,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ എളുപ്പമുള്ള ഒരു "
-"വിലാസം ലഭിക്കും: https://duck.ai"
+"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ "
+"എളുപ്പമുള്ള ഒരു വിലാസം ലഭിക്കും: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6719,8 +6789,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s അജ്ഞാത കോഡ് "
-"%2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s "
+"അജ്ഞാത കോഡ് %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6741,9 +6811,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും "
-"%1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
+"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഇത് പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും "
+"മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും %1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6754,11 +6824,12 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം കക്ഷി AI ചാറ്റ് "
-"മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഈ ക്രമീകരണം "
-"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ "
-"ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai "
-"ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
+"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം "
+"കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai "
+"ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ ക്രമീകരണം ഓഫ് "
+"ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai ആക്സസ് "
+"ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6773,15 +6844,16 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. നിങ്ങൾക്ക് ഇപ്പോഴും "
-"പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
+"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. "
+"നിങ്ങൾക്ക് ഇപ്പോഴും പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
 msgstr ""
-"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!"
+"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് "
+"പരീക്ഷിച്ചു നോക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6789,14 +6861,16 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ കൃത്യതയ്ക്കായി "
-"പരിശോധിച്ചിട്ടുമില്ല."
+"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ "
+"കൃത്യതയ്ക്കായി പരിശോധിച്ചിട്ടുമില്ല."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
+"Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai "
+"പിന്തുണയ്ക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6815,8 +6889,8 @@ msgstr "Duck.ai അപ്ഗ്രേഡ് ചെയ്തു!"
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
 msgstr ""
-"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ "
-"DuckDuckGo ആപ്പിലാണ്!"
+"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും "
+"സൗജന്യവുമായ DuckDuckGo ആപ്പിലാണ്!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6826,9 +6900,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത AI ചാറ്റ്, "
-"സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI "
-"മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
+"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത "
+"AI ചാറ്റ്, സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, "
+"മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, "
+"അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6856,11 +6931,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
-"കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
-"ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-"
-"ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ "
-"പ്രസക്തമാകുമ്പോൾ മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
+"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ "
+"സംഗ്രഹിക്കാനും കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് "
+"നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist "
+"UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ "
+"ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ "
+"മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
 "കാണിക്കുന്നു). ഇപ്പോൾ, DuckAssist യുഎസ് (ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
@@ -6870,9 +6946,10 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
-"%1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ "
-"നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
+"എന്നിരുന്നാലും, ഞങ്ങൾ %1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് "
+"OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന "
+"ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6881,9 +6958,10 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
-"DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic "
-"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
+"എന്നിരുന്നാലും, ഞങ്ങൾ DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം "
+"ചെയ്യുന്നു, ഇത് OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6895,12 +6973,13 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
-"അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി "
-"വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം "
-"സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ "
-"പ്രതികരണങ്ങൾ നിലവിൽ വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും "
-"കൃത്യത പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ പ്രതികരണങ്ങൾ നിലവിൽ "
+"വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും കൃത്യത "
+"പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6914,14 +6993,16 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ രണ്ടോ "
-"ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ "
-"നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് "
-"പ്രതികരണങ്ങൾ സ്വയം സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് "
+"തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് "
+"ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
+"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
+"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ "
+"രണ്ടോ ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് "
+"വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ "
+"വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
 "%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
@@ -6940,8 +7021,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. ദയവായി നാളെ ഈ "
-"ചാറ്റ് തുടരുക."
+"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. "
+"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6950,8 +7031,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
-"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
+"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6960,8 +7041,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
-"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
+"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6970,8 +7051,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം."
+"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6980,8 +7061,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ "
-"അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി "
+"ഈ അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7114,8 +7195,9 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII "
-"സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ അജ്ഞാതമാക്കുന്നു."
+"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ "
+"പോലുള്ള PII സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ "
+"അജ്ഞാതമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7123,8 +7205,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ Duck.ai-"
-"യുടെ %2$s സമ്മതിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
+"നിങ്ങൾ Duck.ai-യുടെ %2$s സമ്മതിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7133,8 +7215,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ ഞങ്ങളുടെ "
-"%2$s-നെ അംഗീകരിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
+"നിങ്ങൾ ഞങ്ങളുടെ %2$s-നെ അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7143,9 +7225,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന Google, Facebook പോലുള്ള "
-"കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ "
-"DuckDuckGo തടയുന്നു."
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന "
+"Google, Facebook പോലുള്ള കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ "
+"സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ DuckDuckGo തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7157,12 +7239,13 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ "
-"ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് "
-"ഞങ്ങൾക്ക് അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് ഉപയോഗിക്കുന്നു, "
-"തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ "
-"സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ "
-"അറിയുക%2$s."
+"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ "
+"പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് "
+"സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് ഞങ്ങൾക്ക് "
+"അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് "
+"ഉപയോഗിക്കുന്നു, തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി "
+"ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ "
+"സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7182,8 +7265,9 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് കൂടുതൽ ബന്ധമുള്ള, "
-"മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് "
+"കൂടുതൽ ബന്ധമുള്ള, മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7269,10 +7353,11 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo സെർവറുകളിൽ നിന്ന് "
-"ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ "
-"നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 "
-"അക്ഷരങ്ങളെങ്കിലും ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
+"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo "
+"സെർവറുകളിൽ നിന്ന് ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. "
+"പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ "
+"തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 അക്ഷരങ്ങളെങ്കിലും "
+"ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7343,8 +7428,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും പുതിയത് സൃഷ്ടിക്കുകയും "
-"ചെയ്യും."
+"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും "
+"പുതിയത് സൃഷ്ടിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7405,7 +7490,9 @@ msgstr "AI സവിശേഷതകൾ പ്രവർത്തനക്ഷമ�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save പ്രവർത്തനക്ഷമമാക്കുക."
+msgstr ""
+"നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save "
+"പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7444,7 +7531,7 @@ msgstr "ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച 
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "ഇപ്പോൾ പ്രവർത്തനക്ഷമമാക്കുക"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7482,8 +7569,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് എപ്പോൾ "
-"വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് "
+"എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7528,8 +7615,9 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, പക്ഷേ അപ്പോഴും നിങ്ങളുടെ "
-"തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
+"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, "
+"പക്ഷേ അപ്പോഴും നിങ്ങളുടെ തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് "
+"സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7606,7 +7694,8 @@ msgstr "Duck.ai ആസ്വദിക്കുകയാണോ?"
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
 msgstr ""
-"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് "
+"ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7692,8 +7781,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക. ഇത് "
-"നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
+"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് "
+"ചെയ്യുക. ഇത് നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7719,8 +7808,8 @@ msgstr "ടെക്‌സ്റ്റ് നൽകുക"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: %5$sഅപരനാമം "
-"%6$s: ഡി%7$s"
+"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: "
+"%5$sഅപരനാമം %6$s: ഡി%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7750,7 +7839,7 @@ msgstr "വിനോദ ഗൈഡ്"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "മുഴുവൻ ചാറ്റ്"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7761,7 +7850,8 @@ msgstr "ഇക്വറ്റോറിയൽ ഗിനിയ"
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
 msgstr ""
-"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ മായ്ക്കുക %1$s%2$s"
+"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ "
+"മായ്ക്കുക %1$s%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7821,7 +7911,9 @@ msgstr "മാപ്പ് വികസിപ്പിക്കുക"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത ഉൽപ്പന്നങ്ങൾ."
+msgstr ""
+"സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത "
+"ഉൽപ്പന്നങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7894,7 +7986,9 @@ msgstr "ഇത് ലളിതമായി വിശദീകരിക്കു�
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr "ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും വിശദീകരിക്കുക."
+msgstr ""
+"ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും "
+"വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7918,13 +8012,13 @@ msgstr "വ്യക്തമായ വരികൾ"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai പര്യവേക്ഷണം ചെയ്യൂ"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai പര്യവേക്ഷണം ചെയ്യൂ"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8031,7 +8125,7 @@ msgstr "സൗജന്യം"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "സൗജന്യവും ഐച്ഛികവും"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8090,8 +8184,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
-"സ്വാധീനിക്കുന്നു."
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
+"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8100,8 +8194,9 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
-"സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
+"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
+"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും "
+"പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8109,8 +8204,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ സൈറ്റിലേക്കു പകർത്തി "
-"ഒട്ടിക്കുക"
+"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ "
+"സൈറ്റിലേക്കു പകർത്തി ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8194,15 +8289,16 @@ msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
-"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് ഫിൽട്ടർ ചെയ്ത് "
-"ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് "
+"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. "
+"%1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8244,7 +8340,8 @@ msgstr "<b>%1$s</b> നിങ്ങളുടെ ഡൗൺലോഡുകൾ ഫ�
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
 msgstr ""
-"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s "
+"എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8282,8 +8379,8 @@ msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
 msgstr ""
-"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും സുരക്ഷിതവും "
-"അജ്ഞാതവുമാണ്."
+"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും "
+"സുരക്ഷിതവും അജ്ഞാതവുമാണ്."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8347,8 +8444,9 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു മെനു ഓപ്ഷൻ "
-"തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി വന്നേക്കാം."
+"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു "
+"മെനു ഓപ്ഷൻ തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി "
+"വന്നേക്കാം."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8453,7 +8551,7 @@ msgstr "സംഭരണം ഒഴിവാക്കുക"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "സൗജന്യവും എപ്പോഴും സ്വകാര്യവും"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8465,7 +8563,9 @@ msgstr "സൗജന്യവും സ്വകാര്യവുമായ ച�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് ആവശ്യമില്ല."
+msgstr ""
+"സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് "
+"ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8495,7 +8595,9 @@ msgstr "പങ്കിടലും വാണിജ്യപരമായി ഉ�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+msgstr ""
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ "
+"ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8576,9 +8678,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; <strong>അപ്ഡേറ്റുകൾ "
-"പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് ഇൻസ്റ്റാൾ ചെയ്യുക</strong> "
-"തിരഞ്ഞെടുക്കുക."
+"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; "
+"<strong>അപ്ഡേറ്റുകൾ പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് "
+"ഇൻസ്റ്റാൾ ചെയ്യുക</strong> തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8929,8 +9031,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo-യിലേക്ക് "
-"സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന "
+"DuckDuckGo-യിലേക്ക് സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI "
+"മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8941,8 +9044,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo സബ്സ്ക്രിപ്ഷൻ "
-"ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo "
+"സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8971,7 +9074,7 @@ msgstr "കമ്പ്യൂട്ടർ സഹായം നേടുക"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് ഉയർന്ന ഉപയോഗ പരിധികൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8983,7 +9086,8 @@ msgstr "നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഒര�
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
 msgstr ""
-"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ സൗജന്യമായി നേടുക:"
+"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ "
+"സൗജന്യമായി നേടുക:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9013,13 +9117,13 @@ msgstr "ഏറ്റവും പുതിയ പതിപ്പ് നേടു
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "ആപ്പ് നേടൂ"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
+msgstr "YouTube-ലെ പരസ്യങ്ങൾ തടയാൻ %1$s സൗജന്യ DuckDuckGo ബ്രൗസർ നേടുക.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9047,7 +9151,7 @@ msgstr "കൂട്ടുകാരെ മാറാൻ പ്രേരിപ്�
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "ആരംഭിക്കുന്നതിനുള്ള ചെക്ക്‌ലിസ്റ്റ്"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9079,8 +9183,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
-"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക › "
-"ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
+"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക › ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9115,8 +9219,8 @@ msgid ""
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
 "എന്നതിലേക്ക് പോയി %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ "
-"ചെയ്യുക."
+"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
+"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9131,8 +9235,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് പോയി "
-"\"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് "
+"പോയി \"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9392,7 +9496,9 @@ msgstr "ഗ്വാട്ടിമാല"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ നയിക്കുക."
+msgstr ""
+"ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ "
+"നയിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9592,7 +9698,9 @@ msgstr "DuckDuckGo മെച്ചപ്പെടുത്താൻ ഞങ്ങ
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ സഹായിക്കൂ"
+msgstr ""
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ "
+"സഹായിക്കൂ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9650,7 +9758,9 @@ msgstr "Duck ഭാഗത്ത് ചേരാൻ നിങ്ങളുടെ �
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ സഹായിക്കൂ!"
+msgstr ""
+"നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ "
+"സഹായിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9738,7 +9848,7 @@ msgstr "നുറുങ്ങുകൾ മറയ്ക്കുക"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "ട്യൂട്ടോറിയൽ മറയ്ക്കുക"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9825,8 +9935,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search Assist "
-"ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
+"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search "
+"Assist ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9853,8 +9963,9 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ %1$sമടങ്ങുക%2$s "
-"അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ "
+"%1$sമടങ്ങുക%2$s അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് "
+"ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9868,8 +9979,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, നിങ്ങൾക്ക് "
-"ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
+"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, "
+"നിങ്ങൾക്ക് ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9919,8 +10030,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
-"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ "
+"ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10029,7 +10140,9 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് ആഗ്രഹിക്കുന്നത്?"
+msgstr ""
+"നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് "
+"ആഗ്രഹിക്കുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10062,8 +10175,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ തന്ത്രപൂർവ്വം "
-"സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
+"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ "
+"തന്ത്രപൂർവ്വം സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10170,7 +10283,9 @@ msgstr "കൂടുതൽ വിൽപ്പനക്കാരിൽ നിന�
 #. Header above text explaining that passwords can't be recovered.
 msgctxt "cloudsave"
 msgid "I forgot my passphrase. Can you recover it?"
-msgstr "എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ സാധിക്കുമോ?"
+msgstr ""
+"എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ "
+"സാധിക്കുമോ?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user hits a chat limit.
@@ -10185,14 +10300,16 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് "
-"ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
+"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല "
+"പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ എനിക്ക് ആവശ്യമാണ്"
+msgstr ""
+"ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ "
+"എനിക്ക് ആവശ്യമാണ്"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10221,8 +10338,9 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > പുനഃക്രമീകരിക്കുക > "
-"'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s എന്നതിലേക്ക് പോകുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > "
+"പുനഃക്രമീകരിക്കുക > 'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s "
+"എന്നതിലേക്ക് പോകുക."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10232,9 +10350,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക %1$s⋮ > മെനു > "
-"ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് "
-"അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക "
+"%1$s⋮ > മെനു > ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് "
+"DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10249,8 +10367,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ എഞ്ചിനുകളുടെ%4$s "
-"പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
+"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ "
+"എഞ്ചിനുകളുടെ%4$s പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10259,8 +10377,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് "
-"ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് %1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
+"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് "
+"പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് "
+"%1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10269,16 +10388,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ "
-"ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച "
+"ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ "
+"ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, %1$sDuckDuckGo "
-"പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
+"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, "
+"%1$sDuckDuckGo പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10288,8 +10408,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ %1$s "
-"അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
+"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ "
+"%1$s അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10297,8 +10417,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും അടുത്തുള്ള ഹോം പേജ് "
-"തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
+"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും "
+"അടുത്തുള്ള ഹോം പേജ് തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10427,8 +10547,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് ഫലത്തിന്റെ വ്യക്തത "
-"മെച്ചപ്പെടുത്തുന്നു"
+"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് "
+"ഫലത്തിന്റെ വ്യക്തത മെച്ചപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10441,8 +10561,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ ക്ലിക്കുകൾ "
-"റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ "
+"ക്ലിക്കുകൾ റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10453,8 +10573,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, തുടർന്ന് \"മറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
+"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, "
+"തുടർന്ന് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10469,8 +10589,9 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക "
-"എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി പരിശോധിക്കാവുന്നതാണ്."
+"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം "
+"വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി "
+"പരിശോധിക്കാവുന്നതാണ്."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10807,8 +10928,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ പ്രശസ്തി "
-"സംഗ്രഹിക്കുക."
+"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ "
+"പ്രശസ്തി സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10852,15 +10973,17 @@ msgstr "ഇതിന് ഏതാനും നിമിഷങ്ങൾ എടു
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും നൽകുന്നു."
+msgstr ""
+"ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും "
+"നൽകുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) ചോദിക്കുന്നതിൽ "
-"കുഴപ്പമില്ല"
+"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) "
+"ചോദിക്കുന്നതിൽ കുഴപ്പമില്ല"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10879,10 +11002,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, Microsoft-ന്റെ "
-"പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് "
-"നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം "
-"ലഭിക്കുന്നില്ല."
+"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, "
+"Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ "
+"നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് "
+"വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം ലഭിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10891,8 +11014,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 വാക്കുകൾ ഓർമിക്കുവാൻ, "
-"വളരെ അധികം സുരക്ഷിതവും."
+"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 "
+"വാക്കുകൾ ഓർമിക്കുവാൻ, വളരെ അധികം സുരക്ഷിതവും."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11259,7 +11382,9 @@ msgstr "DuckDuckGo ക്രമീകരണങ്ങൾ എങ്ങനെ ക�
 #. Description of a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "Learn how we keep your location private"
-msgstr "നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക"
+msgstr ""
+"നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
+"മനസ്സിലാക്കുക"
 
 # smartling.placeholder_format=C
 #. Link text in the Usage section of Duck.ai settings that opens a help page explaining Duck.ai usage limits.
@@ -11301,7 +11426,9 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് അറിയുക."
+msgstr ""
+"ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് "
+"അറിയുക."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11364,6 +11491,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ "
+"മാറാൻ നിങ്ങളെ അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11421,7 +11550,9 @@ msgstr "ഈ ചാറ്റിനായി പരിമിതമായ ഡാറ
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr "ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് പരിമിതപ്പെടുത്തുന്നു"
+msgstr ""
+"ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് "
+"പരിമിതപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11439,7 +11570,7 @@ msgstr "നേടിയ ലൈനൗട്ടുകൾ"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "ലിങ്ക് 7 ദിവസത്തിനുള്ളിൽ കാലഹരണപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11456,7 +11587,8 @@ msgstr "ലിങ്കുകൾ:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
-"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ ലിസ്റ്റ് ചെയ്യുക."
+"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ "
+"ലിസ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11568,7 +11700,8 @@ msgstr "സ്ക്രോൾ ചെയ്യുമ്പോൾ കൂടുത�
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
 msgstr ""
-"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ ലോഡ് ചെയ്യുന്നു"
+"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ "
+"ലോഡ് ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11749,7 +11882,8 @@ msgstr "എല്ലാ വാക്കുകളും അക്ഷരത്ത�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
+"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് "
+"തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12095,7 +12229,9 @@ msgstr "മൈക്രോനേഷ്യ"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12538,7 +12674,7 @@ msgstr "20 മിനിറ്റിൽ അധികം"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "കൂടുതൽ നുറുങ്ങുകൾ"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12861,10 +12997,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു "
-"DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് "
-"വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ "
-"ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
+"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
 "പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
@@ -13032,7 +13169,7 @@ msgstr "വേണ്ട, നന്ദി"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "വേണ്ട, നന്ദി"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13700,7 +13837,7 @@ msgstr "ഓണാണ്, പക്ഷെ നമ്പറുകൾ ഇല്ല"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "ഓൺബോർഡിംഗ് പൂർത്തിയായി"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13716,8 +13853,9 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ കൂടുതൽ പേജുകളുണ്ട്. %1$s "
-"അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുക."
+"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ "
+"കൂടുതൽ പേജുകളുണ്ട്. %1$s അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13760,8 +13898,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത പിശകുണ്ടായി. പിന്നീട് "
-"വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത "
+"പിശകുണ്ടായി. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13815,8 +13953,8 @@ msgstr "%1$s വെബ്‌സൈറ്റ് തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
 msgstr ""
-"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s "
-"ഉറപ്പാക്കുക"
+"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
+"%3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s ഉറപ്പാക്കുക"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13837,7 +13975,8 @@ msgstr "%1$sക്രമീകരണം%2$s തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
 msgstr ""
-"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
+"%1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13921,7 +14060,7 @@ msgstr "ചിത്രങ്ങൾ സൃഷ്ടിക്കാനും എ�
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "ആരംഭിക്കാനുള്ള ചെക്ക്‌ലിസ്റ്റ് തുറക്കുക"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -13986,7 +14125,9 @@ msgstr "How Duck.ai വർക്ക്സ് പാനൽ തുറക്കു�
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s തിരഞ്ഞെടുക്കുക..."
+msgstr ""
+"Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s "
+"തിരഞ്ഞെടുക്കുക..."
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14087,8 +14228,9 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ നിങ്ങളുടെ "
-"തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല — കാലഘട്ടം"
+"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ "
+"നിങ്ങളുടെ തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് "
+"ചെയ്യുന്നില്ല — കാലഘട്ടം"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14101,8 +14243,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും ശേഖരിക്കുകയോ "
-"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും "
+"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14110,9 +14252,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ ഉൾപ്പെടുത്തി "
-"മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, Android%2$s എന്നിവയിൽ "
-"ലഭ്യമാണ്."
+"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ "
+"ഉൾപ്പെടുത്തി മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, "
+"Android%2$s എന്നിവയിൽ ലഭ്യമാണ്."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14365,8 +14507,9 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും വിവരങ്ങൾ ഞങ്ങൾ "
-"ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും "
+"വിവരങ്ങൾ ഞങ്ങൾ ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14566,9 +14709,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI സഹായമുള്ള ഉത്തരങ്ങൾ "
-"സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. "
-"അവ ഓഫാക്കാനും Assist ബട്ടൺ മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI "
+"സഹായമുള്ള ഉത്തരങ്ങൾ സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും "
+"പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. അവ ഓഫാക്കാനും Assist ബട്ടൺ "
+"മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14577,10 +14721,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist "
-"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ "
-"സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist "
-"ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
+"DuckAssist പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച "
+"ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് "
+"ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14590,9 +14734,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist സ്വയമേവ "
-"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് "
-"ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
+"DuckAssist സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും "
+"മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ "
+"മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14625,8 +14770,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
-"തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
+"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14635,8 +14780,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
-"തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
+"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14645,8 +14790,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ ആപ്പുകൾക്ക് "
-"DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
+"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ "
+"ആപ്പുകൾക്ക് DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14659,8 +14804,8 @@ msgstr "ഒരു നിർദിഷ്ട പ്രശ്നം തിരഞ്
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ നിർദ്ദേശങ്ങൾ "
-"പാലിക്കുക."
+"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ "
+"നിർദ്ദേശങ്ങൾ പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14672,7 +14817,7 @@ msgstr "പിൻ ചെയ്യുക"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "ഒരു ചാറ്റ് പിൻ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14684,7 +14829,7 @@ msgstr "%1$s %2$s-ൽ നിന്നുള്ള ചാറ്റുകൾ ഇ�
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "എന്നെ പിൻ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14707,7 +14852,7 @@ msgstr "പിന്‍ ചെയ്തിരിക്കുന്നു"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "പിൻ ചെയ്ത ചാറ്റുകൾ സമീപകാല ചാറ്റുകളുടെ മുകളിൽ കാണപ്പെടും."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14749,7 +14894,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന ചലഞ്ച് പൂർത്തിയാക്കുക."
+"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന "
+"ചലഞ്ച് പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14758,23 +14904,24 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി പൂർത്തിയാക്കുക."
+"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി "
+"പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
-"(ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
+"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
-"(ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
+"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14795,8 +14942,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് നിങ്ങളുടെ നിലവിലെ "
-"ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
+"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് "
+"നിങ്ങളുടെ നിലവിലെ ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14805,8 +14952,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
-"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
+"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14815,8 +14963,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
-"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
+"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ "
+"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14969,7 +15118,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കുകയില്ല."
+"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
+"സ്വാധീനിക്കുകയില്ല."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15032,6 +15182,8 @@ msgstr "മോശം ഫോർമാറ്റിംഗ്"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ "
+"അജ്ഞാതമാക്കിയിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15245,7 +15397,7 @@ msgstr "മുമ്പത്തെ ടാബുകൾ"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "മുമ്പത്തെ നുറുങ്ങുകൾ"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15540,7 +15692,9 @@ msgstr "എന്നെ പ്രോംപ്റ്റ് ചെയ്യു�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് നിർദേശിക്കുക."
+msgstr ""
+"സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് "
+"നിർദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15558,7 +15712,9 @@ msgstr "നിങ്ങൾ തിരയുകയും ബ്രൗസ് ചെ
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ സംരക്ഷിക്കുക."
+msgstr ""
+"തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ "
+"സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15583,8 +15739,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. [നിങ്ങളുടെ സ്വന്തം "
-"വാചകം ഇവിടെ ചേർക്കുക.]"
+"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. "
+"[നിങ്ങളുടെ സ്വന്തം വാചകം ഇവിടെ ചേർക്കുക.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15789,13 +15945,15 @@ msgstr "ഇടത്തരം ബിൽറ്റ്-ഇൻ മോഡറേഷന
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "സങ്കീർണ്ണമായ ചോദ്യങ്ങൾക്ക് കൂടുതൽ മികച്ച മറുപടികൾ നൽകാൻ റീസണിംഗിന് കഴിയും."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ "
+"ഉപയോഗിക്കുന്നു. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15836,7 +15994,7 @@ msgstr "സമീപകാല ചാറ്റ് സംഭരണം %1$s-ൽ ക
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "സമീപകാല ചാറ്റുകൾ"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15845,8 +16003,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15855,8 +16013,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15866,9 +16024,10 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ പ്രോംപ്റ്റുകളും "
-"പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ "
-"സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
+"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ "
+"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15996,7 +16155,7 @@ msgstr "ഉപയോഗം കുറയ്ക്കുക"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "കൂടുതൽ കാര്യക്ഷമമായ ഒരു മോഡൽ ഉപയോഗിച്ച് ഉപയോഗം കുറയ്ക്കുക"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16004,8 +16163,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ വലുപ്പം കുറയ്ക്കുകയും "
-"ചെയ്യുന്നു"
+"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ "
+"വലുപ്പം കുറയ്ക്കുകയും ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16146,8 +16305,9 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ ബ്രൗസറിലെ "
-"&quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
+"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ "
+"ബ്രൗസറിലെ &quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16237,8 +16397,9 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
-"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
+"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും "
+"സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16246,8 +16407,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
-"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
+"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും "
+"സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16305,9 +16467,10 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് അവ "
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ "
-"അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് അയയ്ക്കാറുണ്ട്."
+"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ "
+"സഹായിക്കുന്നതിന് അവ DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ "
+"മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് "
+"അയയ്ക്കാറുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16315,8 +16478,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ "
-"തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ "
+"ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16325,9 +16488,10 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് വിവർത്തനം "
-"ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ "
-"വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് "
+"വിവർത്തനം ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ "
+"അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ "
+"വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16377,7 +16541,7 @@ msgstr "എല്ലാ ക്രമീകരണവും പുനഃക്ര�
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "ട്യൂട്ടോറിയൽ പുനഃക്രമീകരിക്കുക"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16395,7 +16559,7 @@ msgstr "റെസല്യൂഷൻ"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "പ്രതികരണം"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16419,9 +16583,10 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. AI- "
-"സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന "
+"നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16430,9 +16595,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist "
-"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16442,10 +16607,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് "
-"ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search "
-"Assist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി "
+"സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search Assist "
+"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16522,8 +16688,8 @@ msgstr "ബ്ലോക്ക് ചെയ്‌ത സൈറ്റുകളി�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ കൈകാര്യം ചെയ്യാൻ "
-"കഴിയും."
+"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ "
+"കൈകാര്യം ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16872,16 +17038,17 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് "
+"നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ "
+"പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ പ്രാദേശികമായി "
-"സംരക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ "
+"പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -16889,7 +17056,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai ചാറ്റുകൾ സംരക്ഷിക്കുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai "
+"ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17023,13 +17191,17 @@ msgstr "സ്കോട്ട്ലൻഡ്"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
+msgstr ""
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17037,8 +17209,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
-"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
+"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17047,8 +17219,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
-"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
+"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17067,15 +17239,16 @@ msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത്, �
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ "
-"അതിനെ അനുവദിക്കുക."
+"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ "
+"ഉപയോഗിക്കാൻ അതിനെ അനുവദിക്കുക."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s ക്ലിക്ക് ചെയ്യുക."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s "
+"ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17103,7 +17276,7 @@ msgstr "നിങ്ങൾക്ക് അടുത്തുള്ള ഫലങ�
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "തിരയലും Duck.ai-യും ടോഗിളും"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17129,12 +17302,14 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. ഇത് ചെയ്യുന്നതിന്, "
-"പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം "
-"സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
-"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ), "
-"അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ "
-"ഒരു ഭാഗത്ത് മാത്രമേ Search Assist ലഭ്യമാകൂ."
+"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. "
+"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. "
+"നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
+"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ "
+"പ്രസക്തമാകുമ്പോൾ), അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, "
+"ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ ഒരു ഭാഗത്ത് മാത്രമേ Search Assist "
+"ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17142,8 +17317,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search Assist-ന് "
-"കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
+"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search "
+"Assist-ന് കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17152,9 +17327,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ "
-"സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും "
-"കണ്ടെത്തിയ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
+"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
+"സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും കണ്ടെത്തിയ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17275,8 +17451,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള തിരയൽ "
-"വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
+"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള "
+"തിരയൽ വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17295,9 +17471,9 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, നിങ്ങളുടെ പ്രിയപ്പെട്ട "
-"ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് "
-"തിരയുക."
+"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, "
+"നിങ്ങളുടെ പ്രിയപ്പെട്ട ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, "
+"അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് തിരയുക."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17305,8 +17481,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST അഭ്യർത്ഥനകൾ "
-"ഉപയോഗിക്കും)"
+"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST "
+"അഭ്യർത്ഥനകൾ ഉപയോഗിക്കും)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17318,10 +17494,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക സംഭരണത്തിലും നിങ്ങളുടെ "
-"ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
-"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
+"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക "
+"സംഭരണത്തിലും നിങ്ങളുടെ ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു "
+"വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save "
+"ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ "
+"സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
 "വിട്ടുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -17417,7 +17594,8 @@ msgstr "രണ്ടാമതൊരു അഭിപ്രായം"
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
 msgstr ""
-"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
+"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും "
+"സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17426,8 +17604,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17436,8 +17615,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17446,8 +17626,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17456,15 +17637,17 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ "
+"സുരക്ഷിതമായി സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17473,14 +17656,15 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു. "
-"നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു. നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, "
+"ഞങ്ങൾക്ക് പോലും."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "ഞങ്ങളുടെ എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17619,34 +17803,38 @@ msgstr "%1$s%2$s%3$s തിരഞ്ഞെടുക്കുക, തുടർന
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
 msgstr ""
-"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് തിരഞ്ഞെടുക്കുക."
+"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം %3$shttps://duckduckgo.com%4$s എന്ന് "
-"ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
+"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം "
+"%3$shttps://duckduckgo.com%4$s എന്ന് ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ ക്ലിക്ക് "
-"ചെയ്യുക!"
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ "
+"ക്ലിക്ക് ചെയ്യുക!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17658,7 +17846,9 @@ msgstr "ഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ ഡ്ര
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %4$sഅനുവദിക്കുക%3$s"
+msgstr ""
+"ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
+"%4$sഅനുവദിക്കുക%3$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17671,7 +17861,8 @@ msgstr "തിരയൽ ദാതാക്കളുടെ പട്ടികയ�
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
 msgstr ""
-"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
+"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17682,13 +17873,17 @@ msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sManage add-ons%s from the dropdown menu"
-msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -17696,8 +17891,8 @@ msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s എന്നും "
-"തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s "
+"എന്നും തിരഞ്ഞെടുക്കുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17705,8 +17900,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s എന്നും "
-"തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s "
+"എന്നും തിരഞ്ഞെടുക്കുക"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17771,14 +17966,16 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ "
-"നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
+"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %3$sഅനുവദിക്കുക%4$s"
+msgstr ""
+"ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
+"%3$sഅനുവദിക്കുക%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17851,7 +18048,8 @@ msgstr "%1$s-ൽ നിന്ന് തിരഞ്ഞെടുത്ത ടെ�
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
 msgstr ""
-"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
+"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് "
+"വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17895,9 +18093,9 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ സന്ദേശങ്ങളുമായി AI "
-"മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും "
-"ബാധകമാകും."
+"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ "
+"സന്ദേശങ്ങളുമായി AI മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ "
+"നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും ബാധകമാകും."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17998,7 +18196,7 @@ msgstr "ഹോംപേജ് ആയി സജ്ജമാക്കുക"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Duck.ai-യുടെ പ്രതികരണങ്ങളുടെ ഭാവവും ശൈലിയും ക്രമീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18013,8 +18211,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് ചരിത്രം ഓണാക്കിയ "
-"ശേഷം Sync & Backup സജ്ജമാക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് "
+"ചരിത്രം ഓണാക്കിയ ശേഷം Sync & Backup സജ്ജമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18071,13 +18269,13 @@ msgstr "സീഷെൽസ്"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "പങ്കിടുക"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "പങ്കിടുക"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18088,7 +18286,9 @@ msgstr "പങ്കിടുക"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ സഹായിക്കുക!"
+msgstr ""
+"DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ "
+"സഹായിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18115,15 +18315,16 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. Duck.ai "
-"ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ വെളിപ്പെടുത്തുകയില്ല."
+"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. "
+"Duck.ai ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ "
+"വെളിപ്പെടുത്തുകയില്ല."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "ചാറ്റ് പങ്കിടുക"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18187,7 +18388,7 @@ msgstr "പോസിറ്റീവ് ഫീഡ്ബാക്ക് പങ്�
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "പങ്കിടൽ പരിധി"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18212,8 +18413,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക (നിയമവിരുദ്ധവും "
-"ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
+"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക "
+"(നിയമവിരുദ്ധവും ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18328,7 +18529,7 @@ msgstr "വിശദാംശം കാണിക്കുക"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Duck.ai ട്യൂട്ടോറിയൽ കാണിക്കുക"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18339,7 +18540,9 @@ msgstr "DuckAssist <sup>BETA</sup> കാണിക്കുക"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും %1$sഓഫാക്കാം%2$s.)"
+msgstr ""
+"DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും "
+"%1$sഓഫാക്കാം%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18481,7 +18684,7 @@ msgstr "കൂടുതൽ കാണിക്കുക"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "കൂടുതൽ മോഡലുകൾ കാണിക്കുക"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18523,6 +18726,8 @@ msgstr "സൈഡ്ബാർ കാണിക്കുക"
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
+"Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ "
+"കാണിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18577,8 +18782,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. "
-"ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു "
+"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
+"കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18586,9 +18792,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ "
-"കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും "
-"ബാധിക്കുന്നില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു "
+"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
+"കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും ബാധിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18599,7 +18805,8 @@ msgstr "ഫല പേജ് ഇടവേളകളിൽ തിരശ്ചീന
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള ലിങ്കുകൾ കാണിക്കുന്നു"
+"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള "
+"ലിങ്കുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18616,21 +18823,23 @@ msgstr "പുതിയ ടാബ് പേജിൽ ഏറ്റവും ക�
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് "
+"ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18738,12 +18947,16 @@ msgstr "സൈറ്റുകളുടെ പേരുകൾ"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ പ്രവർത്തിക്കുന്നു."
+msgstr ""
+"സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും മറയ്ക്കും"
+msgstr ""
+"നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും "
+"മറയ്ക്കും"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18889,7 +19102,8 @@ msgstr "സെർവറിലേക്ക് സംരക്ഷിക്കു�
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
 msgstr ""
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി വീണ്ടും ശ്രമിക്കുക."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18901,7 +19115,7 @@ msgstr "എന്തോ കുഴപ്പം സംഭവിച്ചു, ദ�
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18920,8 +19134,8 @@ msgstr "ചിലപ്പോൾ"
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
 msgstr ""
-"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു രീതിയിൽ "
-"വിവരിക്കുക."
+"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു "
+"രീതിയിൽ വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18960,8 +19174,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി മറ്റൊരു ചിത്രമോ "
-"ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
+"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി "
+"മറ്റൊരു ചിത്രമോ ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18970,16 +19184,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ ചെയ്തതെന്ന് "
-"ഉറപ്പാക്കുക."
+"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ "
+"ചെയ്തതെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾക്ക് Duck.ai-യോട് "
-"ചോദിക്കാൻ ശ്രമിക്കാം."
+"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. "
+"നിങ്ങൾക്ക് Duck.ai-യോട് ചോദിക്കാൻ ശ്രമിക്കാം."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18988,15 +19202,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. വീണ്ടും ശ്രമിക്കാൻ "
-"%1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
+"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. "
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19051,8 +19266,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും "
-"ശ്രമിക്കൂ."
+"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് "
+"തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19204,7 +19419,7 @@ msgstr "ആഴ്ച തോറുമുള്ള പരിധി ഉപയോഗ
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുക"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19257,7 +19472,9 @@ msgstr "DuckDuckGo-യിൽ തുടരുക"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും അറിവുള്ളവരായും തുടരുക."
+msgstr ""
+"ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും "
+"അറിവുള്ളവരായും തുടരുക."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19307,7 +19524,9 @@ msgstr "സൃഷ്ടിക്കൽ നിർത്തുക"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ പ്രതിരോധിക്കുക."
+msgstr ""
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ "
+"പ്രതിരോധിക്കുക."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19402,8 +19621,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, അല്ലെങ്കിൽ "
-"കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
+"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, "
+"അല്ലെങ്കിൽ കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19472,8 +19691,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ എഴുതാൻ ഒരു വാക്യം "
-"നിർദ്ദേശിക്കാമോ?"
+"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ "
+"എഴുതാൻ ഒരു വാക്യം നിർദ്ദേശിക്കാമോ?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19790,7 +20009,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "ഈ രണ്ടാമത്തെ അഭിപ്രായത്തിലേക്ക് മാറുക"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19803,7 +20022,9 @@ msgstr "%1$sഎന്നതിലേക്ക് മാറി"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് അയയ്ക്കും"
+msgstr ""
+"മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് "
+"അയയ്ക്കും"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19857,7 +20078,9 @@ msgstr "Sync & Backup പ്രവർത്തനക്ഷമമാക്കി!
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
+msgstr ""
+"Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19906,25 +20129,27 @@ msgid ""
 msgstr ""
 "വീണ്ടെടുക്കൽ കോഡ് സമന്വയിപ്പിക്കുക\n"
 "\n"
-" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, ഡാറ്റ ഓട്ടോഫിൽ "
-"ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ "
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
+" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, "
+"ഡാറ്റ ഓട്ടോഫിൽ ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു "
+"ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ നിങ്ങളുടെ സമന്വയിപ്പിച്ച "
+"ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
 "\n"
 "ഈ വിവരങ്ങൾ സുരക്ഷിതമായി സൂക്ഷിക്കുക.\n"
-"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ കഴിയും.\n"
+"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ "
+"കഴിയും.\n"
 "\n"
 "%1$s\n"
 "\n"
 "ഈ കോഡ് എങ്ങനെയാണ് പ്രവർത്തിക്കുന്നത്?\n"
 "1. നിങ്ങളുടെ ബ്രൗസറിൽ Duck.ai-ലേക്ക് പോയി Duck.ai സെറ്റിംഗ്സ് തുറക്കുക.\n"
-"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കുക\" "
-"തിരഞ്ഞെടുക്കുക.\n"
-"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" എന്ന് പറയുന്നിടത്ത് "
-"ഒട്ടിക്കുക.\n"
+"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ "
+"വീണ്ടെടുക്കുക\" തിരഞ്ഞെടുക്കുക.\n"
+"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" "
+"എന്ന് പറയുന്നിടത്ത് ഒട്ടിക്കുക.\n"
 "\n"
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ 18 "
-"മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് ഇല്ലാതാക്കപ്പെടും, അത് "
-"പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ "
+"18 മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് "
+"ഇല്ലാതാക്കപ്പെടും, അത് പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19948,7 +20173,7 @@ msgstr "സമന്വയവും ബാക്കപ്പും താൽക�
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "ഉപകരണങ്ങളിലുടനീളം ചാറ്റുകൾ സമന്വയിപ്പിക്കുക"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20044,6 +20269,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും "
+"വേഗത്തിൽ ആക്സസ് ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് "
+"നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20052,6 +20280,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് "
+"ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് "
+"ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20074,7 +20305,9 @@ msgstr "നിങ്ങളുടെ സ്വകാര്യ ഡാറ്റയ�
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ പങ്കെടുക്കൂ."
+msgstr ""
+"Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ "
+"പങ്കെടുക്കൂ."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20289,9 +20522,10 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ ഒരു മൂന്നാം "
-"കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ "
-"പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ ഉൾപ്പെടുന്നു."
+"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ "
+"ഒരു മൂന്നാം കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. "
+"അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ "
+"ഉൾപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20300,8 +20534,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ സംരക്ഷിക്കാൻ Cloud Save "
-"ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
+"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ "
+"സംരക്ഷിക്കാൻ Cloud Save ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20331,15 +20565,17 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ "
-"നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
+"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ "
+"സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് ഇല്ലാതാക്കും."
+msgstr ""
+"ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് "
+"ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20412,9 +20648,9 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക ഡാറ്റ സംഭരണം "
-"പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ "
-"പരിശോധിക്കുക."
+"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക "
+"ഡാറ്റ സംഭരണം പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി "
+"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20429,8 +20665,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ വീണ്ടും ശ്രമിക്കുന്നതിന് "
-"മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
+"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ "
+"വീണ്ടും ശ്രമിക്കുന്നതിന് മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20449,10 +20685,10 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ എൻക്രിപ്റ്റ് "
-"ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും "
-"നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ "
-"ഉപയോഗിക്കുന്നു."
+"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ "
+"എൻക്രിപ്റ്റ് ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ "
+"എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ "
+"സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ ഉപയോഗിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20498,8 +20734,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ ഒരു പുതിയ "
-"ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
+"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ "
+"പതിപ്പിൽ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20517,7 +20753,7 @@ msgstr "ഈ മാസം"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "ഈ പ്രതികരണം"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20530,6 +20766,8 @@ msgstr "ഈ ആഴ്ച"
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
+"ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും "
+"ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20538,9 +20776,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
-"ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
+"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം "
+"(കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20550,9 +20788,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
-"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%2$s കാണുക)."
+"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
+"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20561,8 +20799,9 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI കൃത്യതയില്ലാത്തതോ "
-"കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
+"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
+"കൃത്യതയില്ലാത്തതോ കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20572,9 +20811,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
-"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ "
-"വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ "
+"സംഭാഷണം സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20606,7 +20845,9 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ചുചെയ്യുക"
+msgstr ""
+"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s "
+"അറ്റാച്ചുചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20614,7 +20855,9 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് ചെയ്യുക."
+msgstr ""
+"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20646,7 +20889,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക"
+"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
+"ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20654,7 +20898,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക."
+"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
+"ചേർക്കുക."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20668,6 +20913,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ "
+"ഇതിന്റെ മെനു (മൂന്ന് ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20676,6 +20923,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire "
+"Button ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20696,8 +20945,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ ഇല്ലാതാക്കും. മറ്റ് മോഡൽ "
-"ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ "
+"ഇല്ലാതാക്കും. മറ്റ് മോഡൽ ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20706,8 +20955,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് മോഡൽ ദാതാക്കൾ ഒരു "
-"പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് "
+"മോഡൽ ദാതാക്കൾ ഒരു പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20744,8 +20993,9 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് "
-"സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് ആക്‌സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് "
+"എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് "
+"ആക്‌സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20754,8 +21004,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
-"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
+"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
+"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20765,10 +21016,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
-"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. "
-"എന്നിരുന്നാലും, %1$s-ൽ AI സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും "
-"ഞങ്ങൾക്ക് ഉണ്ട്."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
+"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
+"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. എന്നിരുന്നാലും, %1$s-ൽ AI "
+"സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും ഞങ്ങൾക്ക് ഉണ്ട്."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20797,7 +21048,9 @@ msgstr "ഈ വീഡിയോ ഇതുവരെ ഇവിടെ കാണാ�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) ഉപയോഗിക്കുന്നില്ല."
+msgstr ""
+"ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) "
+"ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20807,9 +21060,10 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും Sync & Backup "
-"വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ "
-"നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും "
+"Sync & Backup വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് "
+"ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് "
+"ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20818,8 +21072,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. ഇത് "
-"പഴയപടിയാക്കാനാവില്ല."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. "
+"ഇത് പഴയപടിയാക്കാനാവില്ല."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20838,7 +21092,8 @@ msgstr "ഇത് എല്ലാ ക്രമീകരണവും മായ്
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
 msgstr ""
-"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് പുനഃക്രമീകരിക്കും. തുടരണോ?"
+"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് "
+"പുനഃക്രമീകരിക്കും. തുടരണോ?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20935,7 +21190,9 @@ msgstr "ശീർഷക അടിവര"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ ചേർക്കാൻ:"
+msgstr ""
+"മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ "
+"ചേർക്കാൻ:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -20958,8 +21215,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് ചെയ്യേണ്ട റൂട്ട് "
-"തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
+"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് "
+"ചെയ്യേണ്ട റൂട്ട് തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20969,9 +21226,10 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം സജ്ജമാക്കുമ്പോൾ "
-"സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച "
-"ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് ചെയ്‌തിരിക്കാം."
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം "
+"സജ്ജമാക്കുമ്പോൾ സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം "
+"സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് "
+"ചെയ്‌തിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20980,8 +21238,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും പുതിയ "
-"പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും "
+"പുതിയ പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20989,8 +21247,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ "
-"അനുവദിക്കുക."
+"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ "
+"ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21013,6 +21271,8 @@ msgstr "ഇന്ന്"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ "
+"ഇത് പ്രവർത്തനരഹിതമാക്കുക.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21186,8 +21446,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം ബ്ലോക്ക് ചെയ്യുന്നു "
-"എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
+"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം "
+"ബ്ലോക്ക് ചെയ്യുന്നു എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21235,8 +21495,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
-"എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
+"ഞാൻ എങ്ങനെ എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21245,8 +21505,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
-"എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
+"ഞാൻ എങ്ങനെ എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21429,7 +21689,7 @@ msgstr "അവ പരീക്ഷിച്ചു നോക്കൂ"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "മറ്റൊരു മോഡൽ പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21440,7 +21700,7 @@ msgstr "ഒരു തിരയൽ ശ്രമിക്കുക!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "ഒരു നിർദ്ദേശം പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21476,8 +21736,8 @@ msgstr "വ്യത്യസ്ത കീവേഡുകൾ പരീക്ഷ�
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ പ്രവർത്തനരഹിതമാക്കാൻ "
-"ശ്രമിക്കുക."
+"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ "
+"പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21510,7 +21770,7 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21524,13 +21784,15 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ പലതും."
+msgstr ""
+"സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ "
+"പലതും."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "7 ദിവസത്തേക്ക് സൗജന്യമായി പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21563,7 +21825,7 @@ msgstr "ഈ സന്ദേശങ്ങൾ ഒരിക്കലും കാണ
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "റീസണിംഗ് പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21645,7 +21907,8 @@ msgstr "അടുത്തിടെ ചേർത്തിട്ടുള്ള o
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
 msgstr ""
-"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
+"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ "
+"സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21679,8 +21942,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
-"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. "
+"%3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21689,8 +21953,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
-"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. %3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. "
+"%3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21815,7 +22080,7 @@ msgstr "ടാർഗെറ്റ് ചെയ്ത പരസ്യങ്ങള�
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Duck.ai ടോഗിൾ ഓണാക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21879,8 +22144,9 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് തിരയലിനും ഉത്തരം "
-"കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് കാരണമായേക്കാം."
+"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് "
+"തിരയലിനും ഉത്തരം കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് "
+"കാരണമായേക്കാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21978,13 +22244,17 @@ msgstr "ഫീഡ് ബാക്ക് അയയ്ക്കുവാൻ സാ
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr "നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -22010,8 +22280,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് ക്ലിക്ക് "
-"ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് "
+"ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22019,21 +22289,22 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ ചെയ്യുക: "
-"https://duckduckgo.com"
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ "
+"ചെയ്യുക: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
 msgstr ""
-"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ പേജുകൾ%4$s "
-"തിരഞ്ഞെടുക്കുക"
+"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ "
+"പേജുകൾ%4$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: https://duckduckgo.com"
+"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22044,30 +22315,32 @@ msgstr "%1$sതിരയൽ ക്രമീകരണം%2$s എന്നതി�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
 msgstr ""
-"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s "
+"എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s ക്ലിക്ക് "
-"ചെയ്യുക"
+"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s "
+"ക്ലിക്ക് ചെയ്യുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
 msgstr ""
-"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ തുറക്കുക%2$s "
-"എന്നത് തിരഞ്ഞെടുക്കുക"
+"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ "
+"തുറക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22145,8 +22418,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് പ്ലാനിനേക്കാൾ 2 മടങ്ങ് "
-"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
+"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് "
+"പ്ലാനിനേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22168,7 +22441,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും അൺലോക്ക് ചെയ്യുക"
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും "
+"അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22193,13 +22467,15 @@ msgstr "നിങ്ങളുടെ സബ്‌സ്‌ക്രിപ്‌�
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "നൂതന മോഡലുകൾ അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് ചെയ്യുക"
+msgstr ""
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -22207,7 +22483,9 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് ചെയ്യുക. %1$s"
+msgstr ""
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് "
+"ചെയ്യുക. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22287,8 +22565,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് ചെയ്യാനും DuckDuckGo "
-"ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
+"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് "
+"ചെയ്യാനും DuckDuckGo ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22413,15 +22691,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക, "
-"അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
+"ചെയ്യുക, അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക"
+"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22517,9 +22796,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, സ്കാമർമാരിൽ "
-"നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. "
-"സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
+"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, "
+"സ്കാമർമാരിൽ നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. "
+"വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22532,8 +22811,8 @@ msgstr "DuckDuckGo Private Search ഉപയോഗിക്കുക"
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
 msgstr ""
-"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private search "
-"ഉപയോഗിക്കുക!"
+"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private "
+"search ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22561,7 +22840,7 @@ msgstr "Safari-ൽ ഉപയോഗിക്കുക"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "ചരിത്രത്തിൽ നിന്ന് ഒരു ചാറ്റ് ഇല്ലാതാക്കാൻ Fire Button ഉപയോഗിക്കുക."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22570,8 +22849,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
-"ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ "
+"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22579,8 +22858,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
-"ഉപയോഗിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ "
+"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -22730,8 +23009,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ ക്ലിക്കുകൾ "
-"നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ "
+"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22740,8 +23019,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ ക്ലിക്കുകൾ "
-"നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ "
+"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22753,8 +23032,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sAssist "
-"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
+"%1$sAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22763,8 +23042,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sDuckAssist "
-"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
+"%1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22773,8 +23052,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ നിർദേശങ്ങൾ "
-"പാലിക്കുക."
+"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ "
+"നിർദേശങ്ങൾ പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22789,9 +23068,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & "
-"Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > "
+"%3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22801,9 +23080,10 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & "
-"Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" "
-"തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
+"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
+"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22813,9 +23093,10 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, %1$sDuck.ai "
-"ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നിടത്ത് "
-"%7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, "
+"%1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് "
+"ചെയ്യുക%6$s എന്നിടത്ത് %7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22825,9 +23106,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
-"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai "
+"ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" "
+"തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. "
+"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22880,8 +23162,8 @@ msgstr "വോയ്സ് ചാറ്റ് അവസാനിച്ചു"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിച്ചിട്ടില്ല."
+"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിച്ചിട്ടില്ല."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23025,8 +23307,9 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച പ്രവർത്തനത്തെ YouTube "
-"ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck Player-ൽ കാണുക."
+"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച "
+"പ്രവർത്തനത്തെ YouTube ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck "
+"Player-ൽ കാണുക."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23046,10 +23329,11 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് "
-"ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. "
-"DuckDuckGo ഒരു സ്വതന്ത്ര കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി "
-"യാതൊരു ബന്ധവുമില്ല."
+"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന "
+"വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ "
+"നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. DuckDuckGo ഒരു സ്വതന്ത്ര "
+"കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി യാതൊരു "
+"ബന്ധവുമില്ല."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23062,8 +23346,8 @@ msgstr "ഞങ്ങൾ അജ്ഞാതമാക്കുന്നു"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ ലൊക്കേഷൻ%2$s "
-"അജ്ഞാതമാക്കാൻ കഴിയും."
+"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ "
+"ലൊക്കേഷൻ%2$s അജ്ഞാതമാക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23075,9 +23359,10 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
-"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി പങ്കിടുക, അതുവഴി "
-"ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി "
+"പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23089,17 +23374,18 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
-"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രതികരണവും പങ്കിടുക, അതുവഴി "
-"ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും "
+"പ്രതികരണവും പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s ലൊക്കേഷൻ%2$s "
-"ഉപയോഗിക്കാനാകും."
+"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s "
+"ലൊക്കേഷൻ%2$s ഉപയോഗിക്കാനാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -23107,8 +23393,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ ഞങ്ങൾക്ക് അവ "
-"വായിക്കാൻ കഴിയില്ല."
+"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ "
+"ഞങ്ങൾക്ക് അവ വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23119,13 +23405,16 @@ msgstr "പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്�
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ സംഭരിക്കുന്നില്ല."
+msgstr ""
+"ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ "
+"സംഭരിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ ഇല്ല. എപ്പോഴും."
+"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ "
+"ഇല്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23137,8 +23426,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്ങളെ "
-"പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ "
+"നിങ്ങളെ പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23152,8 +23441,9 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ടുവന്നത് എന്താണെന്ന് "
-"ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ "
+"കൊണ്ടുവന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് "
+"ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23162,8 +23452,9 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ നിങ്ങൾക്ക് "
-"ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ "
+"നിങ്ങൾക്ക് ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം "
+"ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23174,7 +23465,9 @@ msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ നയം."
+msgstr ""
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ "
+"നയം."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23203,8 +23496,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ ഉടനീളം "
-"പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
+"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ "
+"ഉടനീളം പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23230,8 +23523,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് ഉറപ്പാക്കാൻ എല്ലാ AI "
-"ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
+"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് "
+"ഉറപ്പാക്കാൻ എല്ലാ AI ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23248,7 +23541,9 @@ msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെ�
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ ശ്രമിക്കൂ."
+msgstr ""
+"ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ "
+"ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23256,8 +23551,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന തിരയൽ "
-"പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
+"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന "
+"തിരയൽ പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23266,20 +23561,24 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ലൊക്കേഷൻ "
-"ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത "
+"ലൊക്കേഷൻ ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് "
+"മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ ആശ്രയിക്കുന്നു."
+"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ "
+"ആശ്രയിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ തടയുന്നു."
+msgstr ""
+"ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ "
+"തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23295,15 +23594,16 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ "
-"വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം "
-"ദൃശ്യമാകണമെന്നില്ല."
+"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് "
+"ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ "
+"സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം ദൃശ്യമാകണമെന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
+"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന "
+"ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23313,8 +23613,8 @@ msgid ""
 "continue to see this error, please reach out to %s."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, ദയവായി %1$s-നെ "
-"സമീപിക്കുക."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, "
+"ദയവായി %1$s-നെ സമീപിക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23324,7 +23624,8 @@ msgid ""
 "clearing your browser's cache can help."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ മായ്ക്കുന്നത് സഹായിക്കാം."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ "
+"മായ്ക്കുന്നത് സഹായിക്കാം."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23339,8 +23640,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ ഞങ്ങൾ കഠിനമായി "
-"പരിശ്രമിക്കുന്നു."
+"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ "
+"ഞങ്ങൾ കഠിനമായി പരിശ്രമിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23349,8 +23650,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് വീണ്ടും ലോഡ് "
-"ചെയ്യേണ്ടതുണ്ട്."
+"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് "
+"വീണ്ടും ലോഡ് ചെയ്യേണ്ടതുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23458,7 +23759,9 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23472,8 +23775,9 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഞങ്ങൾ "
-"അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
+"സ്വകാര്യമാണ്, അവ ഞങ്ങൾ അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23482,9 +23786,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ "
-"ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ "
-"ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
+"സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23494,16 +23798,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s ആണ്. "
-"ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s "
+"ആണ്. ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും "
+"DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്യാം."
+"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ "
+"ഇംപോർട്ട് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23571,8 +23876,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. "
-"പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
+"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു "
+"പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23587,8 +23892,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും പ്രതിവാദങ്ങളും "
-"എന്തൊക്കെയാണ്?"
+"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും "
+"പ്രതിവാദങ്ങളും എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -23609,8 +23914,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' എന്ന വാക്കിനുള്ള ചില "
-"ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
+"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' "
+"എന്ന വാക്കിനുള്ള ചില ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23629,11 +23934,12 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് ചെയ്യുന്നതിന്റെ "
-"പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ മാത്രം അവലംബിക്കുന്നു. Duck.ai "
-"സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് "
-"പ്രതികരണത്തെ വ്യക്തമായ വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം "
-"കൂടുതലുള്ളവർക്കും ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
+"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് "
+"ചെയ്യുന്നതിന്റെ പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ "
+"മാത്രം അവലംബിക്കുന്നു. Duck.ai സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും "
+"ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് പ്രതികരണത്തെ വ്യക്തമായ "
+"വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം കൂടുതലുള്ളവർക്കും "
+"ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23719,7 +24025,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
-"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ എന്തൊക്കെയാണ്?"
+"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ "
+"എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23749,7 +24056,7 @@ msgstr "ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ട
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "നിങ്ങൾക്ക് എന്ത് ചെയ്യാനാകും?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23870,8 +24177,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ "
-"വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
+"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ "
+"ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23947,7 +24254,8 @@ msgstr "നിങ്ങൾ എന്തിനെക്കുറിച്ചാ�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കില്ല."
+"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
+"സ്വാധീനിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23973,8 +24281,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന "
-"ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
+"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ "
+"പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23998,7 +24306,8 @@ msgstr "<strong>%1$s</strong> എവിടെ കാണാം"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
 msgstr ""
-"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
+"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s "
+"എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24039,7 +24348,8 @@ msgstr "ആരാണ് ഞങ്ങൾ"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
-"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് അറിയപ്പെടുന്നത്?"
+"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് "
+"അറിയപ്പെടുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24177,6 +24487,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും "
+"ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24431,7 +24744,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് "
+"വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24451,8 +24765,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
+"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24461,8 +24775,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ DuckDuckGo-യിൽ നിന്ന് മറ്റ് "
-"തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
+"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ "
+"DuckDuckGo-യിൽ നിന്ന് മറ്റ് തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24476,8 +24790,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ ക്രമീകരണങ്ങൾ%3$s-ൽ "
-"എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
+"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ "
+"ക്രമീകരണങ്ങൾ%3$s-ൽ എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24486,21 +24800,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s-ൽ അത് "
-"എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
+"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ "
+"ക്രമീകരണങ്ങൾ%2$s-ൽ അത് എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s ഉപയോഗിക്കാം."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s "
+"ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI Chat%2$s "
-"ഉപയോഗിക്കാനും കഴിയും."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI "
+"Chat%2$s ഉപയോഗിക്കാനും കഴിയും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24514,8 +24829,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist കാണണമെന്നത് "
-"മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
+"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist "
+"കാണണമെന്നത് മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24536,8 +24851,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു പാസ്‌ഫ്രെയ്സിന് കീഴിൽ "
-"സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
+"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു "
+"പാസ്‌ഫ്രെയ്സിന് കീഴിൽ സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24567,7 +24882,8 @@ msgstr "നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉ
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് തുടർന്നോളൂ!"
+"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് "
+"തുടർന്നോളൂ!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24610,7 +24926,7 @@ msgstr "ഓരോ സംഭാഷണത്തിനും നിങ്ങൾക�
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "നിങ്ങൾക്ക് ഒരേസമയം %1$s ടാബുകൾ മാത്രമേ അറ്റാച്ച് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24631,8 +24947,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം മറ്റൊരു സൈറ്റ് "
-"അൺബ്ലോക്ക് ചെയ്യണം."
+"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം "
+"മറ്റൊരു സൈറ്റ് അൺബ്ലോക്ക് ചെയ്യണം."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24668,7 +24984,9 @@ msgstr "നിങ്ങൾക്ക് ഈ പുതിയ ഡൊമെയ്ന
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ സൂക്ഷിക്കാം."
+msgstr ""
+"പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ "
+"സൂക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -24689,8 +25007,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, Plus-നേക്കാൾ 2 മടങ്ങ് "
-"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
+"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, "
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24699,8 +25017,9 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് DuckDuckGo ബ്രൗസറിൽ VPN, "
-"മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് ചെയ്യാം."
+"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് "
+"DuckDuckGo ബ്രൗസറിൽ VPN, മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് "
+"ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24722,9 +25041,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന "
-"30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് "
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് "
+"ചെയ്യാൻ കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. "
+"ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24734,9 +25053,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന 30 "
-"ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ "
-"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ "
+"കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് "
+"എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24750,14 +25069,14 @@ msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
 msgstr ""
-"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo ആപ്പ് അപ്ഡേറ്റുകൾ "
-"ലഭിക്കും."
+"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo "
+"ആപ്പ് അപ്ഡേറ്റുകൾ ലഭിക്കും."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "എല്ലാം സജ്ജമാക്കി!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24766,8 +25085,9 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് ചെയ്യുന്നതിന് Chrome-ന് "
-"പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് "
+"ചെയ്യുന്നതിന് Chrome-ന് പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം "
+"ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24780,8 +25100,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും കുറയ്ക്കുന്നതിന് "
-"നുറുങ്ങുകൾ നേടുക."
+"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും "
+"കുറയ്ക്കുന്നതിന് നുറുങ്ങുകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24810,7 +25130,7 @@ msgstr "നിങ്ങൾ 1 സൈറ്റ് ബ്ലോക്ക് ചെ�
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "നിങ്ങൾ Duck.ai-യുടെ അടിസ്ഥാനകാര്യങ്ങളിൽ പ്രാവീണ്യം നേടി"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24831,8 +25151,8 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. ദയവായി വീണ്ടും "
-"ശ്രമിക്കുക."
+"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. "
+"ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24859,8 +25179,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം തീർന്നു. സമന്വയം "
-"പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം "
+"തീർന്നു. സമന്വയം പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ "
+"ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24871,8 +25192,8 @@ msgid ""
 "deleted."
 msgstr ""
 "Duck.ai ചാറ്റുകൾക്കുള്ള Sync & Backup സ്റ്റോറേജ് തീർന്നിരിക്കുന്നു. സമന്വയം "
-"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത "
-"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ "
+"ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24886,8 +25207,9 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ അനുവദിക്കുന്നില്ല. "
-"അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് YouTube/Google ട്രാക്ക് ചെയ്യും."
+"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ "
+"അനുവദിക്കുന്നില്ല. അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് "
+"YouTube/Google ട്രാക്ക് ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24931,9 +25253,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
-"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"%1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24943,9 +25265,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ 100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
-"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24961,7 +25283,9 @@ msgstr "നിങ്ങൾ ഈ ലിങ്ക് സന്ദർശിച്ച
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു."
+msgstr ""
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
+"നൽകുന്നു."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -24970,8 +25294,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു. DuckDuckGo-"
-"യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
+"നൽകുന്നു. DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -24979,8 +25303,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. DuckDuckGo-യ്ക്ക് "
-"ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. "
+"DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24989,8 +25313,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
+"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25003,15 +25327,16 @@ msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോൾ 
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഒരിക്കലും സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിക്കില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25037,8 +25362,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25046,8 +25371,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25062,9 +25387,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ "
-"പാലിക്കൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് "
+"അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ പാലിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25073,8 +25398,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി Duck.ai-ൽ നിർത്തിയിടത്ത് "
-"നിന്ന് തുടരൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി "
+"Duck.ai-ൽ നിർത്തിയിടത്ത് നിന്ന് തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25122,8 +25447,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കാറില്ല."
+"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25152,10 +25477,11 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് "
-"ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ "
-"ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-"
-"യ്ക്ക് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
+"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് "
+"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ "
+"ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ "
+"ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-യ്ക്ക് "
+"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25170,9 +25496,10 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി തിരിച്ചറിയാൻ "
-"കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ ദാതാക്കൾക്ക് നിങ്ങളുടെ "
-"സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ കഴിയില്ല."
+"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി "
+"തിരിച്ചറിയാൻ കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ "
+"ദാതാക്കൾക്ക് നിങ്ങളുടെ സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25186,8 +25513,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ പരിശോധിക്കാനോ "
-"എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ "
+"പരിശോധിക്കാനോ എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25219,6 +25546,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
+"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
+"പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25227,9 +25557,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
-"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ "
-"അറിയുക%4$s"
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
+"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
+"ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ അറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25249,8 +25579,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി Chrome-ന് പകരം ഞങ്ങളുടെ "
-"ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി "
+"Chrome-ന് പകരം ഞങ്ങളുടെ ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ "
+"ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25259,8 +25590,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം ചുരുക്കി വീണ്ടും "
-"ശ്രമിക്കുക."
+"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം "
+"ചുരുക്കി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25269,8 +25600,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button ഉപയോഗിച്ച് ഈ "
-"സംഭാഷണം മായ്ക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button "
+"ഉപയോഗിച്ച് ഈ സംഭാഷണം മായ്ക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25279,7 +25610,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ "
+"ചാറ്റ് ആരംഭിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25294,8 +25626,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി നാളെ ഈ ചാറ്റ് "
-"തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി "
+"നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25598,8 +25930,8 @@ msgstr "ഔദ്യോഗിക വെബ്സൈറ്റ്"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു എന്‍കോഡ് ചെയ്ത %3$s "
-"പ്രതീകം ആണ്)."
+"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു "
+"എന്‍കോഡ് ചെയ്ത %3$s പ്രതീകം ആണ്)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25815,4 +26147,4 @@ msgstr "വർഷം"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr "%1$s കണ്ടെത്തി"
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -176,9 +182,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
-"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -188,9 +193,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
-"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -206,9 +210,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് "
-"തുടരാൻ, നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
-"മോഡലിലേക്ക് മാറുക."
+"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് തുടരാൻ, നിങ്ങളുടെ "
+"സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -217,8 +220,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ "
-"പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -309,9 +312,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് "
-"പോലും നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് "
-"അവരുടെ സെർവറുകളിൽ സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
+"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് പോലും "
+"നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് അവരുടെ സെർവറുകളിൽ "
+"സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -355,6 +358,12 @@ msgid "%s used"
 msgstr "%1$s ഉപയോഗിച്ചു"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s കാഴ്ച"
@@ -391,8 +400,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ "
-"ചാറ്റ് തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ ചാറ്റ് "
+"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -403,8 +412,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് "
-"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് തുടരുന്നതിന് "
+"നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -417,8 +426,8 @@ msgstr "%1$s വാക്കുകൾ"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, "
-"തുടർന്ന് %6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, തുടർന്ന് "
+"%6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -426,8 +435,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് "
-"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s "
+"ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -437,9 +446,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s "
-"ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s "
-"ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s ക്ലിക്ക് "
+"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -448,8 +456,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ "
-"ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ കരുതുന്നുണ്ടെങ്കിൽ."
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ "
+"കരുതുന്നുണ്ടെങ്കിൽ."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -468,8 +476,7 @@ msgstr "%1$sകൂടുതലറിയുക%2$s ."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
-"മനസ്സിലാക്കുക%2$s."
+"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക%2$s."
 
 # smartling.placeholder_format=C
 #. Footer text with a Learn more link explaining where to find more information about chat privacy.
@@ -477,16 +484,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
-"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
+"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
-"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -499,8 +506,7 @@ msgstr "ഹോം സ്ക്രീനിൽ DuckDuckGo ആപ്പ് ഐക�
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s "
-"വീണ്ടും ശ്രമിക്കുക."
+"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -607,6 +613,12 @@ msgstr "കഴിഞ്ഞ 24 മണിക്കൂറിനുള്ളിൽ D
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 ദിവസം മുമ്പ്"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -834,9 +846,7 @@ msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -890,8 +900,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. "
-"നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. നിങ്ങളുടെ കണക്ഷൻ "
+"പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -949,10 +959,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത "
-"മറയ്ക്കും. %1$sduckduckgo.com/aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് "
-"ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ കഴിയും."
+"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
+"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത മറയ്ക്കും. %1$sduckduckgo.com/"
+"aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1013,11 +1023,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് "
-"പിന്തുണയ്ക്കുന്നില്ല. എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി "
-"%1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, "
-"ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് പിന്തുണയ്ക്കുന്നില്ല. "
+"എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി %1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും "
+"പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് "
+"മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1202,8 +1211,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു "
-"സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
+"മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1239,8 +1248,8 @@ msgstr "പരസ്യം"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ "
-"നിങ്ങളെ തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
+"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ നിങ്ങളെ "
+"തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1248,8 +1257,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
-"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ "
+"ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1300,8 +1309,8 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ചേർക്കുക"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy "
-"Essentials ചേർക്കുക:"
+"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy Essentials "
+"ചേർക്കുക:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1516,6 +1525,14 @@ msgid "Advanced Models"
 msgstr "നൂതന മോഡലുകൾ"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "തിരയലിൽ പരസ്യം ചെയ്യുക"
@@ -1549,17 +1566,15 @@ msgstr "ആഫ്രികാൻസ്"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
 msgstr ""
-"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് "
-"ഡബിൾ ക്ലിക്ക് ചെയ്യുക"
+"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് ഡബിൾ ക്ലിക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1695,9 +1710,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ "
-"DuckDuckGo അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കുന്നില്ല"
+"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ DuckDuckGo "
+"അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1730,8 +1744,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ "
-"ദാതാക്കളെയും അനുവദിക്കില്ല."
+"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ ദാതാക്കളെയും "
+"അനുവദിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1746,8 +1760,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും "
-"(ഉദാഹരണത്തിന്, നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
+"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും (ഉദാഹരണത്തിന്, "
+"നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1779,8 +1793,7 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ "
-"ആക്സസ് അനുവദിക്കുക."
+"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ ആക്സസ് അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1812,11 +1825,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ "
-"%1$s-നെ അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് "
-"എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള "
-"പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ ദൃശ്യപരത പൂജ്യം "
-"ആണ്%4$s."
+"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ %1$s-നെ "
+"അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച "
+"ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ "
+"ദൃശ്യപരത പൂജ്യം ആണ്%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1963,8 +1975,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
-"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
+"അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1973,8 +1985,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
-"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
+"അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1988,9 +2000,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
-"സൃഷ്ടിക്കുന്നു. ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, "
-"അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
+"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്നു. ഇത് "
+"എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2158,8 +2169,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത "
-"ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ ചാറ്റുകളും ഇല്ലാതാക്കും."
+"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ "
+"ചാറ്റുകളും ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2168,8 +2179,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് "
-"ചെയ്ത സമീപകാല ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
+"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് ചെയ്ത സമീപകാല "
+"ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2207,9 +2218,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും "
-"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും ശേഖരിക്കുകയോ "
+"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2307,6 +2317,12 @@ msgid "Ask privately"
 msgstr "സ്വകാര്യമായി ചോദിക്കുക"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2339,15 +2355,13 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ "
-"ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ "
-"പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും ഇല്ല (തിരയൽ "
-"ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
-"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
-"കാണിക്കൂ), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
-"കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി "
-"കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. (ഇംഗ്ലീഷ്) മേഖലയിൽ "
-"മാത്രമേ ലഭ്യമാകൂ."
+"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ ഉത്തരങ്ങൾ അജ്ഞാതമായി "
+"സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
+"ഒരിക്കലും ഇല്ല (തിരയൽ ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
+"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ചിലപ്പോൾ "
+"(വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ "
+"തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. "
+"(ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2359,14 +2373,13 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. "
-"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
-"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
-"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
-"%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
+"അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ %1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് "
+"പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2499,16 +2512,15 @@ msgstr "സ്വയമേവയുള്ള-ഉത്തരം"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ "
-"അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. "
-"പ്രതികരണങ്ങളിൽ അപാകതകൾ അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. പ്രതികരണങ്ങളിൽ അപാകതകൾ "
+"അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2533,9 +2545,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി "
-"തിരയാനും ചില സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. "
-"ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ Assist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി തിരയാനും ചില "
+"സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ "
+"മാത്രമേ Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2544,17 +2556,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് "
-"അജ്ഞാതമായി തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
-"കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് അജ്ഞാതമായി "
+"തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് "
+"പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
 msgstr ""
-"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ "
-"സ്വയമേവ പ്ലേ ചെയ്യുക."
+"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ സ്വയമേവ പ്ലേ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2586,9 +2597,7 @@ msgstr "ശരാശരി വോളിയം"
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr ""
-"നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് "
-"ഒഴിവാക്കുക."
+msgstr "നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് ഒഴിവാക്കുക."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2756,9 +2765,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, "
-"തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo "
-"നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
+"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ "
+"എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3139,18 +3147,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ "
-"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
-"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
+"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
+"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
+"ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ "
-"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
-"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
+"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
+"ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3158,9 +3166,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. "
-"%1$sപ്രധാന ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, "
-"സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. %1$sപ്രധാന "
+"ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ "
+"മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3246,9 +3254,7 @@ msgstr "'%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നി�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം "
-"അംഗീകരിക്കുന്നു."
+msgstr "“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3269,11 +3275,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), "
-"ക്രമീകരണം സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു "
-"വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത "
-"Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
-"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
+"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), ക്രമീകരണം "
+"സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ "
+"ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി "
+"തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
 "നിങ്ങളുടെ ബ്രൗസറിൽ നിന്ന് പുറത്തുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -3282,9 +3287,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
-"നിങ്ങളുടെ ശബ്ദ ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
-"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ ശബ്ദ ഡാറ്റ "
+"OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3293,9 +3297,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
-"നിങ്ങളുടെ വോയ്സ് ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
-"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ വോയ്സ് "
+"ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s "
+"കാണൂ."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3331,8 +3335,8 @@ msgstr "കാമറൂൺ"
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
 msgstr ""
-"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ "
-"പാചകക്കുറിപ്പുകൾ സൃഷ്ടിക്കാൻ കഴിയുമോ?"
+"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ പാചകക്കുറിപ്പുകൾ "
+"സൃഷ്ടിക്കാൻ കഴിയുമോ?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3634,8 +3638,7 @@ msgstr "ഫലങ്ങളുടെ URL-കൾ എങ്ങനെ പ്രദ�
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
 msgstr ""
-"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ "
-"പെരുമാറ്റവും മാറുന്നു"
+"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ പെരുമാറ്റവും മാറുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3654,17 +3657,13 @@ msgstr "മുഴുവൻ സൈറ്റിലും പശ്ചാത്ത�
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം "
-"മാറ്റുന്നു"
+msgstr "ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം "
-"മാറ്റുന്നു"
+msgstr "ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -3787,11 +3786,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ "
-"ചാറ്റ് (Duck.ai സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic "
-"തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo "
-"Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, "
-"%1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
+"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ ചാറ്റ് (Duck.ai "
+"സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. "
+"ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. "
+"എന്നിരുന്നാലും, %1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
 "നിങ്ങൾക്ക് ചാറ്റ് ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
@@ -3848,8 +3846,8 @@ msgstr "സ്വകാര്യമായി ചാറ്റ് ചെയ്യ�
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
-"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3857,8 +3855,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
-"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3871,6 +3869,12 @@ msgstr "%1$s-മായി സ്വകാര്യമായി ചാറ്റ�
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "AI-യുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3921,9 +3925,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത ചാറ്റുകൾ നീക്കം ചെയ്യും."
+"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത "
+"ചാറ്റുകൾ നീക്കം ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3935,13 +3939,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ "
-"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
-"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
-"പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും "
+"അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് "
+"നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും "
+"പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3964,9 +3966,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ "
-"അപ്‌ലോഡ് ചെയ്യുന്ന എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് "
-"അജ്ഞാതമായി പരിശോധിക്കുന്നു."
+"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ അപ്‌ലോഡ് ചെയ്യുന്ന "
+"എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് അജ്ഞാതമായി പരിശോധിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -3974,8 +3975,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. "
-"സമന്വയം പുനരാരംഭിക്കാൻ സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
+"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. സമന്വയം പുനരാരംഭിക്കാൻ "
+"സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4028,9 +4029,7 @@ msgstr "സ്പെല്ലിംഗ് പരിശോധിക്കുക"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് "
-"പരിശോധിക്കുക."
+msgstr "ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4101,9 +4100,7 @@ msgstr "%1$s , %2$s എന്നിവ ഉൾപ്പെടെ AI മോഡല�
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s "
-"തിരഞ്ഞെടുക്കുക."
+msgstr "നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4144,8 +4141,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് "
-"ആപ്പ് ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
+"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് ആപ്പ് "
+"ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4326,9 +4323,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ "
-"നടന്ന ചാറ്റുകൾ അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 "
-"ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ നടന്ന ചാറ്റുകൾ "
+"അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി "
+"ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4338,10 +4335,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ "
-"Duck.ai ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ "
-"യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ "
-"ആശ്രയിച്ചിരിക്കുന്നു."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ Duck.ai "
+"ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ "
+"ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ ആശ്രയിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4350,8 +4346,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. "
-"നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് "
+"ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4360,10 +4356,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ "
-"%1$sDuck.ai%2$s വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic "
-"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI "
-"ചാറ്റ് സേവനം."
+"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ %1$sDuck.ai%2$s "
+"വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI ചാറ്റ് സേവനം."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4422,9 +4417,7 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ച�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് ചെയ്യുക"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4441,8 +4434,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ "
-"വലതുവശത്തുള്ള %3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
+"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ വലതുവശത്തുള്ള "
+"%3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4460,8 +4453,7 @@ msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sക്രമീകരണം%
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
 msgstr ""
-"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി "
-"ക്ലിക്ക് ചെയ്യുക%4$s."
+"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി ക്ലിക്ക് ചെയ്യുക%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4474,8 +4466,7 @@ msgstr "%1$sഉവ്വ്%2$s ക്ലിക്ക് ചെയ്യുക"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് "
-"ചെയ്യുക."
+"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4537,10 +4528,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
-"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ "
-"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
-"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
+"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s "
+"ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4551,10 +4541,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
-"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ "
-"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
-"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
+"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/"
+"ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4623,8 +4612,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ "
-"മെനുവിൽ ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
+"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ "
+"ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4632,8 +4621,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ "
-"ബ്രൗസറിന്റെ മുകളിൽ വലത് കോണിലായിരിക്കും."
+"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ ബ്രൗസറിന്റെ "
+"മുകളിൽ വലത് കോണിലായിരിക്കും."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4674,6 +4663,12 @@ msgstr "ക്ലിപ്പ്ആർട്ട്"
 #. An accessible label for a button that closes a modal dialog
 msgid "Close"
 msgstr "അടയ്ക്കുക"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4718,6 +4713,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "തിരയൽ അടയ്ക്കുക"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4822,8 +4823,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി "
-"സംരക്ഷിക്കാൻ അനുവദിക്കും. ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
+"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി സംരക്ഷിക്കാൻ അനുവദിക്കും. "
+"ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5091,6 +5092,12 @@ msgid "Continue Blocking Ads"
 msgstr "പരസ്യങ്ങൾ തടയുന്നത് തുടരുക"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5156,6 +5163,12 @@ msgid "Cookie data:"
 msgstr "കുക്കി ഡാറ്റ:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5201,6 +5214,12 @@ msgstr "%1$sabout:preferences#search%2$s വിലാസ ബാറിലേക�
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "കോഡ് പകർത്തുക"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5270,9 +5289,7 @@ msgstr "കോസ്റ്റാ റിക്ക"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും "
-"ശ്രമിക്കു."
+msgstr "നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും ശ്രമിക്കു."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5318,6 +5335,12 @@ msgid "Create Image"
 msgstr "ചിത്രം സൃഷ്ടിക്കുക"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5359,6 +5382,14 @@ msgstr "സൃഷ്ടിച്ചത്"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "സൃഷ്ടിച്ചത് %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5514,6 +5545,12 @@ msgid "Customize responses"
 msgstr "പ്രതികരണങ്ങൾ ഇഷ്ടാനുസൃതമാക്കുക"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "ഈ പേജ് ഇഷ്ടാനുസൃതമാക്കുക"
@@ -5585,9 +5622,7 @@ msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞ
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5798,10 +5833,22 @@ msgid "Delete Server Data?"
 msgstr "സെർവർ ഡാറ്റ ഇല്ലാതാക്കുക?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "ട്രാൻസ്ക്രിപ്റ്റ് ഇല്ലാതാക്കുക"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5836,6 +5883,12 @@ msgid "Delete image?"
 msgstr "ചിത്രം ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats to free up storage?"
@@ -5845,9 +5898,7 @@ msgstr "സംഭരണ സ്ഥലം ശൂന്യമാക്കാൻ ഏ
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ "
-"ഇല്ലാതാക്കണോ?"
+msgstr "സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5962,8 +6013,8 @@ msgstr "Duck.ai-യിലെ ഡിക്റ്റേഷൻ"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കാറില്ല."
+"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5981,9 +6032,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ "
-"ഉപയോഗിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് "
-"ചെയ്യാൻ സാധിക്കും."
+"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ ഉപയോഗിക്കുന്നു, "
+"അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് ചെയ്യാൻ സാധിക്കും."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6147,6 +6197,12 @@ msgid "Dismiss promotion"
 msgstr "പ്രൊമോഷൻ ഒഴിവാക്കുക"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6251,9 +6307,7 @@ msgstr "പട്ടികയിൽ DuckDuckGo കാണുന്നില്ല
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് "
-"ചെയ്യുക%4$s"
+msgstr "അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് ചെയ്യുക%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6291,8 +6345,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI "
-"ചിത്രങ്ങൾ ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
+"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI ചിത്രങ്ങൾ "
+"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6359,6 +6413,12 @@ msgid "Download DuckDuckGo"
 msgstr "DuckDuckGo ഡൗൺലോഡ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo Browser"
@@ -6412,8 +6472,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു "
-"വെണ്ടറിന് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടറിന് "
+"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6422,8 +6482,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ "
-"അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് "
+"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6444,8 +6504,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ "
-"പോസ്റ്റിന് കുറച്ച് ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
+"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ പോസ്റ്റിന് കുറച്ച് "
+"ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6454,8 +6514,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു "
-"പോസ്റ്റിന്റെ തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
+"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു പോസ്റ്റിന്റെ "
+"തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6525,9 +6585,7 @@ msgstr "നിങ്ങളുടെ ഫോട്ടോകളോ PDF ഫയലു
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ "
-"അനുവദിക്കുന്നു"
+msgstr "ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6576,6 +6634,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai DuckDuckGo-യുടെതാണ്. സ്വകാര്യ AI ചാറ്റ്. സൗജന്യം."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6583,10 +6647,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് "
-"ഉത്തരം നൽകാൻ സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ "
-"നിങ്ങൾ തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് "
-"ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
+"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് ഉത്തരം നൽകാൻ "
+"സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ നിങ്ങൾ "
+"തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6596,9 +6659,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് "
-"ചെയ്യാൻ കഴിയില്ല. നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും "
-"എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. "
+"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ "
+"ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6607,16 +6670,14 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. "
-"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. ദയവായി നാളെ ഈ "
+"ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും "
-"മികച്ചത്!"
+msgstr "ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും മികച്ചത്!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6626,9 +6687,8 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ "
-"നിയന്ത്രണം തിരികെ നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര "
-"ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
+"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ നിയന്ത്രണം തിരികെ "
+"നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6643,8 +6703,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ "
-"എളുപ്പമുള്ള ഒരു വിലാസം ലഭിക്കും: https://duck.ai"
+"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ എളുപ്പമുള്ള ഒരു "
+"വിലാസം ലഭിക്കും: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6659,8 +6719,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s "
-"അജ്ഞാത കോഡ് %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s അജ്ഞാത കോഡ് "
+"%2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6681,9 +6741,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഇത് പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും "
-"മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും %1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
+"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും "
+"%1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6694,12 +6754,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം "
-"കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai "
-"ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ ക്രമീകരണം ഓഫ് "
-"ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai ആക്സസ് "
-"ചെയ്യാൻ കഴിയും. നേരിട്ട്."
+"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം കക്ഷി AI ചാറ്റ് "
+"മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഈ ക്രമീകരണം "
+"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ "
+"ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai "
+"ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6714,16 +6773,15 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. "
-"നിങ്ങൾക്ക് ഇപ്പോഴും പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
+"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. നിങ്ങൾക്ക് ഇപ്പോഴും "
+"പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
 msgstr ""
-"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് "
-"പരീക്ഷിച്ചു നോക്കൂ!"
+"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6731,8 +6789,14 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ "
-"കൃത്യതയ്ക്കായി പരിശോധിച്ചിട്ടുമില്ല."
+"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ കൃത്യതയ്ക്കായി "
+"പരിശോധിച്ചിട്ടുമില്ല."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6751,8 +6815,8 @@ msgstr "Duck.ai അപ്ഗ്രേഡ് ചെയ്തു!"
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
 msgstr ""
-"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും "
-"സൗജന്യവുമായ DuckDuckGo ആപ്പിലാണ്!"
+"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ "
+"DuckDuckGo ആപ്പിലാണ്!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6762,10 +6826,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത "
-"AI ചാറ്റ്, സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, "
-"മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, "
-"അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
+"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത AI ചാറ്റ്, "
+"സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI "
+"മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6793,12 +6856,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ "
-"സംഗ്രഹിക്കാനും കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് "
-"നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist "
-"UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ "
-"ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ "
-"മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
+"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
+"കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
+"ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-"
+"ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ "
+"പ്രസക്തമാകുമ്പോൾ മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
 "കാണിക്കുന്നു). ഇപ്പോൾ, DuckAssist യുഎസ് (ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
@@ -6808,10 +6870,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
-"എന്നിരുന്നാലും, ഞങ്ങൾ %1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് "
-"OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന "
-"ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
+"%1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ "
+"നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6820,10 +6881,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
-"എന്നിരുന്നാലും, ഞങ്ങൾ DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം "
-"ചെയ്യുന്നു, ഇത് OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
+"DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic "
+"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6835,13 +6895,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ പ്രതികരണങ്ങൾ നിലവിൽ "
-"വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും കൃത്യത "
-"പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
+"അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി "
+"വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം "
+"സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ "
+"പ്രതികരണങ്ങൾ നിലവിൽ വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും "
+"കൃത്യത പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6855,16 +6914,14 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് "
-"തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് "
-"ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
-"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
-"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ "
-"രണ്ടോ ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് "
-"വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ "
-"വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ രണ്ടോ "
+"ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ "
+"നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് "
+"പ്രതികരണങ്ങൾ സ്വയം സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
 "%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
@@ -6883,8 +6940,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. "
-"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
+"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. ദയവായി നാളെ ഈ "
+"ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6893,8 +6950,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
-"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
+"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6903,8 +6960,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
-"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
+"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6913,8 +6970,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -6923,8 +6980,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി "
-"ഈ അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ "
+"അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7057,9 +7114,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ "
-"പോലുള്ള PII സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ "
-"അജ്ഞാതമാക്കുന്നു."
+"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII "
+"സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ അജ്ഞാതമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7067,8 +7123,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
-"നിങ്ങൾ Duck.ai-യുടെ %2$s സമ്മതിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ Duck.ai-"
+"യുടെ %2$s സമ്മതിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7077,8 +7133,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
-"നിങ്ങൾ ഞങ്ങളുടെ %2$s-നെ അംഗീകരിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ ഞങ്ങളുടെ "
+"%2$s-നെ അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7087,9 +7143,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന "
-"Google, Facebook പോലുള്ള കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ "
-"സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ DuckDuckGo തടയുന്നു."
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന Google, Facebook പോലുള്ള "
+"കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ "
+"DuckDuckGo തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7101,13 +7157,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ "
-"പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് "
-"സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് ഞങ്ങൾക്ക് "
-"അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് "
-"ഉപയോഗിക്കുന്നു, തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി "
-"ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ "
-"സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ അറിയുക%2$s."
+"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ "
+"ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് "
+"ഞങ്ങൾക്ക് അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് ഉപയോഗിക്കുന്നു, "
+"തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ "
+"സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ "
+"അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7127,9 +7182,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് "
-"കൂടുതൽ ബന്ധമുള്ള, മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് കൂടുതൽ ബന്ധമുള്ള, "
+"മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7215,11 +7269,10 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo "
-"സെർവറുകളിൽ നിന്ന് ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. "
-"പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ "
-"തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 അക്ഷരങ്ങളെങ്കിലും "
-"ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
+"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo സെർവറുകളിൽ നിന്ന് "
+"ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ "
+"നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 "
+"അക്ഷരങ്ങളെങ്കിലും ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7290,8 +7343,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും "
-"പുതിയത് സൃഷ്ടിക്കുകയും ചെയ്യും."
+"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും പുതിയത് സൃഷ്ടിക്കുകയും "
+"ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7352,9 +7405,7 @@ msgstr "AI സവിശേഷതകൾ പ്രവർത്തനക്ഷമ�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save "
-"പ്രവർത്തനക്ഷമമാക്കുക."
+msgstr "നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7388,6 +7439,12 @@ msgstr "ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച 
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകൾ പ്രവർത്തനക്ഷമമാക്കുക"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7425,8 +7482,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് "
-"എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് എപ്പോൾ "
+"വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7471,9 +7528,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, "
-"പക്ഷേ അപ്പോഴും നിങ്ങളുടെ തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് "
-"സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
+"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, പക്ഷേ അപ്പോഴും നിങ്ങളുടെ "
+"തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7550,8 +7606,7 @@ msgstr "Duck.ai ആസ്വദിക്കുകയാണോ?"
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
 msgstr ""
-"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് "
-"ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7637,8 +7692,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് "
-"ചെയ്യുക. ഇത് നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
+"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക. ഇത് "
+"നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7664,8 +7719,8 @@ msgstr "ടെക്‌സ്റ്റ് നൽകുക"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: "
-"%5$sഅപരനാമം %6$s: ഡി%7$s"
+"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: %5$sഅപരനാമം "
+"%6$s: ഡി%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7692,6 +7747,12 @@ msgid "Entertainment guide"
 msgstr "വിനോദ ഗൈഡ്"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "ഇക്വറ്റോറിയൽ ഗിനിയ"
 
@@ -7700,8 +7761,7 @@ msgstr "ഇക്വറ്റോറിയൽ ഗിനിയ"
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
 msgstr ""
-"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ "
-"മായ്ക്കുക %1$s%2$s"
+"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ മായ്ക്കുക %1$s%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7761,9 +7821,7 @@ msgstr "മാപ്പ് വികസിപ്പിക്കുക"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത "
-"ഉൽപ്പന്നങ്ങൾ."
+msgstr "സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത ഉൽപ്പന്നങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7836,9 +7894,7 @@ msgstr "ഇത് ലളിതമായി വിശദീകരിക്കു�
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
-"ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും "
-"വിശദീകരിക്കുക."
+msgstr "ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7857,6 +7913,18 @@ msgstr "വ്യക്തമായ ഉള്ളടക്കം"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "വ്യക്തമായ വരികൾ"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7960,6 +8028,12 @@ msgid "FREE"
 msgstr "സൗജന്യം"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -8016,8 +8090,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
-"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു."
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
+"സ്വാധീനിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8026,9 +8100,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
-"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും "
-"പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
+"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
+"സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8036,8 +8109,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ "
-"സൈറ്റിലേക്കു പകർത്തി ഒട്ടിക്കുക"
+"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ സൈറ്റിലേക്കു പകർത്തി "
+"ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8121,16 +8194,15 @@ msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
-"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് "
-"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് ഫിൽട്ടർ ചെയ്ത് "
+"ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. "
-"%1$sകൂടുതലറിയുക%2$s"
+"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8172,8 +8244,7 @@ msgstr "<b>%1$s</b> നിങ്ങളുടെ ഡൗൺലോഡുകൾ ഫ�
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
 msgstr ""
-"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s "
-"എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8211,8 +8282,8 @@ msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
 msgstr ""
-"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും "
-"സുരക്ഷിതവും അജ്ഞാതവുമാണ്."
+"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും സുരക്ഷിതവും "
+"അജ്ഞാതവുമാണ്."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8276,9 +8347,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു "
-"മെനു ഓപ്ഷൻ തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി "
-"വന്നേക്കാം."
+"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു മെനു ഓപ്ഷൻ "
+"തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി വന്നേക്കാം."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8380,6 +8450,12 @@ msgid "Free Up Storage"
 msgstr "സംഭരണം ഒഴിവാക്കുക"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8389,9 +8465,7 @@ msgstr "സൗജന്യവും സ്വകാര്യവുമായ ച�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് "
-"ആവശ്യമില്ല."
+msgstr "സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8421,9 +8495,7 @@ msgstr "പങ്കിടലും വാണിജ്യപരമായി ഉ�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ "
-"ഇല്ലാതാക്കില്ല."
+msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8504,9 +8576,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; "
-"<strong>അപ്ഡേറ്റുകൾ പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് "
-"ഇൻസ്റ്റാൾ ചെയ്യുക</strong> തിരഞ്ഞെടുക്കുക."
+"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; <strong>അപ്ഡേറ്റുകൾ "
+"പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് ഇൻസ്റ്റാൾ ചെയ്യുക</strong> "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8857,9 +8929,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന "
-"DuckDuckGo-യിലേക്ക് സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI "
-"മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo-യിലേക്ക് "
+"സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8870,8 +8941,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo "
-"സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo സബ്സ്ക്രിപ്ഷൻ "
+"ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8897,6 +8968,12 @@ msgid "Get computer help"
 msgstr "കമ്പ്യൂട്ടർ സഹായം നേടുക"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8906,8 +8983,7 @@ msgstr "നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഒര�
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
 msgstr ""
-"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ "
-"സൗജന്യമായി നേടുക:"
+"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ സൗജന്യമായി നേടുക:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -8934,6 +9010,18 @@ msgid "Get the Latest Version"
 msgstr "ഏറ്റവും പുതിയ പതിപ്പ് നേടുക"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8954,6 +9042,12 @@ msgstr "ഈ ഗാനം ഇതിൽ നേടുക:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "കൂട്ടുകാരെ മാറാൻ പ്രേരിപ്പിക്കൂ, വളരാൻ ഞങ്ങളെ സഹായിക്കൂ!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8985,8 +9079,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
-"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക › ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
+"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക › "
+"ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9021,8 +9115,8 @@ msgid ""
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
 "എന്നതിലേക്ക് പോയി %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
-"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9037,8 +9131,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് "
-"പോയി \"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് പോയി "
+"\"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9298,9 +9392,7 @@ msgstr "ഗ്വാട്ടിമാല"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ "
-"നയിക്കുക."
+msgstr "ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ നയിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9500,9 +9592,7 @@ msgstr "DuckDuckGo മെച്ചപ്പെടുത്താൻ ഞങ്ങ
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ "
-"സഹായിക്കൂ"
+msgstr "നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ സഹായിക്കൂ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9560,9 +9650,7 @@ msgstr "Duck ഭാഗത്ത് ചേരാൻ നിങ്ങളുടെ �
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ "
-"സഹായിക്കൂ!"
+msgstr "നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ സഹായിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9645,6 +9733,12 @@ msgstr "ഘട്ടങ്ങൾ മറയ്ക്കുക"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "നുറുങ്ങുകൾ മറയ്ക്കുക"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9731,8 +9825,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search "
-"Assist ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
+"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search Assist "
+"ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9759,9 +9853,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ "
-"%1$sമടങ്ങുക%2$s അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് "
-"ക്ലിക്ക് ചെയ്യുക"
+"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ %1$sമടങ്ങുക%2$s "
+"അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9775,8 +9868,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, "
-"നിങ്ങൾക്ക് ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
+"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, നിങ്ങൾക്ക് "
+"ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9826,8 +9919,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ "
-"ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
+"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9936,9 +10029,7 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് "
-"ആഗ്രഹിക്കുന്നത്?"
+msgstr "നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് ആഗ്രഹിക്കുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -9971,8 +10062,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ "
-"തന്ത്രപൂർവ്വം സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
+"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ തന്ത്രപൂർവ്വം "
+"സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10079,9 +10170,7 @@ msgstr "കൂടുതൽ വിൽപ്പനക്കാരിൽ നിന�
 #. Header above text explaining that passwords can't be recovered.
 msgctxt "cloudsave"
 msgid "I forgot my passphrase. Can you recover it?"
-msgstr ""
-"എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ "
-"സാധിക്കുമോ?"
+msgstr "എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ സാധിക്കുമോ?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user hits a chat limit.
@@ -10096,16 +10185,14 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല "
-"പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
+"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് "
+"ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ "
-"എനിക്ക് ആവശ്യമാണ്"
+msgstr "ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ എനിക്ക് ആവശ്യമാണ്"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10134,9 +10221,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > "
-"പുനഃക്രമീകരിക്കുക > 'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s "
-"എന്നതിലേക്ക് പോകുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > പുനഃക്രമീകരിക്കുക > "
+"'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s എന്നതിലേക്ക് പോകുക."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10146,9 +10232,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക "
-"%1$s⋮ > മെനു > ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് "
-"DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക %1$s⋮ > മെനു > "
+"ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് "
+"അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10163,8 +10249,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ "
-"എഞ്ചിനുകളുടെ%4$s പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
+"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ എഞ്ചിനുകളുടെ%4$s "
+"പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10173,9 +10259,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് "
-"പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് "
-"%1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
+"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് "
+"ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് %1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10184,17 +10269,16 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച "
-"ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ "
-"ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ "
+"ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, "
-"%1$sDuckDuckGo പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
+"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, %1$sDuckDuckGo "
+"പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10204,8 +10288,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ "
-"%1$s അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
+"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ %1$s "
+"അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10213,8 +10297,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും "
-"അടുത്തുള്ള ഹോം പേജ് തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
+"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും അടുത്തുള്ള ഹോം പേജ് "
+"തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10343,8 +10427,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് "
-"ഫലത്തിന്റെ വ്യക്തത മെച്ചപ്പെടുത്തുന്നു"
+"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് ഫലത്തിന്റെ വ്യക്തത "
+"മെച്ചപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10357,8 +10441,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ "
-"ക്ലിക്കുകൾ റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ ക്ലിക്കുകൾ "
+"റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10369,8 +10453,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, "
-"തുടർന്ന് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
+"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, തുടർന്ന് \"മറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10385,9 +10469,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം "
-"വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി "
-"പരിശോധിക്കാവുന്നതാണ്."
+"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക "
+"എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി പരിശോധിക്കാവുന്നതാണ്."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10724,8 +10807,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ "
-"പ്രശസ്തി സംഗ്രഹിക്കുക."
+"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ പ്രശസ്തി "
+"സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10769,17 +10852,15 @@ msgstr "ഇതിന് ഏതാനും നിമിഷങ്ങൾ എടു
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും "
-"നൽകുന്നു."
+msgstr "ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും നൽകുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) "
-"ചോദിക്കുന്നതിൽ കുഴപ്പമില്ല"
+"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) ചോദിക്കുന്നതിൽ "
+"കുഴപ്പമില്ല"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10798,10 +10879,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, "
-"Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ "
-"നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് "
-"വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം ലഭിക്കുന്നില്ല."
+"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, Microsoft-ന്റെ "
+"പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് "
+"നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം "
+"ലഭിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10810,8 +10891,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 "
-"വാക്കുകൾ ഓർമിക്കുവാൻ, വളരെ അധികം സുരക്ഷിതവും."
+"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 വാക്കുകൾ ഓർമിക്കുവാൻ, "
+"വളരെ അധികം സുരക്ഷിതവും."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11178,9 +11259,7 @@ msgstr "DuckDuckGo ക്രമീകരണങ്ങൾ എങ്ങനെ ക�
 #. Description of a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "Learn how we keep your location private"
-msgstr ""
-"നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
-"മനസ്സിലാക്കുക"
+msgstr "നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക"
 
 # smartling.placeholder_format=C
 #. Link text in the Usage section of Duck.ai settings that opens a help page explaining Duck.ai usage limits.
@@ -11222,9 +11301,7 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് "
-"അറിയുക."
+msgstr "ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് അറിയുക."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11282,6 +11359,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "DuckDuckGo ഉപയോഗിച്ച് അജ്ഞാതമായി തിരയാൻ നിങ്ങളെ അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "ലൈബീരിയ"
 
@@ -11337,9 +11421,7 @@ msgstr "ഈ ചാറ്റിനായി പരിമിതമായ ഡാറ
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr ""
-"ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് "
-"പരിമിതപ്പെടുത്തുന്നു"
+msgstr "ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് പരിമിതപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -11352,6 +11434,12 @@ msgstr "ലൈൻ ഡ്രോയിംഗ്"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "നേടിയ ലൈനൗട്ടുകൾ"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11368,8 +11456,7 @@ msgstr "ലിങ്കുകൾ:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
-"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ "
-"ലിസ്റ്റ് ചെയ്യുക."
+"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ ലിസ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11481,8 +11568,7 @@ msgstr "സ്ക്രോൾ ചെയ്യുമ്പോൾ കൂടുത�
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
 msgstr ""
-"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ "
-"ലോഡ് ചെയ്യുന്നു"
+"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ ലോഡ് ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11663,8 +11749,7 @@ msgstr "എല്ലാ വാക്കുകളും അക്ഷരത്ത�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് "
-"തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
+"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12010,9 +12095,7 @@ msgstr "മൈക്രോനേഷ്യ"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12452,6 +12535,12 @@ msgid "More than 20 minutes"
 msgstr "20 മിനിറ്റിൽ അധികം"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12772,11 +12861,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
-"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു "
+"DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് "
+"വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ "
+"ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
 "പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
@@ -12939,6 +13027,12 @@ msgstr "വേണ്ട, നന്ദി"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "വേണ്ട, നന്ദി"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13603,6 +13697,12 @@ msgid "On but no numbers"
 msgstr "ഓണാണ്, പക്ഷെ നമ്പറുകൾ ഇല്ല"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13616,9 +13716,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ "
-"കൂടുതൽ പേജുകളുണ്ട്. %1$s അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് "
-"ചെയ്യുക."
+"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ കൂടുതൽ പേജുകളുണ്ട്. %1$s "
+"അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13661,8 +13760,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത "
-"പിശകുണ്ടായി. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത പിശകുണ്ടായി. പിന്നീട് "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13716,8 +13815,8 @@ msgstr "%1$s വെബ്‌സൈറ്റ് തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
 msgstr ""
-"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
-"%3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s ഉറപ്പാക്കുക"
+"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s "
+"ഉറപ്പാക്കുക"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13738,8 +13837,7 @@ msgstr "%1$sക്രമീകരണം%2$s തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
 msgstr ""
-"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
-"%1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -13820,6 +13918,12 @@ msgid "Open create and edit images suggestions"
 msgstr "ചിത്രങ്ങൾ സൃഷ്ടിക്കാനും എഡിറ്റ് ചെയ്യാനുമുള്ള നിർദ്ദേശങ്ങൾ തുറക്കുക"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13882,9 +13986,7 @@ msgstr "How Duck.ai വർക്ക്സ് പാനൽ തുറക്കു�
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s "
-"തിരഞ്ഞെടുക്കുക..."
+msgstr "Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s തിരഞ്ഞെടുക്കുക..."
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -13985,9 +14087,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ "
-"നിങ്ങളുടെ തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് "
-"ചെയ്യുന്നില്ല — കാലഘട്ടം"
+"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ നിങ്ങളുടെ "
+"തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല — കാലഘട്ടം"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14000,8 +14101,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും "
-"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും ശേഖരിക്കുകയോ "
+"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14009,9 +14110,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ "
-"ഉൾപ്പെടുത്തി മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, "
-"Android%2$s എന്നിവയിൽ ലഭ്യമാണ്."
+"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ ഉൾപ്പെടുത്തി "
+"മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, Android%2$s എന്നിവയിൽ "
+"ലഭ്യമാണ്."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14264,9 +14365,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും "
-"വിവരങ്ങൾ ഞങ്ങൾ ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ "
-"കഴിയില്ല."
+"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും വിവരങ്ങൾ ഞങ്ങൾ "
+"ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14466,10 +14566,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI "
-"സഹായമുള്ള ഉത്തരങ്ങൾ സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും "
-"പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. അവ ഓഫാക്കാനും Assist ബട്ടൺ "
-"മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI സഹായമുള്ള ഉത്തരങ്ങൾ "
+"സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. "
+"അവ ഓഫാക്കാനും Assist ബട്ടൺ മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14478,10 +14577,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
-"DuckAssist പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച "
-"ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് "
-"ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist "
+"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ "
+"സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist "
+"ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14491,10 +14590,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
-"DuckAssist സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും "
-"മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ "
-"മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist സ്വയമേവ "
+"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് "
+"ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14527,8 +14625,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
-"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14537,8 +14635,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
-"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14547,8 +14645,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ "
-"ആപ്പുകൾക്ക് DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
+"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ ആപ്പുകൾക്ക് "
+"DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14561,8 +14659,8 @@ msgstr "ഒരു നിർദിഷ്ട പ്രശ്നം തിരഞ്
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ "
-"നിർദ്ദേശങ്ങൾ പാലിക്കുക."
+"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ നിർദ്ദേശങ്ങൾ "
+"പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14571,10 +14669,22 @@ msgid "Pin"
 msgstr "പിൻ ചെയ്യുക"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "%1$s %2$s-ൽ നിന്നുള്ള ചാറ്റുകൾ ഇവിടെ പിന്‍ ചെയ്യുക"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14592,6 +14702,12 @@ msgstr "പിങ്ക്"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "പിന്‍ ചെയ്തിരിക്കുന്നു"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14633,8 +14749,7 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന "
-"ചലഞ്ച് പൂർത്തിയാക്കുക."
+"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന ചലഞ്ച് പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14643,24 +14758,23 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി "
-"പൂർത്തിയാക്കുക."
+"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
-"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
+"(ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
-"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
+"(ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14681,8 +14795,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് "
-"നിങ്ങളുടെ നിലവിലെ ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
+"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് നിങ്ങളുടെ നിലവിലെ "
+"ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14691,9 +14805,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
-"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ "
-"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
+"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14702,9 +14815,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
-"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ "
-"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
+"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14857,8 +14969,7 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
-"സ്വാധീനിക്കുകയില്ല."
+"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കുകയില്ല."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14915,6 +15026,12 @@ msgstr "പോളിഷ്"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "മോശം ഫോർമാറ്റിംഗ്"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15123,6 +15240,12 @@ msgstr "മുൻപത്തെ ചിത്രം"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "മുമ്പത്തെ ടാബുകൾ"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15417,9 +15540,7 @@ msgstr "എന്നെ പ്രോംപ്റ്റ് ചെയ്യു�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് "
-"നിർദേശിക്കുക."
+msgstr "സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് നിർദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15437,9 +15558,7 @@ msgstr "നിങ്ങൾ തിരയുകയും ബ്രൗസ് ചെ
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ "
-"സംരക്ഷിക്കുക."
+msgstr "തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15464,8 +15583,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. "
-"[നിങ്ങളുടെ സ്വന്തം വാചകം ഇവിടെ ചേർക്കുക.]"
+"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. [നിങ്ങളുടെ സ്വന്തം "
+"വാചകം ഇവിടെ ചേർക്കുക.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15667,6 +15786,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "ഇടത്തരം ബിൽറ്റ്-ഇൻ മോഡറേഷനോടുകൂടിയ റീസണിംഗ് AI"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15702,14 +15833,20 @@ msgid "Recent chat storage can be adjusted in %s."
 msgstr "സമീപകാല ചാറ്റ് സംഭരണം %1$s-ൽ ക്രമീകരിക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
 msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15718,8 +15855,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15729,10 +15866,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ "
-"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
+"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ പ്രോംപ്റ്റുകളും "
+"പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ "
+"സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15857,13 +15993,19 @@ msgid "Reduce Usage"
 msgstr "ഉപയോഗം കുറയ്ക്കുക"
 
 # smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ "
-"വലുപ്പം കുറയ്ക്കുകയും ചെയ്യുന്നു"
+"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ വലുപ്പം കുറയ്ക്കുകയും "
+"ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16004,9 +16146,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ "
-"ബ്രൗസറിലെ &quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് "
-"ചെയ്യുക."
+"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ ബ്രൗസറിലെ "
+"&quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16096,9 +16237,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
-"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും "
-"സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
+"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16106,9 +16246,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
-"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും "
-"സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
+"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16166,10 +16305,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ "
-"സഹായിക്കുന്നതിന് അവ DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ "
-"മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് "
-"അയയ്ക്കാറുണ്ട്."
+"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് അവ "
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ "
+"അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് അയയ്ക്കാറുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16177,8 +16315,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ "
-"ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ "
+"തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16187,10 +16325,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് "
-"വിവർത്തനം ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ "
-"അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ "
-"വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് വിവർത്തനം "
+"ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ "
+"വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16237,6 +16374,12 @@ msgid "Reset All Settings"
 msgstr "എല്ലാ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16247,6 +16390,12 @@ msgstr "%1$s-ൽ പുനഃക്രമീകരിക്കുന്നു"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "റെസല്യൂഷൻ"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16270,10 +16419,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന "
-"നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. AI- "
+"സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16282,9 +16430,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist "
+"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16294,11 +16442,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി "
-"സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search Assist "
-"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് "
+"ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search "
+"Assist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16375,8 +16522,8 @@ msgstr "ബ്ലോക്ക് ചെയ്‌ത സൈറ്റുകളി�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ "
-"കൈകാര്യം ചെയ്യാൻ കഴിയും."
+"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ കൈകാര്യം ചെയ്യാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16725,17 +16872,16 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് "
-"നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ "
-"പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ "
-"പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ പ്രാദേശികമായി "
+"സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -16743,8 +16889,7 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai "
-"ചാറ്റുകൾ സംരക്ഷിക്കുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16878,17 +17023,13 @@ msgstr "സ്കോട്ട്ലൻഡ്"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് "
-"ചെയ്യുക."
+msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16896,8 +17037,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
-"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
+"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16906,8 +17047,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
-"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
+"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16926,16 +17067,15 @@ msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത്, �
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ "
-"ഉപയോഗിക്കാൻ അതിനെ അനുവദിക്കുക."
+"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ "
+"അതിനെ അനുവദിക്കുക."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s "
-"ക്ലിക്ക് ചെയ്യുക."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16958,6 +17098,12 @@ msgstr "തിരയുക"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "നിങ്ങൾക്ക് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്താൻ %1$s തിരയണമോ?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16983,14 +17129,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. "
-"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. "
-"നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
-"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ "
-"പ്രസക്തമാകുമ്പോൾ), അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, "
-"ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ ഒരു ഭാഗത്ത് മാത്രമേ Search Assist "
-"ലഭ്യമാകൂ."
+"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. ഇത് ചെയ്യുന്നതിന്, "
+"പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം "
+"സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
+"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ), "
+"അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ "
+"ഒരു ഭാഗത്ത് മാത്രമേ Search Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16998,8 +17142,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search "
-"Assist-ന് കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
+"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search Assist-ന് "
+"കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17008,10 +17152,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
-"സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും കണ്ടെത്തിയ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
+"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ "
+"സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും "
+"കണ്ടെത്തിയ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17132,8 +17275,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള "
-"തിരയൽ വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
+"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള തിരയൽ "
+"വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17152,9 +17295,9 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, "
-"നിങ്ങളുടെ പ്രിയപ്പെട്ട ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, "
-"അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് തിരയുക."
+"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, നിങ്ങളുടെ പ്രിയപ്പെട്ട "
+"ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് "
+"തിരയുക."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17162,8 +17305,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST "
-"അഭ്യർത്ഥനകൾ ഉപയോഗിക്കും)"
+"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST അഭ്യർത്ഥനകൾ "
+"ഉപയോഗിക്കും)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17175,11 +17318,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക "
-"സംഭരണത്തിലും നിങ്ങളുടെ ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു "
-"വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save "
-"ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ "
-"സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
+"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക സംഭരണത്തിലും നിങ്ങളുടെ "
+"ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
+"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
 "വിട്ടുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -17275,8 +17417,7 @@ msgstr "രണ്ടാമതൊരു അഭിപ്രായം"
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
 msgstr ""
-"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും "
-"സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
+"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17285,9 +17426,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17296,9 +17436,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17307,9 +17446,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17318,17 +17456,15 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ "
-"സുരക്ഷിതമായി സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിച്ചിരിക്കുന്നു."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17337,9 +17473,14 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിച്ചിരിക്കുന്നു. നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, "
-"ഞങ്ങൾക്ക് പോലും."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു. "
+"നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17478,38 +17619,34 @@ msgstr "%1$s%2$s%3$s തിരഞ്ഞെടുക്കുക, തുടർന
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
 msgstr ""
-"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക."
+"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം "
-"%3$shttps://duckduckgo.com%4$s എന്ന് ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
+"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം %3$shttps://duckduckgo.com%4$s എന്ന് "
+"ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ "
-"ക്ലിക്ക് ചെയ്യുക!"
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ ക്ലിക്ക് "
+"ചെയ്യുക!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
-"ചെയ്യുക."
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17521,9 +17658,7 @@ msgstr "ഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ ഡ്ര
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
-"%4$sഅനുവദിക്കുക%3$s"
+msgstr "ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %4$sഅനുവദിക്കുക%3$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17536,8 +17671,7 @@ msgstr "തിരയൽ ദാതാക്കളുടെ പട്ടികയ�
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
 msgstr ""
-"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s "
-"തിരഞ്ഞെടുക്കുക"
+"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17548,17 +17682,13 @@ msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sManage add-ons%s from the dropdown menu"
-msgstr ""
-"ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -17566,8 +17696,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s "
-"എന്നും തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s എന്നും "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17575,8 +17705,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s "
-"എന്നും തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s എന്നും "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17641,16 +17771,14 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
+"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ "
+"നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
-"%3$sഅനുവദിക്കുക%4$s"
+msgstr "ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %3$sഅനുവദിക്കുക%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17723,8 +17851,7 @@ msgstr "%1$s-ൽ നിന്ന് തിരഞ്ഞെടുത്ത ടെ�
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
 msgstr ""
-"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് "
-"വീണ്ടും ശ്രമിക്കൂ."
+"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17768,9 +17895,9 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ "
-"സന്ദേശങ്ങളുമായി AI മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ "
-"നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും ബാധകമാകും."
+"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ സന്ദേശങ്ങളുമായി AI "
+"മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും "
+"ബാധകമാകും."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17868,6 +17995,12 @@ msgid "Set as Homepage"
 msgstr "ഹോംപേജ് ആയി സജ്ജമാക്കുക"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17880,8 +18013,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് "
-"ചരിത്രം ഓണാക്കിയ ശേഷം Sync & Backup സജ്ജമാക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് ചരിത്രം ഓണാക്കിയ "
+"ശേഷം Sync & Backup സജ്ജമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17935,6 +18068,18 @@ msgid "Seychelles"
 msgstr "സീഷെൽസ്"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17943,9 +18088,7 @@ msgstr "പങ്കിടുക"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ "
-"സഹായിക്കുക!"
+msgstr "DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ സഹായിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17972,9 +18115,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. "
-"Duck.ai ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ "
-"വെളിപ്പെടുത്തുകയില്ല."
+"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. Duck.ai "
+"ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ വെളിപ്പെടുത്തുകയില്ല."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18035,6 +18184,12 @@ msgid "Share positive feedback"
 msgstr "പോസിറ്റീവ് ഫീഡ്ബാക്ക് പങ്കിടുക"
 
 # smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -18057,8 +18212,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക "
-"(നിയമവിരുദ്ധവും ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
+"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക (നിയമവിരുദ്ധവും "
+"ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18170,6 +18325,12 @@ msgid "Show Detail"
 msgstr "വിശദാംശം കാണിക്കുക"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "DuckAssist <sup>BETA</sup> കാണിക്കുക"
@@ -18178,9 +18339,7 @@ msgstr "DuckAssist <sup>BETA</sup> കാണിക്കുക"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും "
-"%1$sഓഫാക്കാം%2$s.)"
+msgstr "DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും %1$sഓഫാക്കാം%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18319,6 +18478,12 @@ msgid "Show more"
 msgstr "കൂടുതൽ കാണിക്കുക"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18352,6 +18517,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "സൈഡ്ബാർ കാണിക്കുക"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18406,9 +18577,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു "
-"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
-"കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. "
+"ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18416,9 +18586,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു "
-"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
-"കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും ബാധിക്കുന്നില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ "
+"കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും "
+"ബാധിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18429,8 +18599,7 @@ msgstr "ഫല പേജ് ഇടവേളകളിൽ തിരശ്ചീന
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള "
-"ലിങ്കുകൾ കാണിക്കുന്നു"
+"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള ലിങ്കുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18447,23 +18616,21 @@ msgstr "പുതിയ ടാബ് പേജിൽ ഏറ്റവും ക�
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് "
-"ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18571,16 +18738,12 @@ msgstr "സൈറ്റുകളുടെ പേരുകൾ"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ "
-"പ്രവർത്തിക്കുന്നു."
+msgstr "സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും "
-"മറയ്ക്കും"
+msgstr "നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും മറയ്ക്കും"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18726,14 +18889,19 @@ msgstr "സെർവറിലേക്ക് സംരക്ഷിക്കു�
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
 msgstr ""
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി "
-"വീണ്ടും ശ്രമിക്കുക."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "എന്തോ കുഴപ്പം സംഭവിച്ചു, ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18752,8 +18920,8 @@ msgstr "ചിലപ്പോൾ"
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
 msgstr ""
-"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു "
-"രീതിയിൽ വിവരിക്കുക."
+"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു രീതിയിൽ "
+"വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18792,8 +18960,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി "
-"മറ്റൊരു ചിത്രമോ ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
+"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി മറ്റൊരു ചിത്രമോ "
+"ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18802,16 +18970,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ "
-"ചെയ്തതെന്ന് ഉറപ്പാക്കുക."
+"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ ചെയ്തതെന്ന് "
+"ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. "
-"നിങ്ങൾക്ക് Duck.ai-യോട് ചോദിക്കാൻ ശ്രമിക്കാം."
+"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾക്ക് Duck.ai-യോട് "
+"ചോദിക്കാൻ ശ്രമിക്കാം."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18820,16 +18988,15 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. "
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
+"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. വീണ്ടും ശ്രമിക്കാൻ "
+"%1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് "
-"വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18884,8 +19051,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് "
-"തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
+"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും "
+"ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19034,6 +19201,12 @@ msgid "Start Using Weekly Limit"
 msgstr "ആഴ്ച തോറുമുള്ള പരിധി ഉപയോഗിക്കാൻ തുടങ്ങുക"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "തിരയൽ ആരംഭിക്കുക!"
@@ -19084,9 +19257,7 @@ msgstr "DuckDuckGo-യിൽ തുടരുക"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും "
-"അറിവുള്ളവരായും തുടരുക."
+msgstr "ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും അറിവുള്ളവരായും തുടരുക."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19136,9 +19307,7 @@ msgstr "സൃഷ്ടിക്കൽ നിർത്തുക"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ "
-"പ്രതിരോധിക്കുക."
+msgstr "മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ പ്രതിരോധിക്കുക."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19233,8 +19402,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, "
-"അല്ലെങ്കിൽ കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
+"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, അല്ലെങ്കിൽ "
+"കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19303,8 +19472,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ "
-"എഴുതാൻ ഒരു വാക്യം നിർദ്ദേശിക്കാമോ?"
+"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ എഴുതാൻ ഒരു വാക്യം "
+"നിർദ്ദേശിക്കാമോ?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19616,6 +19785,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "നിങ്ങളെ ട്രാക്ക് ചെയ്യാത്ത തിരയൽ എഞ്ചിനിലേക്ക് മാറുക. എപ്പോഴും."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19626,9 +19803,7 @@ msgstr "%1$sഎന്നതിലേക്ക് മാറി"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് "
-"അയയ്ക്കും"
+msgstr "മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് അയയ്ക്കും"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19682,9 +19857,7 @@ msgstr "Sync & Backup പ്രവർത്തനക്ഷമമാക്കി!
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ "
-"കഴിയില്ല."
+msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19733,27 +19906,25 @@ msgid ""
 msgstr ""
 "വീണ്ടെടുക്കൽ കോഡ് സമന്വയിപ്പിക്കുക\n"
 "\n"
-" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, "
-"ഡാറ്റ ഓട്ടോഫിൽ ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു "
-"ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ നിങ്ങളുടെ സമന്വയിപ്പിച്ച "
-"ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
+" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, ഡാറ്റ ഓട്ടോഫിൽ "
+"ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ "
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
 "\n"
 "ഈ വിവരങ്ങൾ സുരക്ഷിതമായി സൂക്ഷിക്കുക.\n"
-"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ "
-"കഴിയും.\n"
+"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ കഴിയും.\n"
 "\n"
 "%1$s\n"
 "\n"
 "ഈ കോഡ് എങ്ങനെയാണ് പ്രവർത്തിക്കുന്നത്?\n"
 "1. നിങ്ങളുടെ ബ്രൗസറിൽ Duck.ai-ലേക്ക് പോയി Duck.ai സെറ്റിംഗ്സ് തുറക്കുക.\n"
-"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ "
-"വീണ്ടെടുക്കുക\" തിരഞ്ഞെടുക്കുക.\n"
-"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" "
-"എന്ന് പറയുന്നിടത്ത് ഒട്ടിക്കുക.\n"
+"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കുക\" "
+"തിരഞ്ഞെടുക്കുക.\n"
+"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" എന്ന് പറയുന്നിടത്ത് "
+"ഒട്ടിക്കുക.\n"
 "\n"
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ "
-"18 മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് "
-"ഇല്ലാതാക്കപ്പെടും, അത് പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ 18 "
+"മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് ഇല്ലാതാക്കപ്പെടും, അത് "
+"പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19772,6 +19943,12 @@ msgstr "മറ്റൊരു ഉപകരണവുമായി സമന്വ�
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "സമന്വയവും ബാക്കപ്പും താൽക്കാലികമായി ലഭ്യമല്ല"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19861,6 +20038,22 @@ msgid "Take Back Your Privacy!"
 msgstr "നിങ്ങളുടെ സ്വകാര്യത തിരികെ എടുക്കുക!"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19881,9 +20074,7 @@ msgstr "നിങ്ങളുടെ സ്വകാര്യ ഡാറ്റയ�
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ "
-"പങ്കെടുക്കൂ."
+msgstr "Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ പങ്കെടുക്കൂ."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20098,10 +20289,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ "
-"ഒരു മൂന്നാം കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. "
-"അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ "
-"ഉൾപ്പെടുന്നു."
+"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ ഒരു മൂന്നാം "
+"കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ "
+"പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ ഉൾപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20110,8 +20300,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ "
-"സംരക്ഷിക്കാൻ Cloud Save ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
+"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ സംരക്ഷിക്കാൻ Cloud Save "
+"ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20141,17 +20331,15 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ "
-"സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
+"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ "
+"നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് "
-"ഇല്ലാതാക്കും."
+msgstr "ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20224,9 +20412,9 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക "
-"ഡാറ്റ സംഭരണം പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി "
-"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക."
+"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക ഡാറ്റ സംഭരണം "
+"പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ "
+"പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20241,8 +20429,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ "
-"വീണ്ടും ശ്രമിക്കുന്നതിന് മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
+"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ വീണ്ടും ശ്രമിക്കുന്നതിന് "
+"മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20261,10 +20449,10 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ "
-"എൻക്രിപ്റ്റ് ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ "
-"എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ "
-"സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ ഉപയോഗിക്കുന്നു."
+"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ എൻക്രിപ്റ്റ് "
+"ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും "
+"നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ "
+"ഉപയോഗിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20310,8 +20498,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ "
-"പതിപ്പിൽ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
+"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ ഒരു പുതിയ "
+"ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20326,10 +20514,22 @@ msgid "This Month"
 msgstr "ഈ മാസം"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "ഈ ആഴ്ച"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20338,9 +20538,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
-"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം "
-"(കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
+"ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20350,9 +20550,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
-"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
+"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
+"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20361,9 +20561,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
-"കൃത്യതയില്ലാത്തതോ കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%2$s കാണുക)."
+"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI കൃത്യതയില്ലാത്തതോ "
+"കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20373,9 +20572,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ "
-"സംഭാഷണം സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
+"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ "
+"വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20407,9 +20606,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s "
-"അറ്റാച്ചുചെയ്യുക"
+msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ചുചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20417,9 +20614,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് "
-"ചെയ്യുക."
+msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -20451,8 +20646,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
-"ചേർക്കുക"
+"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -20460,13 +20654,28 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
-"ചേർക്കുക."
+"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "ഈ വിവരങ്ങൾ ഉപയോഗപ്രദമല്ല"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20487,8 +20696,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ "
-"ഇല്ലാതാക്കും. മറ്റ് മോഡൽ ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ ഇല്ലാതാക്കും. മറ്റ് മോഡൽ "
+"ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20497,8 +20706,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് "
-"മോഡൽ ദാതാക്കൾ ഒരു പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് മോഡൽ ദാതാക്കൾ ഒരു "
+"പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20535,9 +20744,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് "
-"എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് "
-"ആക്‌സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് "
+"സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് ആക്‌സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20546,9 +20754,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
-"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
-"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
+"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20558,10 +20765,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
-"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
-"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. എന്നിരുന്നാലും, %1$s-ൽ AI "
-"സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും ഞങ്ങൾക്ക് ഉണ്ട്."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
+"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. "
+"എന്നിരുന്നാലും, %1$s-ൽ AI സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും "
+"ഞങ്ങൾക്ക് ഉണ്ട്."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20590,9 +20797,7 @@ msgstr "ഈ വീഡിയോ ഇതുവരെ ഇവിടെ കാണാ�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) "
-"ഉപയോഗിക്കുന്നില്ല."
+msgstr "ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20602,10 +20807,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും "
-"Sync & Backup വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് "
-"ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് "
-"ചെയ്യാൻ കഴിയും."
+"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും Sync & Backup "
+"വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ "
+"നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20614,8 +20818,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. "
-"ഇത് പഴയപടിയാക്കാനാവില്ല."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. ഇത് "
+"പഴയപടിയാക്കാനാവില്ല."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20634,8 +20838,7 @@ msgstr "ഇത് എല്ലാ ക്രമീകരണവും മായ്
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
 msgstr ""
-"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് "
-"പുനഃക്രമീകരിക്കും. തുടരണോ?"
+"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് പുനഃക്രമീകരിക്കും. തുടരണോ?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20732,9 +20935,7 @@ msgstr "ശീർഷക അടിവര"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ "
-"ചേർക്കാൻ:"
+msgstr "മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ ചേർക്കാൻ:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -20757,8 +20958,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് "
-"ചെയ്യേണ്ട റൂട്ട് തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
+"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് ചെയ്യേണ്ട റൂട്ട് "
+"തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20768,10 +20969,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം "
-"സജ്ജമാക്കുമ്പോൾ സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം "
-"സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് "
-"ചെയ്‌തിരിക്കാം."
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം സജ്ജമാക്കുമ്പോൾ "
+"സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച "
+"ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് ചെയ്‌തിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20780,8 +20980,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും "
-"പുതിയ പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും പുതിയ "
+"പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20789,8 +20989,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ "
-"ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുക."
+"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ "
+"അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20807,6 +21007,12 @@ msgstr "ഇന്ന്"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "ഇന്ന്"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20980,8 +21186,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം "
-"ബ്ലോക്ക് ചെയ്യുന്നു എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
+"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം ബ്ലോക്ക് ചെയ്യുന്നു "
+"എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21029,8 +21235,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
-"ഞാൻ എങ്ങനെ എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
+"എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21039,8 +21245,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
-"ഞാൻ എങ്ങനെ എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
+"എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21220,9 +21426,21 @@ msgid "Try Them Out"
 msgstr "അവ പരീക്ഷിച്ചു നോക്കൂ"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "ഒരു തിരയൽ ശ്രമിക്കുക!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21258,8 +21476,8 @@ msgstr "വ്യത്യസ്ത കീവേഡുകൾ പരീക്ഷ�
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ "
-"പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുക."
+"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ പ്രവർത്തനരഹിതമാക്കാൻ "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21289,6 +21507,12 @@ msgid "Try for free"
 msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21300,9 +21524,13 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ പലതും."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
-"സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ "
-"പലതും."
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21330,6 +21558,12 @@ msgstr "ഞങ്ങളുടെ ബ്രൗസർ പരീക്ഷിക്�
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "ഈ സന്ദേശങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഞങ്ങളുടെ ഹോംപേജ് പരീക്ഷിക്കുക:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21411,8 +21645,7 @@ msgstr "അടുത്തിടെ ചേർത്തിട്ടുള്ള o
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
 msgstr ""
-"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ "
-"സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
+"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21446,9 +21679,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. "
-"%3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
+"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21457,9 +21689,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. "
-"%3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
+"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21581,6 +21812,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "ടാർഗെറ്റ് ചെയ്ത പരസ്യങ്ങളില്ലാതെ YouTube കാണുന്നതിന് Duck Player ഓണാക്കുക"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21642,9 +21879,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് "
-"തിരയലിനും ഉത്തരം കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് "
-"കാരണമായേക്കാം."
+"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് തിരയലിനും ഉത്തരം "
+"കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് കാരണമായേക്കാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21742,17 +21978,13 @@ msgstr "ഫീഡ് ബാക്ക് അയയ്ക്കുവാൻ സാ
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr ""
-"നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -21778,8 +22010,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് "
-"ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് ക്ലിക്ക് "
+"ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -21787,22 +22019,21 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ "
-"ചെയ്യുക: https://duckduckgo.com"
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ ചെയ്യുക: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
 msgstr ""
-"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ "
-"പേജുകൾ%4$s തിരഞ്ഞെടുക്കുക"
+"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ പേജുകൾ%4$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: "
-"https://duckduckgo.com"
+"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21813,32 +22044,30 @@ msgstr "%1$sതിരയൽ ക്രമീകരണം%2$s എന്നതി�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
 msgstr ""
-"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s "
-"എന്നത് തിരഞ്ഞെടുക്കുക"
+"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s "
-"ക്ലിക്ക് ചെയ്യുക"
+"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
 msgstr ""
-"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ "
-"തുറക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ തുറക്കുക%2$s "
+"എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21916,8 +22145,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് "
-"പ്ലാനിനേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
+"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് പ്ലാനിനേക്കാൾ 2 മടങ്ങ് "
+"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21939,8 +22168,7 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും "
-"അൺലോക്ക് ചെയ്യുക"
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21962,12 +22190,16 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "നിങ്ങളുടെ സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് നൂതനമായ AI അൺലോക്ക് ചെയ്യുക!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് "
-"ചെയ്യുക"
+msgstr "DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -21975,9 +22207,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് "
-"ചെയ്യുക. %1$s"
+msgstr "DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് ചെയ്യുക. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22057,8 +22287,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് "
-"ചെയ്യാനും DuckDuckGo ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
+"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് ചെയ്യാനും DuckDuckGo "
+"ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22183,16 +22413,15 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
-"ചെയ്യുക, അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക, "
+"അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
-"ചെയ്യുക"
+"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22288,9 +22517,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, "
-"സ്കാമർമാരിൽ നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. "
-"വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
+"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, സ്കാമർമാരിൽ "
+"നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. "
+"സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22303,8 +22532,8 @@ msgstr "DuckDuckGo Private Search ഉപയോഗിക്കുക"
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
 msgstr ""
-"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private "
-"search ഉപയോഗിക്കുക!"
+"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private search "
+"ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22329,14 +22558,20 @@ msgid "Use in Safari"
 msgstr "Safari-ൽ ഉപയോഗിക്കുക"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ "
-"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
+"ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22344,8 +22579,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ "
-"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
+"ഉപയോഗിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -22495,8 +22730,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ "
-"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ ക്ലിക്കുകൾ "
+"നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22505,8 +22740,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ "
-"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ ക്ലിക്കുകൾ "
+"നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22518,8 +22753,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
-"%1$sAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sAssist "
+"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22528,8 +22763,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
-"%1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sDuckAssist "
+"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22538,8 +22773,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ "
-"നിർദേശങ്ങൾ പാലിക്കുക."
+"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ നിർദേശങ്ങൾ "
+"പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22554,9 +22789,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > "
-"%3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & "
+"Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22566,10 +22801,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
-"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
-"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & "
+"Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" "
+"തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22579,10 +22813,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, "
-"%1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് "
-"ചെയ്യുക%6$s എന്നിടത്ത് %7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s "
-"തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, %1$sDuck.ai "
+"ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നിടത്ത് "
+"%7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22592,10 +22825,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai "
-"ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" "
-"തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. "
-"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
+"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22648,8 +22880,8 @@ msgstr "വോയ്സ് ചാറ്റ് അവസാനിച്ചു"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിച്ചിട്ടില്ല."
+"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിച്ചിട്ടില്ല."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22793,9 +23025,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച "
-"പ്രവർത്തനത്തെ YouTube ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck "
-"Player-ൽ കാണുക."
+"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച പ്രവർത്തനത്തെ YouTube "
+"ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck Player-ൽ കാണുക."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22815,11 +23046,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന "
-"വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ "
-"നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. DuckDuckGo ഒരു സ്വതന്ത്ര "
-"കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി യാതൊരു "
-"ബന്ധവുമില്ല."
+"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് "
+"ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. "
+"DuckDuckGo ഒരു സ്വതന്ത്ര കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി "
+"യാതൊരു ബന്ധവുമില്ല."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22832,8 +23062,8 @@ msgstr "ഞങ്ങൾ അജ്ഞാതമാക്കുന്നു"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ "
-"ലൊക്കേഷൻ%2$s അജ്ഞാതമാക്കാൻ കഴിയും."
+"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ ലൊക്കേഷൻ%2$s "
+"അജ്ഞാതമാക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22845,10 +23075,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
-"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി "
-"പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ "
-"കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
+"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി പങ്കിടുക, അതുവഴി "
+"ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22860,18 +23089,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
-"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും "
-"പ്രതികരണവും പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ "
-"കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
+"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രതികരണവും പങ്കിടുക, അതുവഴി "
+"ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s "
-"ലൊക്കേഷൻ%2$s ഉപയോഗിക്കാനാകും."
+"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s ലൊക്കേഷൻ%2$s "
+"ഉപയോഗിക്കാനാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -22879,8 +23107,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ "
-"ഞങ്ങൾക്ക് അവ വായിക്കാൻ കഴിയില്ല."
+"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ ഞങ്ങൾക്ക് അവ "
+"വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22891,16 +23119,13 @@ msgstr "പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്�
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ "
-"സംഭരിക്കുന്നില്ല."
+msgstr "ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ സംഭരിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ "
-"ഇല്ല. എപ്പോഴും."
+"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ ഇല്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22912,8 +23137,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ "
-"നിങ്ങളെ പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്ങളെ "
+"പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22927,9 +23152,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ "
-"കൊണ്ടുവന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് "
-"ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ടുവന്നത് എന്താണെന്ന് "
+"ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22938,9 +23162,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ "
-"നിങ്ങൾക്ക് ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം "
-"ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ നിങ്ങൾക്ക് "
+"ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22951,9 +23174,7 @@ msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ "
-"നയം."
+msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ നയം."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22982,8 +23203,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ "
-"ഉടനീളം പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
+"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ ഉടനീളം "
+"പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23009,8 +23230,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് "
-"ഉറപ്പാക്കാൻ എല്ലാ AI ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
+"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് ഉറപ്പാക്കാൻ എല്ലാ AI "
+"ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23027,9 +23248,7 @@ msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെ�
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ "
-"ശ്രമിക്കൂ."
+msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23037,8 +23256,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന "
-"തിരയൽ പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
+"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന തിരയൽ "
+"പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23047,24 +23266,20 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത "
-"ലൊക്കേഷൻ ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് "
-"മാറ്റാൻ കഴിയും."
+"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ലൊക്കേഷൻ "
+"ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ "
-"ആശ്രയിക്കുന്നു."
+"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ ആശ്രയിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ "
-"തടയുന്നു."
+msgstr "ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23080,16 +23295,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് "
-"ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ "
-"സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം ദൃശ്യമാകണമെന്നില്ല."
+"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ "
+"വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം "
+"ദൃശ്യമാകണമെന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന "
-"ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
+"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23099,8 +23313,8 @@ msgid ""
 "continue to see this error, please reach out to %s."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, "
-"ദയവായി %1$s-നെ സമീപിക്കുക."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, ദയവായി %1$s-നെ "
+"സമീപിക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23110,8 +23324,7 @@ msgid ""
 "clearing your browser's cache can help."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ "
-"മായ്ക്കുന്നത് സഹായിക്കാം."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ മായ്ക്കുന്നത് സഹായിക്കാം."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23126,8 +23339,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ "
-"ഞങ്ങൾ കഠിനമായി പരിശ്രമിക്കുന്നു."
+"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ ഞങ്ങൾ കഠിനമായി "
+"പരിശ്രമിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23136,8 +23349,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് "
-"വീണ്ടും ലോഡ് ചെയ്യേണ്ടതുണ്ട്."
+"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് വീണ്ടും ലോഡ് "
+"ചെയ്യേണ്ടതുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23245,9 +23458,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23261,9 +23472,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
-"സ്വകാര്യമാണ്, അവ ഞങ്ങൾ അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കുന്നില്ല."
+"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഞങ്ങൾ "
+"അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23272,9 +23482,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
-"സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ "
+"ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ "
+"ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23284,17 +23494,16 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s "
-"ആണ്. ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും "
-"DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s ആണ്. "
+"ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ "
-"ഇംപോർട്ട് ചെയ്യാം."
+"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23362,8 +23571,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു "
-"പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
+"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. "
+"പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23378,8 +23587,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും "
-"പ്രതിവാദങ്ങളും എന്തൊക്കെയാണ്?"
+"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും പ്രതിവാദങ്ങളും "
+"എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -23400,8 +23609,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' "
-"എന്ന വാക്കിനുള്ള ചില ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
+"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' എന്ന വാക്കിനുള്ള ചില "
+"ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23420,12 +23629,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് "
-"ചെയ്യുന്നതിന്റെ പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ "
-"മാത്രം അവലംബിക്കുന്നു. Duck.ai സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും "
-"ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് പ്രതികരണത്തെ വ്യക്തമായ "
-"വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം കൂടുതലുള്ളവർക്കും "
-"ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
+"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് ചെയ്യുന്നതിന്റെ "
+"പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ മാത്രം അവലംബിക്കുന്നു. Duck.ai "
+"സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് "
+"പ്രതികരണത്തെ വ്യക്തമായ വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം "
+"കൂടുതലുള്ളവർക്കും ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23511,8 +23719,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
-"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ "
-"എന്തൊക്കെയാണ്?"
+"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23537,6 +23744,12 @@ msgstr "നിങ്ങളെ ഏറ്റവും അലട്ടിയ കാ
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ടുവന്നത് എന്താണ്?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23657,8 +23870,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ "
-"ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
+"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ "
+"വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23734,8 +23947,7 @@ msgstr "നിങ്ങൾ എന്തിനെക്കുറിച്ചാ�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
-"സ്വാധീനിക്കില്ല."
+"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23761,8 +23973,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ "
-"പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
+"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന "
+"ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23786,8 +23998,7 @@ msgstr "<strong>%1$s</strong> എവിടെ കാണാം"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
 msgstr ""
-"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s "
-"എന്നത് ക്ലിക്ക് ചെയ്യുക."
+"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23828,8 +24039,7 @@ msgstr "ആരാണ് ഞങ്ങൾ"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
-"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് "
-"അറിയപ്പെടുന്നത്?"
+"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് അറിയപ്പെടുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23959,6 +24169,14 @@ msgstr "വിജയങ്ങൾ"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "വിന്ററി മിക്സ്"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24213,8 +24431,7 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് "
-"വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24234,8 +24451,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
-"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24244,8 +24461,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ "
-"DuckDuckGo-യിൽ നിന്ന് മറ്റ് തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
+"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ DuckDuckGo-യിൽ നിന്ന് മറ്റ് "
+"തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24259,8 +24476,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ "
-"ക്രമീകരണങ്ങൾ%3$s-ൽ എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
+"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ ക്രമീകരണങ്ങൾ%3$s-ൽ "
+"എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24269,22 +24486,21 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ "
-"ക്രമീകരണങ്ങൾ%2$s-ൽ അത് എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
+"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s-ൽ അത് "
+"എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s "
-"ഉപയോഗിക്കാം."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI "
-"Chat%2$s ഉപയോഗിക്കാനും കഴിയും."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI Chat%2$s "
+"ഉപയോഗിക്കാനും കഴിയും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24298,8 +24514,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist "
-"കാണണമെന്നത് മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
+"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist കാണണമെന്നത് "
+"മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24320,8 +24536,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു "
-"പാസ്‌ഫ്രെയ്സിന് കീഴിൽ സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
+"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു പാസ്‌ഫ്രെയ്സിന് കീഴിൽ "
+"സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24351,8 +24567,7 @@ msgstr "നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉ
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് "
-"തുടർന്നോളൂ!"
+"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് തുടർന്നോളൂ!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24391,6 +24606,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "ഓരോ സംഭാഷണത്തിനും നിങ്ങൾക്ക് %1$s ഇമേജുകൾ മാത്രമേ അറ്റാച്ച് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24409,8 +24631,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം "
-"മറ്റൊരു സൈറ്റ് അൺബ്ലോക്ക് ചെയ്യണം."
+"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം മറ്റൊരു സൈറ്റ് "
+"അൺബ്ലോക്ക് ചെയ്യണം."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24446,9 +24668,7 @@ msgstr "നിങ്ങൾക്ക് ഈ പുതിയ ഡൊമെയ്ന
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ "
-"സൂക്ഷിക്കാം."
+msgstr "പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ സൂക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -24469,8 +24689,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, "
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
+"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, Plus-നേക്കാൾ 2 മടങ്ങ് "
+"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24479,9 +24699,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് "
-"DuckDuckGo ബ്രൗസറിൽ VPN, മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് "
-"ചെയ്യാം."
+"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് DuckDuckGo ബ്രൗസറിൽ VPN, "
+"മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24503,9 +24722,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് "
-"ചെയ്യാൻ കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. "
-"ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന "
+"30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് "
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24515,9 +24734,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ "
-"കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് "
-"എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന 30 "
+"ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ "
+"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24531,8 +24750,14 @@ msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
 msgstr ""
-"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo "
-"ആപ്പ് അപ്ഡേറ്റുകൾ ലഭിക്കും."
+"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo ആപ്പ് അപ്ഡേറ്റുകൾ "
+"ലഭിക്കും."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24541,9 +24766,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് "
-"ചെയ്യുന്നതിന് Chrome-ന് പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം "
-"ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് ചെയ്യുന്നതിന് Chrome-ന് "
+"പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24556,8 +24780,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും "
-"കുറയ്ക്കുന്നതിന് നുറുങ്ങുകൾ നേടുക."
+"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും കുറയ്ക്കുന്നതിന് "
+"നുറുങ്ങുകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24583,6 +24807,12 @@ msgid "You've blocked 1 site"
 msgstr "നിങ്ങൾ 1 സൈറ്റ് ബ്ലോക്ക് ചെയ്തു"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24601,8 +24831,8 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. "
-"ദയവായി വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. ദയവായി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24629,9 +24859,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം "
-"തീർന്നു. സമന്വയം പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ "
-"ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം തീർന്നു. സമന്വയം "
+"പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24642,8 +24871,8 @@ msgid ""
 "deleted."
 msgstr ""
 "Duck.ai ചാറ്റുകൾക്കുള്ള Sync & Backup സ്റ്റോറേജ് തീർന്നിരിക്കുന്നു. സമന്വയം "
-"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ "
-"ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത "
+"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24657,9 +24886,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ "
-"അനുവദിക്കുന്നില്ല. അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് "
-"YouTube/Google ട്രാക്ക് ചെയ്യും."
+"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ അനുവദിക്കുന്നില്ല. "
+"അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് YouTube/Google ട്രാക്ക് ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24703,9 +24931,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
-"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"%1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
+"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
+"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24715,9 +24943,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
-"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
+"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ 100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
+"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24733,9 +24961,7 @@ msgstr "നിങ്ങൾ ഈ ലിങ്ക് സന്ദർശിച്ച
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
-"നൽകുന്നു."
+msgstr "നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -24744,8 +24970,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
-"നൽകുന്നു. DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു. DuckDuckGo-"
+"യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -24753,8 +24979,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. "
-"DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. DuckDuckGo-യ്ക്ക് "
+"ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24763,8 +24989,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
-"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24777,16 +25003,15 @@ msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോൾ 
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഒരിക്കലും സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിക്കില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24812,8 +25037,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24821,8 +25046,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24837,9 +25062,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് "
-"അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ പാലിക്കൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ "
+"പാലിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24848,8 +25073,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി "
-"Duck.ai-ൽ നിർത്തിയിടത്ത് നിന്ന് തുടരൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി Duck.ai-ൽ നിർത്തിയിടത്ത് "
+"നിന്ന് തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24897,8 +25122,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല."
+"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24927,11 +25152,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് "
-"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ "
-"ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ "
-"ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-യ്ക്ക് "
-"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
+"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് "
+"ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ "
+"ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-"
+"യ്ക്ക് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24946,10 +25170,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി "
-"തിരിച്ചറിയാൻ കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ "
-"ദാതാക്കൾക്ക് നിങ്ങളുടെ സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ "
-"കഴിയില്ല."
+"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി തിരിച്ചറിയാൻ "
+"കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ ദാതാക്കൾക്ക് നിങ്ങളുടെ "
+"സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24963,8 +25186,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ "
-"പരിശോധിക്കാനോ എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ പരിശോധിക്കാനോ "
+"എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -24990,15 +25213,23 @@ msgid "Your searches can’t be tied back to you"
 msgstr "നിന്റെ തിരയലുകൾ നിന്നുമായി ബന്ധിപ്പിക്കാൻ കഴിയില്ല"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
-"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
-"ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ അറിയുക%4$s"
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
+"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ "
+"അറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25018,9 +25249,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി "
-"Chrome-ന് പകരം ഞങ്ങളുടെ ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ "
-"ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി Chrome-ന് പകരം ഞങ്ങളുടെ "
+"ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25029,8 +25259,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം "
-"ചുരുക്കി വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം ചുരുക്കി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25039,8 +25269,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button "
-"ഉപയോഗിച്ച് ഈ സംഭാഷണം മായ്ക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button ഉപയോഗിച്ച് ഈ "
+"സംഭാഷണം മായ്ക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25049,8 +25279,7 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ "
-"ചാറ്റ് ആരംഭിക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25065,8 +25294,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി "
-"നാളെ ഈ ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി നാളെ ഈ ചാറ്റ് "
+"തുടരുക."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25369,8 +25598,8 @@ msgstr "ഔദ്യോഗിക വെബ്സൈറ്റ്"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു "
-"എന്‍കോഡ് ചെയ്ത %3$s പ്രതീകം ആണ്)."
+"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു എന്‍കോഡ് ചെയ്ത %3$s "
+"പ്രതീകം ആണ്)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25581,3 +25810,9 @@ msgstr "വർഷങ്ങൾ"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "വർഷം"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/mn_MN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mn_MN/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4013,6 +4055,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4067,6 +4114,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4104,6 +4156,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4200,6 +4257,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4234,6 +4296,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4359,6 +4428,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4595,9 +4669,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4625,6 +4709,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4878,6 +4967,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5044,6 +5138,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5219,6 +5318,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5326,6 +5430,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5814,6 +5923,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6053,6 +6167,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6186,6 +6305,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6267,6 +6396,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6596,6 +6730,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7017,6 +7156,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7046,6 +7190,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7062,6 +7216,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7613,6 +7772,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8908,6 +9072,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8963,6 +9133,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9859,6 +10034,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10253,6 +10433,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10801,6 +10986,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr ""
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10969,6 +11159,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11565,9 +11760,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11582,6 +11787,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11838,6 +12048,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12007,6 +12222,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12449,6 +12669,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12476,6 +12706,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12598,6 +12833,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12900,6 +13140,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12908,6 +13153,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13465,6 +13715,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13745,6 +14000,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14142,6 +14402,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14194,6 +14459,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14223,6 +14498,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14271,6 +14552,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14382,6 +14668,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14506,6 +14797,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14534,6 +14830,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14832,6 +15133,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15064,6 +15370,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15542,6 +15853,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15654,6 +15972,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15723,6 +16046,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16092,9 +16429,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16195,6 +16542,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16451,6 +16812,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16788,8 +17154,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16844,6 +17220,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16854,6 +17235,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16876,6 +17262,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17076,6 +17467,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17360,6 +17756,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17655,6 +18056,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18568,6 +18974,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18907,6 +19318,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19251,6 +19669,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19359,6 +19783,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19393,6 +19822,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19690,6 +20124,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20162,4 +20603,9 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""

--- a/locales/mr_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mr_IN/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3675,6 +3707,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3710,6 +3747,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4016,6 +4058,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4070,6 +4117,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4107,6 +4159,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4203,6 +4260,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4237,6 +4299,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4362,6 +4431,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4598,9 +4672,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4628,6 +4712,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4881,6 +4970,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5047,6 +5141,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5222,6 +5321,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5329,6 +5433,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5825,6 +5934,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6064,6 +6178,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6197,6 +6316,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6278,6 +6407,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6607,6 +6741,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7028,6 +7167,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7057,6 +7201,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7073,6 +7227,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7624,6 +7783,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8920,6 +9084,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8975,6 +9145,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9871,6 +10046,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10265,6 +10445,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10813,6 +10998,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "चालू, पण संख्या नाहीत."
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10981,6 +11171,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11577,9 +11772,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11594,6 +11799,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11850,6 +12060,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12019,6 +12234,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12461,6 +12681,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12488,6 +12718,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12610,6 +12845,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12912,6 +13152,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12920,6 +13165,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13477,6 +13727,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13759,6 +14014,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14156,6 +14416,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "स्वगृह म्हणून स्थापित करा"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14208,6 +14473,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14237,6 +14512,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14285,6 +14566,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14396,6 +14682,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14520,6 +14811,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14548,6 +14844,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14846,6 +15147,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15078,6 +15384,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15556,6 +15867,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15668,6 +15986,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15737,6 +16060,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16106,9 +16443,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16209,6 +16556,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16465,6 +16826,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16802,8 +17168,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16858,6 +17234,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16868,6 +17249,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16890,6 +17276,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17090,6 +17481,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17374,6 +17770,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17669,6 +18070,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18582,6 +18988,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18921,6 +19332,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19265,6 +19683,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19373,6 +19797,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19407,6 +19836,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19704,6 +20138,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20178,6 +20619,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/ms_MY/LC_MESSAGES/duckduckgo.po
+++ b/locales/ms_MY/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3081,6 +3108,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3682,6 +3714,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3717,6 +3754,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4024,6 +4066,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4078,6 +4125,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4115,6 +4167,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4211,6 +4268,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4245,6 +4307,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4370,6 +4439,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4606,9 +4680,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4636,6 +4720,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4889,6 +4978,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5055,6 +5149,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5230,6 +5329,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5337,6 +5441,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5825,6 +5934,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6064,6 +6178,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6197,6 +6316,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6278,6 +6407,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6610,6 +6744,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7031,6 +7170,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7060,6 +7204,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7077,6 +7231,11 @@ msgstr "Dapatkan lagu ini di:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Ajak kenalan anda untuk beralih dan membantu kami berkembang!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7627,6 +7786,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8927,6 +9091,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8982,6 +9152,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9879,6 +10054,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10273,6 +10453,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10825,6 +11010,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Hidup tetapi tiada nombor"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10995,6 +11185,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11591,9 +11786,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11608,6 +11813,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11864,6 +12074,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12033,6 +12248,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12475,6 +12695,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12502,6 +12732,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12624,6 +12859,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12926,6 +13166,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Atur Balik Semua Tetapan"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12934,6 +13179,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13491,6 +13741,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13773,6 +14028,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14174,6 +14434,11 @@ msgstr "Setkan sebagai Enjin Carian Lalai"
 msgid "Set as Homepage"
 msgstr "Tetapkan sebagai Laman Utama"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14226,6 +14491,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14255,6 +14530,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14303,6 +14584,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14414,6 +14700,11 @@ msgstr "Tunjukkan Penanda Buku and Butiran Tetapan"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14538,6 +14829,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14566,6 +14862,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14864,6 +15165,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15096,6 +15402,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15574,6 +15885,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15686,6 +16004,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15756,6 +16079,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Dapatkan Hak Privasi Anda!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16124,9 +16461,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16227,6 +16574,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16483,6 +16844,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16820,9 +17186,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Cuba satu carian!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16876,6 +17252,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16886,6 +17267,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16909,6 +17295,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Cuba halaman utama kami yang tidak pernah menunjukkan mesej ini:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17108,6 +17499,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17398,6 +17794,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17694,6 +18095,11 @@ msgstr ""
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Guna dalam pelayar Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18606,6 +19012,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18945,6 +19356,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19291,6 +19709,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19399,6 +19823,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19433,6 +19862,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19733,6 +20167,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20207,6 +20648,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "attribution"

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "%1$s dager siden"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s identifisert"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +361,12 @@ msgid "%s used"
 msgstr "%1$s brukt"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s visning"
@@ -473,7 +485,8 @@ msgstr "%1$sFinn ut hvordan du kan holde lokasjonen din privat%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
+msgstr ""
+"%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -598,6 +611,12 @@ msgstr "1 forsøk blokkert av DuckDuckGo i løpet av de siste 24 timene"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 dag siden"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -818,7 +837,8 @@ msgstr "6 timers bruksgrense er nådd."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1510,6 +1530,14 @@ msgid "Advanced Models"
 msgstr "Avanserte modeller"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Annonser på Søk"
@@ -1720,7 +1748,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
+msgstr ""
+"Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1767,7 +1796,8 @@ msgstr "Tillat"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
+msgstr ""
+"Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1789,7 +1819,8 @@ msgstr "Vil du tillate anonym gjennomgang av filer i denne chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
+msgstr ""
+"Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2121,7 +2152,8 @@ msgstr "Er du der fortsatt?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
+msgstr ""
+"Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2291,6 +2323,12 @@ msgid "Ask privately"
 msgstr "Spør privat"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2341,12 +2379,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere "
-"KI-assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner "
-"den nettet etter relevant innhold, og bruker deretter KI-drevet naturlig "
-"språk-teknologi til å generere et kort svar basert på relevant informasjon "
-"den har funnet. Det er viktig å huske at svarene genereres automatisk fra "
-"siterte kilder og er basert på %1$sgjennomsøking av nettet%2$s."
+"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere KI-"
+"assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner den "
+"nettet etter relevant innhold, og bruker deretter KI-drevet naturlig språk-"
+"teknologi til å generere et kort svar basert på relevant informasjon den har "
+"funnet. Det er viktig å huske at svarene genereres automatisk fra siterte "
+"kilder og er basert på %1$sgjennomsøking av nettet%2$s."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2437,7 +2475,8 @@ msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er avsluttet."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
+msgstr ""
+"Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2484,7 +2523,8 @@ msgstr "Autogenerert basert på oppførte kilder. Kan inneholde unøyaktigheter.
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
+msgstr ""
+"Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -3114,8 +3154,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Bruk nettleseren som vanlig, så legger vi til personvernbeskyttelse. Vi har "
-"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én "
-"%1$s%2$s-utvidelse%3$s."
+"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én %1$s%2$s-"
+"utvidelse%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3750,8 +3790,8 @@ msgid ""
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
 "Med chatten (via Duck.ai-tjenesten vår) kan du ha anonyme samtaler med "
-"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic "
-"m.m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
+"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic m."
+"m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
 "DuckDuckGo Search. Men du kan likevel få tilgang til chatten når denne "
 "innstillingen er av, ved å gå til %1$shttps.://duck.ai%2$s direkte."
 
@@ -3808,7 +3848,8 @@ msgstr "Chat privat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
+msgstr ""
+"Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3830,6 +3871,12 @@ msgstr "Chat privat med %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Chat privat med AI"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4373,7 +4420,8 @@ msgstr "Klikk %1$sher%2$s for å laste ned DuckDuckGo-utvidelsen"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
+msgstr ""
+"Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4406,7 +4454,8 @@ msgstr "Klikk på %1$sInnstillinger%2$s i nedtrekksmenyen."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
+msgstr ""
+"Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4619,6 +4668,12 @@ msgid "Close"
 msgstr "Lukk"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4661,6 +4716,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Lukk søket"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5034,6 +5095,12 @@ msgid "Continue Blocking Ads"
 msgstr "Fortsett å blokkere annonser"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5099,6 +5166,12 @@ msgid "Cookie data:"
 msgstr "Informasjonskapseldata:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5144,6 +5217,12 @@ msgstr "Kopier og lim inn %1$sabout:preferences#search%2$s i adresselinjen"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopier koden"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5259,6 +5338,12 @@ msgid "Create Image"
 msgstr "Lag bilde"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5300,6 +5385,14 @@ msgstr "Opprettet av"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Skapt av %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5453,6 +5546,12 @@ msgstr "Tilpass svar"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Tilpass svar"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5739,10 +5838,22 @@ msgid "Delete Server Data?"
 msgstr "Vil du slette serverdata?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Slett utskrift"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5777,6 +5888,12 @@ msgid "Delete image?"
 msgstr "Vil du slette bildet?"
 
 # smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats to free up storage?"
@@ -5786,7 +5903,8 @@ msgstr "Vil du slette de eldste chattene for å frigjøre lagringsplass?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
+msgstr ""
+"Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5810,7 +5928,8 @@ msgstr "Slettede chatter"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
+msgstr ""
+"Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -5900,7 +6019,8 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
+msgstr ""
+"Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6083,6 +6203,12 @@ msgid "Dismiss promotion"
 msgstr "Avvis kampanje"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6235,8 +6361,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten "
-"AI-funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
+"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten AI-"
+"funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6291,6 +6417,12 @@ msgstr "Nedlastingen er fullført"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Last ned DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6508,6 +6640,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai fra DuckDuckGo. Privat AI-chat. Gratis."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6626,8 +6764,8 @@ msgstr ""
 "Med Duck.ai kan du ha anonyme samtaler med tredjeparts AI-chatmodeller, som "
 "OpenAI, Anthropic og andre. Hvis du slår av denne innstillingen, skjules "
 "Duck.ai-knapper og -lenker på DuckDuckGo Search. Men du kan likevel få "
-"tilgang til Duck.ai når denne innstillingen er av, ved å gå til "
-"%1$shttps://duck.ai%2$s direkte."
+"tilgang til Duck.ai når denne innstillingen er av, ved å gå til %1$shttps://"
+"duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6659,6 +6797,12 @@ msgid ""
 msgstr ""
 "Svarene fra Duck.ai er ikke basert på spesifikke kilder eller kontrollert om "
 "de er korrekte."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6985,8 +7129,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du "
-"Duck.ai's %2$s."
+"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du Duck."
+"ai's %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7076,7 +7220,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
+msgstr ""
+"DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7301,6 +7446,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Aktiver Mest besøkte sider"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7348,7 +7499,8 @@ msgstr "Aktiver diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
+msgstr ""
+"Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7598,6 +7750,12 @@ msgid "Entertainment guide"
 msgstr "Underholdningsguide"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Ekvatorial-Guinea"
 
@@ -7761,6 +7919,18 @@ msgid "Explicit lyrics"
 msgstr "Eksplisitte sangtekster"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7860,6 +8030,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Gratis"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8022,7 +8198,8 @@ msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
+msgstr ""
+"Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8108,7 +8285,8 @@ msgstr "Søk nærmere der du er."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
+msgstr ""
+"Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8275,6 +8453,12 @@ msgid "Free Up Storage"
 msgstr "Frigjør lagringsplass"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8314,7 +8498,8 @@ msgstr "Kan deles og brukes kommersielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
+msgstr ""
+"Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8787,6 +8972,12 @@ msgid "Get computer help"
 msgstr "Få datamaskinhjelp"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8824,6 +9015,18 @@ msgid "Get the Latest Version"
 msgstr "Få den siste versjonen"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8844,6 +9047,12 @@ msgstr "Skaff deg denne sangen på:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Få vennene dine til å bytte, og hjelp oss å vokse!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9530,6 +9739,12 @@ msgid "Hide Tips"
 msgstr "Skjul tips"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -10049,8 +10264,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt "
-"chat-svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
+"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt chat-"
+"svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -11149,6 +11364,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Lar deg søke anonymt med DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11219,6 +11441,12 @@ msgid "Lineouts Won"
 msgstr "Antall lineouts vunnet"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Skrifttype for lenke:"
@@ -11232,7 +11460,8 @@ msgstr "Lenker:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
+msgstr ""
+"Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11343,7 +11572,8 @@ msgstr "Laster flere bilderesultater når du ruller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
+msgstr ""
+"Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12100,7 +12330,8 @@ msgstr "Månedlig grense er nådd"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12307,6 +12538,12 @@ msgstr "Mer statistikk om %1$s"
 msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Mer enn 20 minutter"
+
+# smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12795,6 +13032,12 @@ msgstr "Nei takk"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Nei takk"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13459,6 +13702,12 @@ msgid "On but no numbers"
 msgstr "På, men ingen tall"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13500,8 +13749,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"Bare innstillingene du har endret. De er spesifisert på siden "
-"%1$sURL-parameter%2$s."
+"Bare innstillingene du har endret. De er spesifisert på siden %1$sURL-"
+"parameter%2$s."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13669,6 +13918,12 @@ msgstr "Åpne forslag til chatter"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Åpne forslag for å lage og redigere bilder"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14417,10 +14672,22 @@ msgid "Pin"
 msgstr "Fest"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Fest chatter her fra %1$s-%2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14438,6 +14705,12 @@ msgstr "Rosa"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Festede"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14755,6 +15028,12 @@ msgid "Poor formatting"
 msgstr "Dårlig formatering"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14961,6 +15240,12 @@ msgstr "Forrige bilde"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Forrige faner"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15255,7 +15540,8 @@ msgstr "Spør meg"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
+msgstr ""
+"Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15501,6 +15787,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Resonnerende KI med innebygd middels moderering"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15536,14 +15834,20 @@ msgid "Recent chat storage can be adjusted in %s."
 msgstr "Lagring av nylige chatter kan justeres i %1$s."
 
 # smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
 msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter som lagres lokalt på enheten din, i stedet for på "
-"DuckDuckGo-servere eller andre eksterne servere."
+"Nylige chatter som lagres lokalt på enheten din, i stedet for på DuckDuckGo-"
+"servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15552,8 +15856,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter lagres lokalt på enheten din i stedet for på "
-"DuckDuckGo-servere eller andre eksterne servere."
+"Nylige chatter lagres lokalt på enheten din i stedet for på DuckDuckGo-"
+"servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15688,6 +15992,12 @@ msgstr "Søk på nytt uten dette nettstedet"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Reduser bruken"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16065,6 +16375,12 @@ msgid "Reset All Settings"
 msgstr "Nullstill alle innstillinger"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16075,6 +16391,12 @@ msgstr "Tilbakestilles om %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Oppløsning"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16565,7 +16887,8 @@ msgstr "Lagre opptil 30 av de siste chattene lokalt på enheten din."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
+msgstr ""
+"Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16748,7 +17071,8 @@ msgstr "Rull ned til %1$sDuckDuckGo%2$s og la den bruke posisjonen din."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
+msgstr ""
+"Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16771,6 +17095,12 @@ msgstr "Søk"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Vil du søke etter %1$s for å finne resultater nærmere deg?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16972,8 +17302,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke "
-"POST-forespørsler)"
+"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke POST-"
+"forespørsler)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17092,8 +17422,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
-"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
+"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17102,8 +17432,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
-"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
+"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17141,6 +17471,12 @@ msgid ""
 msgstr ""
 "Sikker lagring på DuckDuckGos server med ende-til-ende-kryptering. Ingen kan "
 "se dataene dine, ikke vi engang."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17251,7 +17587,8 @@ msgstr "Se noen av våre nyeste oppdateringer"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
+msgstr ""
+"Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17405,7 +17742,8 @@ msgstr "Velg %1$sInnstillinger%2$s fra nedtrekksmenyen."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
+msgstr ""
+"Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17433,7 +17771,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
+msgstr ""
+"Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17649,6 +17988,12 @@ msgid "Set as Homepage"
 msgstr "Sett som startside"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17716,6 +18061,18 @@ msgid "Seychelles"
 msgstr "Seychellene"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17752,8 +18109,15 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Del plassering så nær som nærmeste by med AI-modeller for å forbedre "
-"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller "
-"AI-modeller."
+"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller AI-"
+"modeller."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17812,6 +18176,12 @@ msgstr "Del sidens nettadresse"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Del positive tilbakemeldinger"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17947,6 +18317,12 @@ msgstr "Vis bokmerkeapplikasjons- og innstillingsdata"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Vis detaljer"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18096,6 +18472,12 @@ msgid "Show more"
 msgstr "Vis mer"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18129,6 +18511,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Vis sidefeltet"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18223,12 +18611,14 @@ msgstr "Viser de mest besøkte lenkene på ny fane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
+msgstr ""
+"Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
+msgstr ""
+"Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18505,6 +18895,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Noe gikk galt, prøv igjen senere."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18520,7 +18916,8 @@ msgstr "Noen ganger"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
+msgstr ""
+"Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18594,7 +18991,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
+msgstr ""
+"Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18648,7 +19046,8 @@ msgstr "Kildetekst fjernet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
+msgstr ""
+"Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18797,6 +19196,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Begynn å bruke ukentlig grense"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Begynn å søke!"
@@ -18847,7 +19252,8 @@ msgstr "Bli på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
+msgstr ""
+"Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19375,6 +19781,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Bytt til søkemotoren som ikke sporer deg. Noensinne."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19441,7 +19855,8 @@ msgstr "Sync & Backup er aktivert!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
+msgstr ""
+"Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19490,9 +19905,9 @@ msgid ""
 msgstr ""
 "Synkroniseringsgjenopprettingskode\n"
 "\n"
-"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og "
-"Duck.ai-chatter på tvers av flere enheter, og gjenopprette synkroniserte "
-"data hvis du mister tilgangen til en enhet.\n"
+"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og Duck.ai-"
+"chatter på tvers av flere enheter, og gjenopprette synkroniserte data hvis "
+"du mister tilgangen til en enhet.\n"
 "\n"
 "Ta godt vare på denne informasjonen.\n"
 "Alle som har tilgang til denne koden kan få tilgang til de synkroniserte "
@@ -19527,6 +19942,12 @@ msgstr "Synkroniser med en annen enhet"
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sync & Backup er midlertidig utilgjengelig"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19614,6 +20035,22 @@ msgstr "Tadsjikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Ta tilbake personvernet ditt!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19882,7 +20319,8 @@ msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
+msgstr ""
+"De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -19904,7 +20342,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
+msgstr ""
+"Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20073,7 +20512,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
+msgstr ""
+"Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20082,10 +20522,22 @@ msgid "This Month"
 msgstr "Denne måneden"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Denne uken"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20094,9 +20546,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss "
-"%3$s-modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s "
-"for mer informasjon)."
+"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss %3$s-"
+"modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s for mer "
+"informasjon)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20201,19 +20653,37 @@ msgstr "Dette bildet kunne ikke opprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
+msgstr ""
+"Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
+msgstr ""
+"Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Denne informasjonen er ikke nyttig"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20330,7 +20800,8 @@ msgstr "Denne oversettelsen er feil"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
+msgstr ""
+"Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20521,8 +20992,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"For å overføre chat-historikken din til Duck.ai, oppdater "
-"DuckDuckGo-nettleseren din til den nyeste versjonen og prøv igjen."
+"For å overføre chat-historikken din til Duck.ai, oppdater DuckDuckGo-"
+"nettleseren din til den nyeste versjonen og prøv igjen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20548,6 +21019,12 @@ msgstr "I dag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "I dag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20961,9 +21438,21 @@ msgid "Try Them Out"
 msgstr "Prøv dem"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Prøv et søk!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21030,6 +21519,12 @@ msgid "Try for free"
 msgstr "Prøv gratis"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21042,6 +21537,12 @@ msgstr "Prøv gratis"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "Prøv gratis! En sikker VPN, avansert og privat AI m.m."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21069,6 +21570,12 @@ msgstr "Prøv nettleseren vår,"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Prøv hjemmesiden vår som aldri viser disse beskjedene:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21320,6 +21827,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Slå på Duck Player for å se på YouTube uten målrettede annonser"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21533,8 +22046,8 @@ msgstr "Under %1$sÅpne med%2$s velger du %3$sEn spesifikk side eller sider%4$s"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: "
-"https://duckduckgo.com"
+"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21556,7 +22069,8 @@ msgstr "Under %1$sSøke%2$sseksjon trykker du på %3$sBehandle søkemotorer …%
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
+msgstr ""
+"Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21663,8 +22177,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Få tilgang til avanserte AI-modeller og høyere grenser med et "
-"DuckDuckGo-abonnement"
+"Få tilgang til avanserte AI-modeller og høyere grenser med et DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21684,6 +22198,12 @@ msgstr "Få tilgang til avanserte AI-modeller med et DuckDuckGo-abonnement"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Få tilgang til avansert AI med abonnementet ditt!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22047,6 +22567,12 @@ msgid "Use in Safari"
 msgstr "Bruk i Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22272,9 +22798,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Gå til Duck.ai i den andre nettleseren din og så til "
-"%1$sDuck.ai-innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. "
-"Velg deretter %7$sSynkroniser med en annen enhet%8$s."
+"Gå til Duck.ai i den andre nettleseren din og så til %1$sDuck.ai-"
+"innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. Velg "
+"deretter %7$sSynkroniser med en annen enhet%8$s."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22310,8 +22836,8 @@ msgid ""
 msgstr ""
 "Gå til Duck.ai i nettleseren din eller i DuckDuckGo-appen, og åpne "
 "innstillingene for Duck.ai. Velg «Slå på» under Sync & Backup og velg "
-"«Synkroniser med en annen enhet». Eller skann QR-koden på "
-"gjenopprettings-PDF-en din."
+"«Synkroniser med en annen enhet». Eller skann QR-koden på gjenopprettings-"
+"PDF-en din."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22363,7 +22889,8 @@ msgstr "Talechatten er avsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
+msgstr ""
+"Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22599,7 +23126,8 @@ msgstr "Vi følger ikke etter deg med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
+msgstr ""
+"Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22759,7 +23287,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
+msgstr ""
+"Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22782,7 +23311,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
+msgstr ""
+"Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22816,7 +23346,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
+msgstr ""
+"Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22926,7 +23457,8 @@ msgstr "Ukentlig bruksgrense er nådd"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -22979,13 +23511,15 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
+msgstr ""
+"Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
+msgstr ""
+"Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23221,6 +23755,12 @@ msgstr "Hva plaget deg mest?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Hva førte deg tilbake i dag?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23641,6 +24181,14 @@ msgid "Wintry Mix"
 msgstr "Sludd"
 
 # smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -23892,7 +24440,8 @@ msgstr "Ja, ny bruker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
+msgstr ""
+"Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23911,7 +24460,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
+msgstr ""
+"Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24065,6 +24615,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Du kan bare legge ved %1$s bilder per samtale."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24090,7 +24647,8 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr "Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
+msgstr ""
+"Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24208,6 +24766,12 @@ msgstr ""
 "versjonen."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24227,7 +24791,8 @@ msgstr "Du søker nå med personvern!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
+msgstr ""
+"Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24253,6 +24818,12 @@ msgid "You've blocked 1 site"
 msgstr "Du har blokkert 1 nettsted"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24270,7 +24841,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
+msgstr ""
+"Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24443,8 +25015,8 @@ msgstr "Chattene dine blir nå lagret."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Chattene dine er private og verken lagres eller brukes til å trene opp "
-"AI-modeller"
+"Chattene dine er private og verken lagres eller brukes til å trene opp AI-"
+"modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24476,8 +25048,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
-"AI-modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24485,8 +25057,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
-"AI-modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24587,11 +25159,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure "
-"Hash-algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den "
-"tilhørende innstillingsfilen som forlater nettleseren din. Vi lagrer "
-"innstillingsfilen ved å bruke nøkkelen som navn. DuckDuckGo vet aldri "
-"passordet ditt."
+"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure Hash-"
+"algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den tilhørende "
+"innstillingsfilen som forlater nettleseren din. Vi lagrer innstillingsfilen "
+"ved å bruke nøkkelen som navn. DuckDuckGo vet aldri passordet ditt."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24647,6 +25218,14 @@ msgstr "Din rolle"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Søkene dine kan ikke knyttes til deg"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25026,7 +25605,8 @@ msgstr "det offisielle nettstedet"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
+msgstr ""
+"eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25237,3 +25817,9 @@ msgstr "år"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "år"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s identifisert"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s filer er brukt"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -364,7 +364,7 @@ msgstr "%1$s brukt"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s bruker kvoten opptil 2–5 ganger raskere enn standardmodeller %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -485,8 +485,7 @@ msgstr "%1$sFinn ut hvordan du kan holde lokasjonen din privat%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
+msgstr "%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -616,7 +615,7 @@ msgstr "1 dag siden"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 fil er brukt"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -837,8 +836,7 @@ msgstr "6 timers bruksgrense er nådd."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1536,6 +1534,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Avanserte modeller kan bruke kvoten 2–5 ganger raskere enn andre modeller. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1748,8 +1748,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
+msgstr "Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1796,8 +1795,7 @@ msgstr "Tillat"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
+msgstr "Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1819,8 +1817,7 @@ msgstr "Vil du tillate anonym gjennomgang av filer i denne chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
+msgstr "Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2152,8 +2149,7 @@ msgstr "Er du der fortsatt?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
+msgstr "Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2326,7 +2322,7 @@ msgstr "Spør privat"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Spør privat"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2379,12 +2375,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere KI-"
-"assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner den "
-"nettet etter relevant innhold, og bruker deretter KI-drevet naturlig språk-"
-"teknologi til å generere et kort svar basert på relevant informasjon den har "
-"funnet. Det er viktig å huske at svarene genereres automatisk fra siterte "
-"kilder og er basert på %1$sgjennomsøking av nettet%2$s."
+"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere "
+"KI-assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner "
+"den nettet etter relevant innhold, og bruker deretter KI-drevet naturlig "
+"språk-teknologi til å generere et kort svar basert på relevant informasjon "
+"den har funnet. Det er viktig å huske at svarene genereres automatisk fra "
+"siterte kilder og er basert på %1$sgjennomsøking av nettet%2$s."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2475,8 +2471,7 @@ msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er avsluttet."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
+msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2523,8 +2518,7 @@ msgstr "Autogenerert basert på oppførte kilder. Kan inneholde unøyaktigheter.
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
+msgstr "Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -3154,8 +3148,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Bruk nettleseren som vanlig, så legger vi til personvernbeskyttelse. Vi har "
-"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én %1$s%2$s-"
-"utvidelse%3$s."
+"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én "
+"%1$s%2$s-utvidelse%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3790,8 +3784,8 @@ msgid ""
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
 "Med chatten (via Duck.ai-tjenesten vår) kan du ha anonyme samtaler med "
-"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic m."
-"m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
+"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic "
+"m.m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
 "DuckDuckGo Search. Men du kan likevel få tilgang til chatten når denne "
 "innstillingen er av, ved å gå til %1$shttps.://duck.ai%2$s direkte."
 
@@ -3848,8 +3842,7 @@ msgstr "Chat privat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
+msgstr "Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3876,7 +3869,7 @@ msgstr "Chat privat med AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Chat privat med populære AI-modeller"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4420,8 +4413,7 @@ msgstr "Klikk %1$sher%2$s for å laste ned DuckDuckGo-utvidelsen"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
+msgstr "Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4454,8 +4446,7 @@ msgstr "Klikk på %1$sInnstillinger%2$s i nedtrekksmenyen."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
+msgstr "Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4671,7 +4662,7 @@ msgstr "Lukk"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Lukk"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4721,7 +4712,7 @@ msgstr "Lukk søket"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Lukk ny vurdering"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5098,7 +5089,7 @@ msgstr "Fortsett å blokkere annonser"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Fortsett nylige chatter her. Eller slett dem med Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5169,7 +5160,7 @@ msgstr "Informasjonskapseldata:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Kopiert"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5222,7 +5213,7 @@ msgstr "Kopier koden"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopier lenken"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5341,7 +5332,7 @@ msgstr "Lag bilde"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Opprett en delingslenke"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5393,6 +5384,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Når du oppretter en lenke, lages det en kopi av chatten som kan ses av alle "
+"som åpner den."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5551,7 +5544,7 @@ msgstr "Tilpass svar"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Tilpass svar"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5841,7 +5834,7 @@ msgstr "Vil du slette serverdata?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Slett den delte lenken"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5853,7 +5846,7 @@ msgstr "Slett utskrift"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Slett en chat"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5891,7 +5884,7 @@ msgstr "Vil du slette bildet?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Slett meg"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5903,8 +5896,7 @@ msgstr "Vil du slette de eldste chattene for å frigjøre lagringsplass?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
+msgstr "Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -5928,8 +5920,7 @@ msgstr "Slettede chatter"
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
+msgstr "Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6019,8 +6010,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
+msgstr "Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6206,7 +6196,7 @@ msgstr "Avvis kampanje"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Lukk omvisning"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6361,8 +6351,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten AI-"
-"funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
+"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten "
+"AI-funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6422,7 +6412,7 @@ msgstr "Last ned DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Last ned DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6643,7 +6633,7 @@ msgstr "Duck.ai fra DuckDuckGo. Privat AI-chat. Gratis."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai kan nå analysere PDF-filer. Prøv det!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6764,8 +6754,8 @@ msgstr ""
 "Med Duck.ai kan du ha anonyme samtaler med tredjeparts AI-chatmodeller, som "
 "OpenAI, Anthropic og andre. Hvis du slår av denne innstillingen, skjules "
 "Duck.ai-knapper og -lenker på DuckDuckGo Search. Men du kan likevel få "
-"tilgang til Duck.ai når denne innstillingen er av, ved å gå til %1$shttps://"
-"duck.ai%2$s direkte."
+"tilgang til Duck.ai når denne innstillingen er av, ved å gå til "
+"%1$shttps://duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6802,7 +6792,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai støtter modeller fra Anthropic, OpenAI og andre."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7129,8 +7119,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du Duck."
-"ai's %2$s."
+"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du "
+"Duck.ai's %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7220,8 +7210,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
+msgstr "DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7449,7 +7438,7 @@ msgstr "Aktiver Mest besøkte sider"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Aktiver nå"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7499,8 +7488,7 @@ msgstr "Aktiver diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
+msgstr "Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7753,7 +7741,7 @@ msgstr "Underholdningsguide"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Hele chatten"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7922,13 +7910,13 @@ msgstr "Eksplisitte sangtekster"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Utforsk Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Utforsk Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8035,7 +8023,7 @@ msgstr "Gratis"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRATIS OG VALGFRITT"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8198,8 +8186,7 @@ msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
+msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8285,8 +8272,7 @@ msgstr "Søk nærmere der du er."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
+msgstr "Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8456,7 +8442,7 @@ msgstr "Frigjør lagringsplass"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Gratis og alltid privat"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8498,8 +8484,7 @@ msgstr "Kan deles og brukes kommersielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
+msgstr "Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8975,7 +8960,7 @@ msgstr "Få datamaskinhjelp"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Få høyere bruksgrenser med et DuckDuckGo-abonnement."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9018,13 +9003,15 @@ msgstr "Få den siste versjonen"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Skaff deg appen"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Skaff deg den gratis DuckDuckGo-nettleseren %1$sfor å blokkere annonser på "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9052,7 +9039,7 @@ msgstr "Få vennene dine til å bytte, og hjelp oss å vokse!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Sjekkliste for å komme i gang"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9742,7 +9729,7 @@ msgstr "Skjul tips"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Skjul veiledning"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10264,8 +10251,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt chat-"
-"svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
+"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt "
+"chat-svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -11368,7 +11355,7 @@ msgstr "Lar deg søke anonymt med DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Veksler mellom å sende søkespørringer og ledetekster til Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11444,7 +11431,7 @@ msgstr "Antall lineouts vunnet"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Lenken utløper om syv dager."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11460,8 +11447,7 @@ msgstr "Lenker:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
+msgstr "Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11572,8 +11558,7 @@ msgstr "Laster flere bilderesultater når du ruller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
+msgstr "Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12330,8 +12315,7 @@ msgstr "Månedlig grense er nådd"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12543,7 +12527,7 @@ msgstr "Mer enn 20 minutter"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Flere tips"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13037,7 +13021,7 @@ msgstr "Nei takk"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nei takk"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13705,7 +13689,7 @@ msgstr "På, men ingen tall"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Innføringen er fullført"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13749,8 +13733,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"Bare innstillingene du har endret. De er spesifisert på siden %1$sURL-"
-"parameter%2$s."
+"Bare innstillingene du har endret. De er spesifisert på siden "
+"%1$sURL-parameter%2$s."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13923,7 +13907,7 @@ msgstr "Åpne forslag for å lage og redigere bilder"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Åpne sjekklisten for å komme i gang"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14675,7 +14659,7 @@ msgstr "Fest"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Fest en chat"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14687,7 +14671,7 @@ msgstr "Fest chatter her fra %1$s-%2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Fest meg"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14710,7 +14694,7 @@ msgstr "Festede"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Festede chatter vises øverst i de nyeste chattene dine."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15032,6 +15016,8 @@ msgstr "Dårlig formatering"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Populære AI-modeller er tilgjengelige. Ingen konto kreves. Chatter "
+"anonymiseres av oss."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15245,7 +15231,7 @@ msgstr "Forrige faner"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Forrige tips"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15540,8 +15526,7 @@ msgstr "Spør meg"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
+msgstr "Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15790,13 +15775,13 @@ msgstr "Resonnerende KI med innebygd middels moderering"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Resonnering kan gi bedre svar på komplekse spørsmål."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Resonnering er grundigere, men bruker kvoten 2–5 ganger raskere. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15837,7 +15822,7 @@ msgstr "Lagring av nylige chatter kan justeres i %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Nylige chatter"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15846,8 +15831,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter som lagres lokalt på enheten din, i stedet for på DuckDuckGo-"
-"servere eller andre eksterne servere."
+"Nylige chatter som lagres lokalt på enheten din, i stedet for på "
+"DuckDuckGo-servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15856,8 +15841,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter lagres lokalt på enheten din i stedet for på DuckDuckGo-"
-"servere eller andre eksterne servere."
+"Nylige chatter lagres lokalt på enheten din i stedet for på "
+"DuckDuckGo-servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15997,7 +15982,7 @@ msgstr "Reduser bruken"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Reduser bruken med en mer effektiv modell"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16378,7 +16363,7 @@ msgstr "Nullstill alle innstillinger"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Tilbakestill veiledning"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16396,7 +16381,7 @@ msgstr "Oppløsning"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Svar"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16887,8 +16872,7 @@ msgstr "Lagre opptil 30 av de siste chattene lokalt på enheten din."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
+msgstr "Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17071,8 +17055,7 @@ msgstr "Rull ned til %1$sDuckDuckGo%2$s og la den bruke posisjonen din."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
+msgstr "Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17100,7 +17083,7 @@ msgstr "Vil du søke etter %1$s for å finne resultater nærmere deg?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Søk- og Duck.ai-bryter"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17302,8 +17285,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke POST-"
-"forespørsler)"
+"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke "
+"POST-forespørsler)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17422,8 +17405,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
-"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
+"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17432,8 +17415,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
-"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
+"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17476,7 +17459,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Lagret sikkert på vår krypterte server."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17587,8 +17570,7 @@ msgstr "Se noen av våre nyeste oppdateringer"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
+msgstr "Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17742,8 +17724,7 @@ msgstr "Velg %1$sInnstillinger%2$s fra nedtrekksmenyen."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
+msgstr "Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17771,8 +17752,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
+msgstr "Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17991,7 +17971,7 @@ msgstr "Sett som startside"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Angi tone og stil for svarene fra Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18064,13 +18044,13 @@ msgstr "Seychellene"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Del"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Del"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18109,15 +18089,15 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Del plassering så nær som nærmeste by med AI-modeller for å forbedre "
-"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller AI-"
-"modeller."
+"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Del chat"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18181,7 +18161,7 @@ msgstr "Del positive tilbakemeldinger"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Delingsomfang"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18322,7 +18302,7 @@ msgstr "Vis detaljer"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Vis veiledning for Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18475,7 +18455,7 @@ msgstr "Vis mer"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Vis flere modeller"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18516,7 +18496,7 @@ msgstr "Vis sidefeltet"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Vis trinnvise tips for å få mest mulig ut av Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18611,14 +18591,12 @@ msgstr "Viser de mest besøkte lenkene på ny fane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
+msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
+msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18898,7 +18876,7 @@ msgstr "Noe gikk galt, prøv igjen senere."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Noe gikk galt. Prøv igjen."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18916,8 +18894,7 @@ msgstr "Noen ganger"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
+msgstr "Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18991,8 +18968,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
+msgstr "Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19046,8 +19022,7 @@ msgstr "Kildetekst fjernet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
+msgstr "Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19199,7 +19174,7 @@ msgstr "Begynn å bruke ukentlig grense"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Start en ny chat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19252,8 +19227,7 @@ msgstr "Bli på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
+msgstr "Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19786,7 +19760,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Bytt til denne nye vurderingen"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19855,8 +19829,7 @@ msgstr "Sync & Backup er aktivert!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
+msgstr "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19905,9 +19878,9 @@ msgid ""
 msgstr ""
 "Synkroniseringsgjenopprettingskode\n"
 "\n"
-"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og Duck.ai-"
-"chatter på tvers av flere enheter, og gjenopprette synkroniserte data hvis "
-"du mister tilgangen til en enhet.\n"
+"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og "
+"Duck.ai-chatter på tvers av flere enheter, og gjenopprette synkroniserte "
+"data hvis du mister tilgangen til en enhet.\n"
 "\n"
 "Ta godt vare på denne informasjonen.\n"
 "Alle som har tilgang til denne koden kan få tilgang til de synkroniserte "
@@ -19947,7 +19920,7 @@ msgstr "Sync & Backup er midlertidig utilgjengelig"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Synkroniser chatter mellom enheter"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20043,6 +20016,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Ta med Duck.ai overalt. Få den innebygd i den gratis appen vår for raskere "
+"tilgang, uansett hvor du er."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20051,6 +20026,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Ta med Duck.ai overalt. Få den innebygd i den gratis nettleseren vår for "
+"raskere tilgang, uansett hvor du surfer."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20319,8 +20296,7 @@ msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
+msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20342,8 +20318,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
+msgstr "Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20512,8 +20487,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
+msgstr "Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20525,7 +20499,7 @@ msgstr "Denne måneden"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Dette svaret"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20537,7 +20511,7 @@ msgstr "Denne uken"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Denne chatten forblir i Duck.ai og privat for deg."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20546,9 +20520,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss %3$s-"
-"modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s for mer "
-"informasjon)."
+"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss "
+"%3$s-modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s "
+"for mer informasjon)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20653,16 +20627,14 @@ msgstr "Dette bildet kunne ikke opprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
+msgstr "Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
+msgstr "Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20676,6 +20648,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Dette er bare en eksempel-chat. Åpne menyen (de tre prikkene) og velg Fest "
+"for å beholde den øverst i chattene dine!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20684,6 +20658,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Dette er bare en eksempel-chat. Bruk Fire Button i sidemenyen for å slette "
+"den!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20800,8 +20776,7 @@ msgstr "Denne oversettelsen er feil"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
+msgstr "Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20992,8 +20967,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"For å overføre chat-historikken din til Duck.ai, oppdater DuckDuckGo-"
-"nettleseren din til den nyeste versjonen og prøv igjen."
+"For å overføre chat-historikken din til Duck.ai, oppdater "
+"DuckDuckGo-nettleseren din til den nyeste versjonen og prøv igjen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21024,7 +20999,7 @@ msgstr "I dag"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
+msgstr "Prøv privat AI-chat eller %1$sdeaktiver den i %2$s-menyen.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21441,7 +21416,7 @@ msgstr "Prøv dem"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Prøv en annen modell"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21452,7 +21427,7 @@ msgstr "Prøv et søk!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Prøv et forslag"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21522,7 +21497,7 @@ msgstr "Prøv gratis"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Prøv gratis"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21542,7 +21517,7 @@ msgstr "Prøv gratis! En sikker VPN, avansert og privat AI m.m."
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Prøv gratis i 7 dager"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21575,7 +21550,7 @@ msgstr "Prøv hjemmesiden vår som aldri viser disse beskjedene:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Prøv resonnering"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21830,7 +21805,7 @@ msgstr "Slå på Duck Player for å se på YouTube uten målrettede annonser"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Slå på Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22046,8 +22021,8 @@ msgstr "Under %1$sÅpne med%2$s velger du %3$sEn spesifikk side eller sider%4$s"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: https://"
-"duckduckgo.com"
+"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22069,8 +22044,7 @@ msgstr "Under %1$sSøke%2$sseksjon trykker du på %3$sBehandle søkemotorer …%
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
+msgstr "Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22177,8 +22151,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Få tilgang til avanserte AI-modeller og høyere grenser med et DuckDuckGo-"
-"abonnement"
+"Få tilgang til avanserte AI-modeller og høyere grenser med et "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22203,7 +22177,7 @@ msgstr "Få tilgang til avansert AI med abonnementet ditt!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Få tilgang til avanserte modeller"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22570,7 +22544,7 @@ msgstr "Bruk i Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Bruk Fire Button til å slette en chat fra historikken."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22798,9 +22772,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Gå til Duck.ai i den andre nettleseren din og så til %1$sDuck.ai-"
-"innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. Velg "
-"deretter %7$sSynkroniser med en annen enhet%8$s."
+"Gå til Duck.ai i den andre nettleseren din og så til "
+"%1$sDuck.ai-innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. "
+"Velg deretter %7$sSynkroniser med en annen enhet%8$s."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22836,8 +22810,8 @@ msgid ""
 msgstr ""
 "Gå til Duck.ai i nettleseren din eller i DuckDuckGo-appen, og åpne "
 "innstillingene for Duck.ai. Velg «Slå på» under Sync & Backup og velg "
-"«Synkroniser med en annen enhet». Eller skann QR-koden på gjenopprettings-"
-"PDF-en din."
+"«Synkroniser med en annen enhet». Eller skann QR-koden på "
+"gjenopprettings-PDF-en din."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22889,8 +22863,7 @@ msgstr "Talechatten er avsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
+msgstr "Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23126,8 +23099,7 @@ msgstr "Vi følger ikke etter deg med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
+msgstr "Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23287,8 +23259,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
+msgstr "Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23311,8 +23282,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
+msgstr "Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23346,8 +23316,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
+msgstr "Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23457,8 +23426,7 @@ msgstr "Ukentlig bruksgrense er nådd"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23511,15 +23479,13 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
+msgstr "Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
+msgstr "Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -23760,7 +23726,7 @@ msgstr "Hva førte deg tilbake i dag?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Hva kan du gjøre?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24187,6 +24153,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Med Duck.ai er chattene dine anonymisert og brukes aldri til å trene AI. Slå "
+"det av eller på når som helst i «%1$s»-menyen."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24440,8 +24408,7 @@ msgstr "Ja, ny bruker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
+msgstr "Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24460,8 +24427,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
+msgstr "Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24619,7 +24585,7 @@ msgstr "Du kan bare legge ved %1$s bilder per samtale."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Du kan bare legge ved %1$s faner av gangen."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24647,8 +24613,7 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr ""
-"Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
+msgstr "Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24769,7 +24734,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Du er klar!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24791,8 +24756,7 @@ msgstr "Du søker nå med personvern!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
+msgstr "Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24821,7 +24785,7 @@ msgstr "Du har blokkert 1 nettsted"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Du har mestret det grunnleggende i Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24841,8 +24805,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
+msgstr "Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25015,8 +24978,8 @@ msgstr "Chattene dine blir nå lagret."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Chattene dine er private og verken lagres eller brukes til å trene opp AI-"
-"modeller"
+"Chattene dine er private og verken lagres eller brukes til å trene opp "
+"AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25048,8 +25011,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
-"modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25057,8 +25020,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
-"modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25159,10 +25122,11 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure Hash-"
-"algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den tilhørende "
-"innstillingsfilen som forlater nettleseren din. Vi lagrer innstillingsfilen "
-"ved å bruke nøkkelen som navn. DuckDuckGo vet aldri passordet ditt."
+"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure "
+"Hash-algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den "
+"tilhørende innstillingsfilen som forlater nettleseren din. Vi lagrer "
+"innstillingsfilen ved å bruke nøkkelen som navn. DuckDuckGo vet aldri "
+"passordet ditt."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25226,6 +25190,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Innstillingene dine er lagret, men hvis du sletter informasjonskapsler, blir "
+"de tilbakestilt. Aktiver utvidelsen %1$sDuckDuckGo No AI%2$s for å gjøre det "
+"permanent."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25605,8 +25572,7 @@ msgstr "det offisielle nettstedet"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
+msgstr "eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25822,4 +25788,4 @@ msgstr "år"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ne_NP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ne_NP/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1224,6 +1239,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3675,6 +3707,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3710,6 +3747,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4015,6 +4057,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4069,6 +4116,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4106,6 +4158,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4202,6 +4259,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4236,6 +4298,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4361,6 +4430,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4597,9 +4671,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4627,6 +4711,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4880,6 +4969,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5046,6 +5140,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5221,6 +5320,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5328,6 +5432,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5828,6 +5937,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6067,6 +6181,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6200,6 +6319,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6281,6 +6410,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6610,6 +6744,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7031,6 +7170,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7060,6 +7204,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7076,6 +7230,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7627,6 +7786,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8926,6 +9090,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8981,6 +9151,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9877,6 +10052,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10271,6 +10451,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10819,6 +11004,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr ""
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10987,6 +11177,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11583,9 +11778,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11600,6 +11805,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11856,6 +12066,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12025,6 +12240,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12467,6 +12687,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12494,6 +12724,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12616,6 +12851,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12918,6 +13158,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12926,6 +13171,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13483,6 +13733,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13765,6 +14020,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14162,6 +14422,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "गृहपृष्ठ बनाउनुहोस् । "
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14214,6 +14479,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14243,6 +14518,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14291,6 +14572,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14402,6 +14688,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14526,6 +14817,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14554,6 +14850,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14852,6 +15153,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15084,6 +15390,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15562,6 +15873,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15674,6 +15992,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15743,6 +16066,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16112,9 +16449,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16215,6 +16562,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16471,6 +16832,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16808,8 +17174,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16864,6 +17240,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16874,6 +17255,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16896,6 +17282,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17096,6 +17487,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17380,6 +17776,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17675,6 +18076,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18588,6 +18994,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18927,6 +19338,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19271,6 +19689,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19379,6 +19803,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19413,6 +19842,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19710,6 +20144,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20182,6 +20623,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Load Cloud Settings"

--- a/locales/nl_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_BE/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3684,6 +3716,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3719,6 +3756,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4026,6 +4068,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4080,6 +4127,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4117,6 +4169,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4213,6 +4270,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4247,6 +4309,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4372,6 +4441,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4608,9 +4682,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4638,6 +4722,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4891,6 +4980,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5057,6 +5151,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5232,6 +5331,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5339,6 +5443,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5827,6 +5936,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6067,6 +6181,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6200,6 +6319,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6281,6 +6410,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6612,6 +6746,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7033,6 +7172,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7062,6 +7206,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7079,6 +7233,11 @@ msgstr "Bekom dit liedje op:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Overtuig je vrienden en help ons groeien!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7629,6 +7788,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8928,6 +9092,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8983,6 +9153,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9879,6 +10054,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "meer dan 20 minuten"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10273,6 +10453,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10823,6 +11008,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Ingeschakeld maar geen nummers"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10993,6 +11183,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11593,9 +11788,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11610,6 +11815,11 @@ msgstr "Roze"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11866,6 +12076,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12035,6 +12250,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12477,6 +12697,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12504,6 +12734,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12626,6 +12861,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12928,6 +13168,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Instellingen Ongedaan Maken"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12936,6 +13181,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13495,6 +13745,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Zoek anoniem"
 
@@ -13777,6 +14032,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14181,6 +14441,11 @@ msgstr "Stel in als standaard zoekmachine"
 msgid "Set as Homepage"
 msgstr "Instellen als startpagina"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14235,6 +14500,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14264,6 +14539,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14312,6 +14593,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14423,6 +14709,11 @@ msgstr "Toon Bookmarklet en Instellingen"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14547,6 +14838,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14575,6 +14871,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14874,6 +15175,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15106,6 +15412,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15584,6 +15895,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Schakel over naar de zoekmachine die je niet volgt. Nooit. "
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15696,6 +16014,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15766,6 +16089,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Neem je privacy opnieuw in je eigen handen!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16134,9 +16471,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16237,6 +16584,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16494,6 +16855,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16831,9 +17197,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Probeer een zoekopdracht!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16888,6 +17264,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16898,6 +17279,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16921,6 +17307,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Probeer onze home pagina die nooit volgende berichten toont:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17120,6 +17511,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17410,6 +17806,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17706,6 +18107,11 @@ msgstr "Gebruik in Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Gebruik in Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18626,6 +19032,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Wat zorgde ervoor dat u vandaag terugkwam?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18965,6 +19376,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19311,6 +19729,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19421,6 +19845,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19456,6 +19885,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19757,6 +20191,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20231,6 +20672,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,7 +87,8 @@ msgstr "%1$s en %2$s AI-modellen"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
+msgstr ""
+"%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -122,6 +123,12 @@ msgstr "%1$s dagen geleden"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s gedetecteerd"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +362,12 @@ msgid "%s used"
 msgstr "%1$s gebruikt"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s weergave"
@@ -416,7 +429,8 @@ msgstr "%1$s woorden"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
+msgstr ""
+"%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -479,7 +493,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
+msgstr ""
+"%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -602,6 +617,12 @@ msgstr "1 poging geblokkeerd door DuckDuckGo in de afgelopen 24 uur"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 dag geleden"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -822,7 +843,8 @@ msgstr "De 6-uurs gebruikslimiet is bereikt."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1514,6 +1536,14 @@ msgid "Advanced Models"
 msgstr "Geavanceerde modellen"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Adverteren in zoekresultaten"
@@ -1794,7 +1824,8 @@ msgstr "Anonieme bestandscontrole toestaan voor deze chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
+msgstr ""
+"Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1954,8 +1985,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
-"open-source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
+"source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1964,8 +1995,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
-"open-source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
+"source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2302,6 +2333,12 @@ msgid "Ask privately"
 msgstr "Vraag privé"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2338,8 +2375,8 @@ msgstr ""
 "relevante webinhoud samen te vatten. Je kunt kiezen hoe vaak je wilt dat "
 "Assist wordt weergegeven: 'Nooit' (de Assist-gebruikersinterface wordt "
 "helemaal uit de zoekresultaten verwijderd), 'Op verzoek' (AI-antwoorden "
-"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' "
-"(AI-antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
+"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' (AI-"
+"antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
 "'Vaak' (wordt vaker weergegeven bij een breder scala aan zoekopdrachten). "
 "Voorlopig zijn AI-antwoorden alleen beschikbaar in de Amerikaanse regio."
 
@@ -2353,8 +2390,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist is een optionele functie in onze zoekresultaten die anoniem "
-"AI-ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
+"Assist is een optionele functie in onze zoekresultaten die anoniem AI-"
+"ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
 "het web op relevante inhoud en gebruikt vervolgens AI-technologie op basis "
 "van natuurlijke taal om een kort antwoord te genereren aan de hand van de "
 "gevonden relevante informatie. Het is belangrijk om te onthouden dat "
@@ -3627,7 +3664,8 @@ msgstr "Wijzigt hoe URL's van resultaten worden weergegeven"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
+msgstr ""
+"Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3838,14 +3876,16 @@ msgstr "Privé chatten"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
+msgstr ""
+"Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
+msgstr ""
+"Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3858,6 +3898,12 @@ msgstr "Privé chatten met %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Privé chatten met AI"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4651,6 +4697,12 @@ msgid "Close"
 msgstr "Sluiten"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4693,6 +4745,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Zoeken sluiten"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5066,6 +5124,12 @@ msgid "Continue Blocking Ads"
 msgstr "Advertenties blijven blokkeren"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5131,6 +5195,12 @@ msgid "Cookie data:"
 msgstr "Cookiegegevens:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5176,6 +5246,12 @@ msgstr "Kopieer en plak %1$sabout:preferences#search%2$s in de adresbalk"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Code kopiëren"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5245,7 +5321,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
+msgstr ""
+"Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5291,10 +5368,17 @@ msgid "Create Image"
 msgstr "Afbeelding maken"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr "Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
+msgstr ""
+"Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5332,6 +5416,14 @@ msgstr "Gemaakt door"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Gemaakt door %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5487,6 +5579,12 @@ msgid "Customize responses"
 msgstr "Antwoorden aanpassen"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "Deze pagina aanpassen"
@@ -5551,7 +5649,8 @@ msgstr "Dagelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5771,10 +5870,22 @@ msgid "Delete Server Data?"
 msgstr "Servergegevens verwijderen?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Transcript verwijderen"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5807,6 +5918,12 @@ msgstr "Afbeelding verwijderen"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Afbeelding verwijderen?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6033,7 +6150,8 @@ msgstr "Uitschakelen en loskoppelen"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
+msgstr ""
+"Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6115,6 +6233,12 @@ msgstr "Verbergen"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Promotie sluiten"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6269,8 +6393,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder "
-"AI-functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
+"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder AI-"
+"functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6325,6 +6449,12 @@ msgstr "Download voltooid"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "DuckDuckGo downloaden"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6493,7 +6623,8 @@ msgstr "Sleep je foto's of PDF-bestanden"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
+msgstr ""
+"Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6540,6 +6671,12 @@ msgstr "Servicevoorwaarden van Duck.ai"
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai van DuckDuckGo. Privé AI-chat. Gratis."
+
+# smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6623,8 +6760,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een "
-"e-mail met deze anonieme code %1$s naar %2$s"
+"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een e-"
+"mail met deze anonieme code %1$s naar %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6686,7 +6823,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
+msgstr ""
+"Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6696,6 +6834,12 @@ msgid ""
 msgstr ""
 "Duck.ai-antwoorden zijn niet gebaseerd op specifieke bronnen en worden niet "
 "gecontroleerd op juistheid."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6724,8 +6868,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privé AI-chatbot, gratis AI-chat, anonieme AI-chat, "
-"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open "
-"source  AI-modellen, privacy  AI, AI-chat zonder account"
+"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open source  AI-"
+"modellen, privacy  AI, AI-chat zonder account"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6797,9 +6941,9 @@ msgid ""
 msgstr ""
 "DuckAssist is een nieuwe functie in onze zoekresultaten die anoniem "
 "antwoorden voor zoekopdrachten kan genereren. Hij scant daarvoor Wikipedia "
-"en gerelateerde sites op relevante inhoud en gebruikt vervolgens "
-"AI-technologie voor natuurlijke taal om die informatie samen te vatten. Let "
-"op: de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
+"en gerelateerde sites op relevante inhoud en gebruikt vervolgens AI-"
+"technologie voor natuurlijke taal om die informatie samen te vatten. Let op: "
+"de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
 "inhoud en worden niet gecontroleerd op juistheid."
 
 # smartling.placeholder_format=C
@@ -6897,7 +7041,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
+msgstr ""
+"DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7119,7 +7264,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
+msgstr ""
+"DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7345,6 +7491,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Meest bezochte websites inschakelen"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7504,7 +7656,8 @@ msgstr "Ben je tevreden met Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
+msgstr ""
+"Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7645,6 +7798,12 @@ msgid "Entertainment guide"
 msgstr "Entertainmentgids"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Equatoriaal-Guinea"
 
@@ -7712,7 +7871,8 @@ msgstr "Kaart uitvouwen"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
+msgstr ""
+"Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7804,6 +7964,18 @@ msgstr "Expliciete inhoud"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Expliciete songteksten"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7905,6 +8077,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Gratis"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8061,7 +8239,8 @@ msgstr "Filters niet effectief"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
+msgstr ""
+"Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8326,6 +8505,12 @@ msgid "Free Up Storage"
 msgstr "Opslagruimte vrijmaken"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8448,9 +8633,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Selecteer in de menubalk van de app voor Mac de optie "
-"<strong>DuckDuckGo</strong> &gt; <strong>Controleren op updates...</strong> "
-"en selecteer vervolgens <strong>Update installeren</strong>."
+"Selecteer in de menubalk van de app voor Mac de optie <strong>DuckDuckGo</"
+"strong> &gt; <strong>Controleren op updates...</strong> en selecteer "
+"vervolgens <strong>Update installeren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8815,9 +9000,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een "
-"DuckDuckGo-abonnement, dat ook onze VPN en andere premium "
-"privacybeschermingen omvat."
+"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een DuckDuckGo-"
+"abonnement, dat ook onze VPN en andere premium privacybeschermingen omvat."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8841,6 +9025,12 @@ msgstr "Krijg antwoorden bij DuckDuckGo Help."
 msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr "Hulp van de computer krijgen"
+
+# smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8880,6 +9070,18 @@ msgid "Get the Latest Version"
 msgstr "Download de laatste versie"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8900,6 +9102,12 @@ msgstr "Download dit nummer op:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Overtuig je vrienden om over te stappen en help ons groeien!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8941,9 +9149,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
-"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
+"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
+"een ander apparaat%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8953,9 +9161,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
-"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s en scan deze code:"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
+"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
+"een ander apparaat%4$s en scan deze code:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8967,8 +9175,8 @@ msgid ""
 msgstr ""
 "Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of naar de "
 "DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je "
-"herstel-PDF."
+"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je herstel-"
+"PDF."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9587,6 +9795,12 @@ msgstr "Stappen verbergen"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Tips verbergen"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10276,8 +10490,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbetert de leesbaarheid van het resultaat met een bijgewerkte "
-"URL-indeling, -plaatsing en -kleur"
+"Verbetert de leesbaarheid van het resultaat met een bijgewerkte URL-"
+"indeling, -plaatsing en -kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11152,7 +11366,8 @@ msgstr "Lees meer over hoe het werkt"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Informatie over waarom het terugdringen van online tracking belangrijk is."
+msgstr ""
+"Informatie over waarom het terugdringen van online tracking belangrijk is."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11208,6 +11423,13 @@ msgstr "Laten we je weer toegang geven."
 msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Nu kun je anoniem zoeken met DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11280,6 +11502,12 @@ msgstr "Lijntekening"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Line-outs gewonnen"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11590,7 +11818,8 @@ msgstr "Zorg ervoor dat alle woorden correct gespeld zijn."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
+msgstr ""
+"Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12380,6 +12609,12 @@ msgid "More than 20 minutes"
 msgstr "Langer dan 20 minuten"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12868,6 +13103,12 @@ msgid "No Thanks"
 msgstr "Nee, bedankt"
 
 # smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
 msgid "No Tracking. Ever."
 msgstr "Niet volgen, maar dan ook nooit."
@@ -13013,7 +13254,8 @@ msgstr "Geen resultaten gevonden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
+msgstr ""
+"Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13530,6 +13772,12 @@ msgid "On but no numbers"
 msgstr "Aan maar geen nummers"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13641,7 +13889,8 @@ msgstr "%1$s-website openen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
+msgstr ""
+"Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13742,6 +13991,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Open suggesties voor het maken en bewerken van afbeeldingen"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13804,7 +14059,8 @@ msgstr "Open het paneel 'Hoe Duck.ai werkt'"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
+msgstr ""
+"Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14490,10 +14746,22 @@ msgid "Pin"
 msgstr "Pin"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Pin hier chats vast van %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14511,6 +14779,12 @@ msgstr "Roze"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Vastgezet"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14830,6 +15104,12 @@ msgid "Poor formatting"
 msgstr "Slechte opmaak"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15038,6 +15318,12 @@ msgid "Previous tabs"
 msgstr "Vorige tabbladen"
 
 # smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
 msgctxt "Rich Facts label"
 msgid "Price"
@@ -15047,7 +15333,8 @@ msgstr "Prijs"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr "De weergegeven prijs komt niet overeen met die op de site van de verkoper"
+msgstr ""
+"De weergegeven prijs komt niet overeen met die op de site van de verkoper"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -15330,7 +15617,8 @@ msgstr "Vraag het mij"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
+msgstr ""
+"Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15576,6 +15864,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Redenerend AI-model met gemiddelde moderatie"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15609,6 +15909,12 @@ msgstr "Recente tabbladen"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Recente chatopslag kan worden aangepast in %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15764,6 +16070,12 @@ msgstr "Zoekopdracht opnieuw uitvoeren zonder deze site"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Gebruik verminderen"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15924,7 +16236,8 @@ msgstr "Mijn keuze onthouden"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
+msgstr ""
+"Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16144,6 +16457,12 @@ msgid "Reset All Settings"
 msgstr "Herstel alle instellingen"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16154,6 +16473,12 @@ msgstr "Reset over %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Resolutie"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16645,7 +16970,8 @@ msgstr "Bewaar maximaal 30 van je meest recente chats op je apparaat."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
+msgstr ""
+"Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16779,13 +17105,15 @@ msgstr "Schotland"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
+msgstr ""
+"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
+msgstr ""
+"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16855,6 +17183,12 @@ msgstr "Zoeken"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "%1$s zoeken om resultaten dichter bij je in de buurt te vinden?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17028,8 +17362,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar "
-"\"!w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
+"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar \"!"
+"w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17214,7 +17548,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
+msgstr ""
+"Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17225,6 +17560,12 @@ msgid ""
 msgstr ""
 "Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling. "
 "Niemand anders dan jij kan je gegevens zien, zelfs wij niet."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17335,7 +17676,8 @@ msgstr "Bekijk enkele van onze nieuwste updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
+msgstr ""
+"Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17362,7 +17704,8 @@ msgstr "Selecteer %1$s%2$s%3$s en vervolgens %4$sZoekmachine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
+msgstr ""
+"Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17375,18 +17718,21 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17398,7 +17744,8 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in het uitklapmenu Standaard zoekmachine"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17410,7 +17757,8 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst met zoekmachines"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17497,7 +17845,8 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
+msgstr ""
+"Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17519,7 +17868,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
+msgstr ""
+"Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17736,6 +18086,12 @@ msgid "Set as Homepage"
 msgstr "Instellen als startpagina"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17803,6 +18159,18 @@ msgid "Seychelles"
 msgstr "Seychellen"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17839,8 +18207,15 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Deel een locatie op stadsniveau met AI-modellen om de relevantie te "
-"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan "
-"AI-modellen."
+"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan AI-"
+"modellen."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17899,6 +18274,12 @@ msgstr "URL van pagina delen"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Deel positieve feedback"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18034,6 +18415,12 @@ msgstr "Bladwijzer- en gegevensinstellingen weergeven"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Details weergeven"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18185,6 +18572,12 @@ msgid "Show more"
 msgstr "Laat meer zien"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18218,6 +18611,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Zijbalk weergeven"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18312,7 +18711,8 @@ msgstr "Meest bezochte links weergeven op een nieuw tabblad"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
+msgstr ""
+"Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18326,8 +18726,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"Geeft af en toe herinneringen weer om je aan te melden voor de "
-"DuckDuckGo-nieuwsbrieven over privacy"
+"Geeft af en toe herinneringen weer om je aan te melden voor de DuckDuckGo-"
+"nieuwsbrieven over privacy"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18337,7 +18737,8 @@ msgstr "Geeft paginanummers weer naast resultaatpagina-einden"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
+msgstr ""
+"Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18366,8 +18767,8 @@ msgstr "Geeft een welkomstbericht weer bovenaan de pagina met zoekresultaten"
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
 msgstr ""
-"Geeft een welkomstbericht weer aan gebruikers van het "
-"EU-Android-voorkeursmenu"
+"Geeft een welkomstbericht weer aan gebruikers van het EU-Android-"
+"voorkeursmenu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18585,7 +18986,8 @@ msgstr "Er is iets misgegaan"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
+msgstr ""
+"Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18600,6 +19002,12 @@ msgstr ""
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Er is iets misgegaan. Probeer het later opnieuw."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18617,7 +19025,8 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
+msgstr ""
+"Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18691,7 +19100,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
+msgstr ""
+"Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18896,6 +19306,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Weeklimiet gebruiken"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Begin met zoeken!"
@@ -19001,7 +19417,8 @@ msgstr "Stop verborgen trackers die op de loer liggen op andere websites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Stop de meeste verborgen trackers die op de loer liggen op andere websites."
+msgstr ""
+"Stop de meeste verborgen trackers die op de loer liggen op andere websites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19478,6 +19895,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Stap over naar de zoekmachine die je niet volgt. Nooit."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19635,6 +20060,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Synchronisatie en back-up is tijdelijk niet beschikbaar"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19720,6 +20151,22 @@ msgstr "Tadzjikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Weer controle over je privacy!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19982,13 +20429,15 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
+msgstr ""
+"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
+msgstr ""
+"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20044,7 +20493,8 @@ msgstr "Het verzoek is verlopen. Probeer het opnieuw."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
+msgstr ""
+"De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -20184,7 +20634,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
+msgstr ""
+"Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20193,10 +20644,22 @@ msgid "This Month"
 msgstr "Deze maand"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Deze week"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20331,6 +20794,22 @@ msgid "This information isn’t useful"
 msgstr "Deze informatie is niet nuttig"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20377,7 +20856,8 @@ msgstr "Voor deze pagina moet JavaScript zijn ingeschakeld."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
+msgstr ""
+"De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20446,13 +20926,15 @@ msgstr "Deze vertaling is onjuist"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
+msgstr ""
+"Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
+msgstr ""
+"Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20571,8 +21053,8 @@ msgstr "Tips"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij "
-"helpen.%2$s"
+"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij helpen."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20604,7 +21086,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
+msgstr ""
+"Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20645,8 +21128,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je "
-"DuckDuckGo-browser naar de nieuwste versie en probeer het opnieuw."
+"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je DuckDuckGo-"
+"browser naar de nieuwste versie en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20672,6 +21155,12 @@ msgstr "Vandaag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Vandaag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21019,7 +21508,8 @@ msgstr "Probeer %1$s om dit soort berichten niet meer te zien."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
+msgstr ""
+"Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21085,9 +21575,21 @@ msgid "Try Them Out"
 msgstr "Probeer ze uit"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Probeer een zoekopdracht!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21130,14 +21632,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
+msgstr ""
+"Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
+msgstr ""
+"Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21154,6 +21658,12 @@ msgid "Try for free"
 msgstr "Probeer het gratis"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21165,7 +21675,14 @@ msgstr "Probeer het gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
+msgstr ""
+"Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21192,7 +21709,14 @@ msgstr "Probeer onze browser"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
+msgstr ""
+"Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21444,6 +21968,12 @@ msgstr ""
 "advertenties"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21613,7 +22143,8 @@ msgstr ""
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr "Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
+msgstr ""
+"Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -21654,7 +22185,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
+msgstr ""
+"Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21669,13 +22201,15 @@ msgstr "Bij %1$sZoekinstellingen%2$s selecteer je %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
+msgstr ""
+"Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
+msgstr ""
+"Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21689,7 +22223,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
+msgstr ""
+"Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21790,8 +22325,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Ontgrendel geavanceerde AI-modellen en hogere limieten met een "
-"DuckDuckGo-abonnement"
+"Ontgrendel geavanceerde AI-modellen en hogere limieten met een DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21811,6 +22346,12 @@ msgstr "Ontgrendel geavanceerde AI-modellen met een DuckDuckGo-abonnement"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Ontgrendel geavanceerde AI met je abonnement!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22039,7 +22580,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
+msgstr ""
+"Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22149,7 +22691,8 @@ msgstr "Gebruik DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
+msgstr ""
+"Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22172,6 +22715,12 @@ msgstr "Gebruiken in Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Gebruiken in Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22436,10 +22985,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open "
-"'Duck.ai-instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en "
-"selecteer 'Synchroniseren met een ander apparaat'. Of scan de QR-code op je "
-"herstel-PDF."
+"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open 'Duck.ai-"
+"instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en selecteer "
+"'Synchroniseren met een ander apparaat'. Of scan de QR-code op je herstel-"
+"PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22638,8 +23187,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Kijk in Duck Player om gepersonaliseerde advertenties op YouTube te "
-"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op "
-"YouTube-aanbevelingen."
+"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op YouTube-"
+"aanbevelingen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22732,12 +23281,14 @@ msgstr "We achtervolgen je niet met advertenties."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
+msgstr ""
+"We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
+msgstr ""
+"We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22763,7 +23314,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
+msgstr ""
+"We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22771,7 +23323,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
+msgstr ""
+"We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22858,7 +23411,8 @@ msgstr "De verbinding is verbroken. Probeer het later opnieuw."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
+msgstr ""
+"We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -22890,7 +23444,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
+msgstr ""
+"We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -22913,7 +23468,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
+msgstr ""
+"We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22947,7 +23503,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
+msgstr ""
+"Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23057,7 +23614,8 @@ msgstr "Wekelijkse gebruikslimiet bereikt"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23110,7 +23668,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
+msgstr ""
+"Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23353,6 +23912,12 @@ msgstr "Wat stoorde je het meest?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Waarom ben je weer teruggekeerd?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23775,6 +24340,14 @@ msgid "Wintry Mix"
 msgstr "Winterse neerslag"
 
 # smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -24125,7 +24698,8 @@ msgstr "Je kunt dit op elk moment wijzigen in %1$sZoekinstellingen%2$s"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
+msgstr ""
+"Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24201,6 +24775,13 @@ msgstr "Je kunt slechts %1$s afbeeldingen per gesprek bijvoegen"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Je kunt slechts %1$s afbeeldingen per gesprek bijvoegen."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24294,8 +24875,8 @@ msgid ""
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
 "Je hebt nu toegang tot geavanceerde AI-modellen. Je hebt toegang tot de VPN "
-"en andere beveiligingen van het DuckDuckGo-abonnement in de "
-"DuckDuckGo-browser."
+"en andere beveiligingen van het DuckDuckGo-abonnement in de DuckDuckGo-"
+"browser."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24349,6 +24930,12 @@ msgstr ""
 "versie hebt geïnstalleerd."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24396,6 +24983,12 @@ msgid "You've blocked 1 site"
 msgstr "Je hebt 1 site geblokkeerd"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24435,7 +25028,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
+msgstr ""
+"Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24604,8 +25198,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24613,8 +25207,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24647,8 +25241,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24794,6 +25388,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Je zoekacties kunnen niet aan jou worden gekoppeld."
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24875,7 +25477,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
+msgstr ""
+"Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24958,7 +25561,8 @@ msgstr "door %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
+msgstr ""
+"Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25384,3 +25988,9 @@ msgstr "jaar"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "jr"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,8 +87,7 @@ msgstr "%1$s en %2$s AI-modellen"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
+msgstr "%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -128,7 +127,7 @@ msgstr "%1$s gedetecteerd"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s bestanden gebruikt"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,7 +364,7 @@ msgstr "%1$s gebruikt"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s verbruikt limieten tot 2-5x sneller dan basismodellen %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -429,8 +428,7 @@ msgstr "%1$s woorden"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
+msgstr "%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -493,8 +491,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
+msgstr "%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -622,7 +619,7 @@ msgstr "1 dag geleden"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 bestand gebruikt"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -843,8 +840,7 @@ msgstr "De 6-uurs gebruikslimiet is bereikt."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1542,6 +1538,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Geavanceerde modellen kunnen limieten 2-5× sneller verbruiken dan andere "
+"modellen. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1824,8 +1822,7 @@ msgstr "Anonieme bestandscontrole toestaan voor deze chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
+msgstr "Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1985,8 +1982,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
-"source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
+"open-source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1995,8 +1992,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
-"source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
+"open-source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2336,7 +2333,7 @@ msgstr "Vraag privé"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Vraag privé"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2375,8 +2372,8 @@ msgstr ""
 "relevante webinhoud samen te vatten. Je kunt kiezen hoe vaak je wilt dat "
 "Assist wordt weergegeven: 'Nooit' (de Assist-gebruikersinterface wordt "
 "helemaal uit de zoekresultaten verwijderd), 'Op verzoek' (AI-antwoorden "
-"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' (AI-"
-"antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
+"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' "
+"(AI-antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
 "'Vaak' (wordt vaker weergegeven bij een breder scala aan zoekopdrachten). "
 "Voorlopig zijn AI-antwoorden alleen beschikbaar in de Amerikaanse regio."
 
@@ -2390,8 +2387,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist is een optionele functie in onze zoekresultaten die anoniem AI-"
-"ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
+"Assist is een optionele functie in onze zoekresultaten die anoniem "
+"AI-ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
 "het web op relevante inhoud en gebruikt vervolgens AI-technologie op basis "
 "van natuurlijke taal om een kort antwoord te genereren aan de hand van de "
 "gevonden relevante informatie. Het is belangrijk om te onthouden dat "
@@ -3664,8 +3661,7 @@ msgstr "Wijzigt hoe URL's van resultaten worden weergegeven"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
+msgstr "Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3876,16 +3872,14 @@ msgstr "Privé chatten"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
+msgstr "Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
+msgstr "Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3903,7 +3897,7 @@ msgstr "Privé chatten met AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Chat privé met populaire AI's"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4700,7 +4694,7 @@ msgstr "Sluiten"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Sluiten"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4750,7 +4744,7 @@ msgstr "Zoeken sluiten"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Second opinion sluiten"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5127,7 +5121,7 @@ msgstr "Advertenties blijven blokkeren"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Ga hier verder met recente chats. Of verwijder ze met de Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5198,7 +5192,7 @@ msgstr "Cookiegegevens:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Gekopieerd"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5251,7 +5245,7 @@ msgstr "Code kopiëren"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Link kopiëren"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5321,8 +5315,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
+msgstr "Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5371,14 +5364,13 @@ msgstr "Afbeelding maken"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Deellink aanmaken"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
-"Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
+msgstr "Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5424,6 +5416,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Het maken van een link maakt een kopie van de chat die bekeken kan worden "
+"door iedereen die deze opent."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5582,7 +5576,7 @@ msgstr "Antwoorden aanpassen"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Antwoorden aanpassen"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5649,8 +5643,7 @@ msgstr "Dagelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5873,7 +5866,7 @@ msgstr "Servergegevens verwijderen?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Gedeelde link verwijderen"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5885,7 +5878,7 @@ msgstr "Transcript verwijderen"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Een chat verwijderen"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5923,7 +5916,7 @@ msgstr "Afbeelding verwijderen?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Verwijder me"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6150,8 +6143,7 @@ msgstr "Uitschakelen en loskoppelen"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
+msgstr "Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6238,7 +6230,7 @@ msgstr "Promotie sluiten"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Rondleiding negeren"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6393,8 +6385,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder AI-"
-"functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
+"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder "
+"AI-functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6454,7 +6446,7 @@ msgstr "DuckDuckGo downloaden"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "DuckDuckGo downloaden"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6623,8 +6615,7 @@ msgstr "Sleep je foto's of PDF-bestanden"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
+msgstr "Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6676,7 +6667,7 @@ msgstr "Duck.ai van DuckDuckGo. Privé AI-chat. Gratis."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai kan nu pdf-bestanden analyseren. Probeer het maar eens!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6760,8 +6751,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een e-"
-"mail met deze anonieme code %1$s naar %2$s"
+"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een "
+"e-mail met deze anonieme code %1$s naar %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6823,8 +6814,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
+msgstr "Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -6839,7 +6829,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai ondersteunt modellen van Anthropic, OpenAI en meer."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6868,8 +6858,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privé AI-chatbot, gratis AI-chat, anonieme AI-chat, "
-"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open source  AI-"
-"modellen, privacy  AI, AI-chat zonder account"
+"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open "
+"source  AI-modellen, privacy  AI, AI-chat zonder account"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6941,9 +6931,9 @@ msgid ""
 msgstr ""
 "DuckAssist is een nieuwe functie in onze zoekresultaten die anoniem "
 "antwoorden voor zoekopdrachten kan genereren. Hij scant daarvoor Wikipedia "
-"en gerelateerde sites op relevante inhoud en gebruikt vervolgens AI-"
-"technologie voor natuurlijke taal om die informatie samen te vatten. Let op: "
-"de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
+"en gerelateerde sites op relevante inhoud en gebruikt vervolgens "
+"AI-technologie voor natuurlijke taal om die informatie samen te vatten. Let "
+"op: de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
 "inhoud en worden niet gecontroleerd op juistheid."
 
 # smartling.placeholder_format=C
@@ -7041,8 +7031,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
+msgstr "DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7264,8 +7253,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
+msgstr "DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7494,7 +7482,7 @@ msgstr "Meest bezochte websites inschakelen"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Nu inschakelen"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7656,8 +7644,7 @@ msgstr "Ben je tevreden met Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
+msgstr "Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7801,7 +7788,7 @@ msgstr "Entertainmentgids"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Volledige chat"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7871,8 +7858,7 @@ msgstr "Kaart uitvouwen"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
+msgstr "Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7969,13 +7955,13 @@ msgstr "Expliciete songteksten"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Ontdek Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Ontdek Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8082,7 +8068,7 @@ msgstr "Gratis"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRATIS EN OPTIONEEL"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8239,8 +8225,7 @@ msgstr "Filters niet effectief"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
+msgstr "Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8508,7 +8493,7 @@ msgstr "Opslagruimte vrijmaken"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Gratis en altijd privé"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8633,9 +8618,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Selecteer in de menubalk van de app voor Mac de optie <strong>DuckDuckGo</"
-"strong> &gt; <strong>Controleren op updates...</strong> en selecteer "
-"vervolgens <strong>Update installeren</strong>."
+"Selecteer in de menubalk van de app voor Mac de optie "
+"<strong>DuckDuckGo</strong> &gt; <strong>Controleren op updates...</strong> "
+"en selecteer vervolgens <strong>Update installeren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9000,8 +8985,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een DuckDuckGo-"
-"abonnement, dat ook onze VPN en andere premium privacybeschermingen omvat."
+"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een "
+"DuckDuckGo-abonnement, dat ook onze VPN en andere premium "
+"privacybeschermingen omvat."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9030,7 +9016,7 @@ msgstr "Hulp van de computer krijgen"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Krijg hogere gebruikslimieten met een DuckDuckGo-abonnement."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9073,13 +9059,15 @@ msgstr "Download de laatste versie"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Download de app"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Download de gratis DuckDuckGo-browser %1$som advertenties op YouTube te "
+"blokkeren.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9107,7 +9095,7 @@ msgstr "Overtuig je vrienden om over te stappen en help ons groeien!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Aan de slag-checklist"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9149,9 +9137,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
-"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
-"een ander apparaat%4$s"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
+"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
+"Synchroniseren met een ander apparaat%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9161,9 +9149,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
-"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
-"een ander apparaat%4$s en scan deze code:"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
+"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
+"Synchroniseren met een ander apparaat%4$s en scan deze code:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9175,8 +9163,8 @@ msgid ""
 msgstr ""
 "Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of naar de "
 "DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je herstel-"
-"PDF."
+"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je "
+"herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9800,7 +9788,7 @@ msgstr "Tips verbergen"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Tutorial verbergen"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10490,8 +10478,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbetert de leesbaarheid van het resultaat met een bijgewerkte URL-"
-"indeling, -plaatsing en -kleur"
+"Verbetert de leesbaarheid van het resultaat met een bijgewerkte "
+"URL-indeling, -plaatsing en -kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11366,8 +11354,7 @@ msgstr "Lees meer over hoe het werkt"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Informatie over waarom het terugdringen van online tracking belangrijk is."
+msgstr "Informatie over waarom het terugdringen van online tracking belangrijk is."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11430,6 +11417,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Hiermee kun je wisselen tussen het indienen van zoekopdrachten en prompts "
+"bij Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11507,7 +11496,7 @@ msgstr "Line-outs gewonnen"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Link verloopt over 7 dagen."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11818,8 +11807,7 @@ msgstr "Zorg ervoor dat alle woorden correct gespeld zijn."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
+msgstr "Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12612,7 +12600,7 @@ msgstr "Langer dan 20 minuten"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Meer tips"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13106,7 +13094,7 @@ msgstr "Nee, bedankt"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nee, bedankt"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13254,8 +13242,7 @@ msgstr "Geen resultaten gevonden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
+msgstr "Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13775,7 +13762,7 @@ msgstr "Aan maar geen nummers"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Onboarding voltooid"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13889,8 +13876,7 @@ msgstr "%1$s-website openen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
+msgstr "Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13994,7 +13980,7 @@ msgstr "Open suggesties voor het maken en bewerken van afbeeldingen"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Open checklist Aan de slag"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14059,8 +14045,7 @@ msgstr "Open het paneel 'Hoe Duck.ai werkt'"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
+msgstr "Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14749,7 +14734,7 @@ msgstr "Pin"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Een chat vastzetten"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14761,7 +14746,7 @@ msgstr "Pin hier chats vast van %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Pin mij"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14784,7 +14769,7 @@ msgstr "Vastgezet"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Vastgepinde chats verschijnen bovenaan je recente chats."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15108,6 +15093,8 @@ msgstr "Slechte opmaak"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Populaire AI-modellen beschikbaar. Geen account nodig. Chats door ons "
+"geanonimiseerd."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15321,7 +15308,7 @@ msgstr "Vorige tabbladen"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Vorige tips"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15333,8 +15320,7 @@ msgstr "Prijs"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr ""
-"De weergegeven prijs komt niet overeen met die op de site van de verkoper"
+msgstr "De weergegeven prijs komt niet overeen met die op de site van de verkoper"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -15617,8 +15603,7 @@ msgstr "Vraag het mij"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
+msgstr "Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15867,13 +15852,13 @@ msgstr "Redenerend AI-model met gemiddelde moderatie"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Redenering kan betere antwoorden geven op complexe vragen."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Redenering is grondiger, maar verbruikt limieten 2-5x sneller. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15914,7 +15899,7 @@ msgstr "Recente chatopslag kan worden aangepast in %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Recente chats"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16075,7 +16060,7 @@ msgstr "Gebruik verminderen"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Verminder je gebruik met een efficiënter model"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16236,8 +16221,7 @@ msgstr "Mijn keuze onthouden"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
+msgstr "Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16460,7 +16444,7 @@ msgstr "Herstel alle instellingen"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Tutorial resetten"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16478,7 +16462,7 @@ msgstr "Resolutie"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Antwoord"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16970,8 +16954,7 @@ msgstr "Bewaar maximaal 30 van je meest recente chats op je apparaat."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
+msgstr "Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17105,15 +17088,13 @@ msgstr "Schotland"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
+msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
+msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17188,7 +17169,7 @@ msgstr "%1$s zoeken om resultaten dichter bij je in de buurt te vinden?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Zoeken en Duck.ai-schakelaar"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17362,8 +17343,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar \"!"
-"w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
+"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar "
+"\"!w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17548,8 +17529,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
+msgstr "Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17565,7 +17545,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Veilig opgeslagen op onze versleutelde server."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17676,8 +17656,7 @@ msgstr "Bekijk enkele van onze nieuwste updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
+msgstr "Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17704,8 +17683,7 @@ msgstr "Selecteer %1$s%2$s%3$s en vervolgens %4$sZoekmachine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
+msgstr "Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17718,21 +17696,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17744,8 +17719,7 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in het uitklapmenu Standaard zoekmachine"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
+msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17757,8 +17731,7 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst met zoekmachines"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
+msgstr "Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17845,8 +17818,7 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
+msgstr "Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17868,8 +17840,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
+msgstr "Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18089,7 +18060,7 @@ msgstr "Instellen als startpagina"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "De toon en stijl van de reacties van Duck.ai instellen."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18162,13 +18133,13 @@ msgstr "Seychellen"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Delen"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Delen"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18207,15 +18178,15 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Deel een locatie op stadsniveau met AI-modellen om de relevantie te "
-"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan AI-"
-"modellen."
+"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan "
+"AI-modellen."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Chat delen"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18279,7 +18250,7 @@ msgstr "Deel positieve feedback"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Deelbereik"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18420,7 +18391,7 @@ msgstr "Details weergeven"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Duck.ai-tutorial weergeven"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18575,7 +18546,7 @@ msgstr "Laat meer zien"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Meer modellen weergeven"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18616,7 +18587,7 @@ msgstr "Zijbalk weergeven"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Toon stapsgewijze tips om het meeste uit Duck.ai te halen."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18711,8 +18682,7 @@ msgstr "Meest bezochte links weergeven op een nieuw tabblad"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
+msgstr "Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18726,8 +18696,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"Geeft af en toe herinneringen weer om je aan te melden voor de DuckDuckGo-"
-"nieuwsbrieven over privacy"
+"Geeft af en toe herinneringen weer om je aan te melden voor de "
+"DuckDuckGo-nieuwsbrieven over privacy"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18737,8 +18707,7 @@ msgstr "Geeft paginanummers weer naast resultaatpagina-einden"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
+msgstr "Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18767,8 +18736,8 @@ msgstr "Geeft een welkomstbericht weer bovenaan de pagina met zoekresultaten"
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
 msgstr ""
-"Geeft een welkomstbericht weer aan gebruikers van het EU-Android-"
-"voorkeursmenu"
+"Geeft een welkomstbericht weer aan gebruikers van het "
+"EU-Android-voorkeursmenu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18986,8 +18955,7 @@ msgstr "Er is iets misgegaan"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
+msgstr "Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19007,7 +18975,7 @@ msgstr "Er is iets misgegaan. Probeer het later opnieuw."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Er is iets misgegaan. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19025,8 +18993,7 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
+msgstr "Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19100,8 +19067,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
+msgstr "Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19309,7 +19275,7 @@ msgstr "Weeklimiet gebruiken"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Start een nieuwe chat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19417,8 +19383,7 @@ msgstr "Stop verborgen trackers die op de loer liggen op andere websites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Stop de meeste verborgen trackers die op de loer liggen op andere websites."
+msgstr "Stop de meeste verborgen trackers die op de loer liggen op andere websites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19900,7 +19865,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Overschakelen naar deze second opinion"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20063,7 +20028,7 @@ msgstr "Synchronisatie en back-up is tijdelijk niet beschikbaar"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Chats op al je apparaten synchroniseren"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20159,6 +20124,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Neem Duck.ai overal met je mee. Krijg het ingebouwd in onze gratis app voor "
+"snellere toegang, waar je ook bent."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20167,6 +20134,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Neem Duck.ai overal met je mee. Krijg het ingebouwd in onze gratis browser "
+"voor snellere toegang, waar je ook browst."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20429,15 +20398,13 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
+msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
+msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -20493,8 +20460,7 @@ msgstr "Het verzoek is verlopen. Probeer het opnieuw."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
+msgstr "De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -20634,8 +20600,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
+msgstr "Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20647,7 +20612,7 @@ msgstr "Deze maand"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Dit antwoord"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20659,7 +20624,7 @@ msgstr "Deze week"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Deze chat blijft in Duck.ai en blijft privé voor je."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20800,6 +20765,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Dit is gewoon een voorbeeldchat. Open het menu (de drie stipjes) en kies "
+"Vastpinnen om deze bovenaan je chats te houden!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20808,6 +20775,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Dit is gewoon een voorbeeldchat. Gebruik de Fire Button in het zijmenu om "
+"deze te verwijderen!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20856,8 +20825,7 @@ msgstr "Voor deze pagina moet JavaScript zijn ingeschakeld."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
+msgstr "De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20926,15 +20894,13 @@ msgstr "Deze vertaling is onjuist"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
+msgstr "Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
+msgstr "Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21053,8 +21019,8 @@ msgstr "Tips"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij helpen."
-"%2$s"
+"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij "
+"helpen.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21086,8 +21052,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
+msgstr "Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21128,8 +21093,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je DuckDuckGo-"
-"browser naar de nieuwste versie en probeer het opnieuw."
+"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je "
+"DuckDuckGo-browser naar de nieuwste versie en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21161,6 +21126,8 @@ msgstr "Vandaag"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Schakel over om privé AI-chat te proberen of %1$sschakel het uit in het menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21508,8 +21475,7 @@ msgstr "Probeer %1$s om dit soort berichten niet meer te zien."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
+msgstr "Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21578,7 +21544,7 @@ msgstr "Probeer ze uit"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Probeer een ander model"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21589,7 +21555,7 @@ msgstr "Probeer een zoekopdracht!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Probeer een suggestie"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21632,16 +21598,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
+msgstr "Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
+msgstr "Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21661,7 +21625,7 @@ msgstr "Probeer het gratis"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Probeer het gratis"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21675,14 +21639,13 @@ msgstr "Probeer het gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
+msgstr "Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Probeer 7 dagen gratis"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21709,14 +21672,13 @@ msgstr "Probeer onze browser"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
+msgstr "Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Probeer redeneren"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21971,7 +21933,7 @@ msgstr ""
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Duck.ai-schakelaar inschakelen"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22143,8 +22105,7 @@ msgstr ""
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr ""
-"Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
+msgstr "Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -22185,8 +22146,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
+msgstr "Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22201,15 +22161,13 @@ msgstr "Bij %1$sZoekinstellingen%2$s selecteer je %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
+msgstr "Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
+msgstr "Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22223,8 +22181,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
+msgstr "Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22325,8 +22282,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Ontgrendel geavanceerde AI-modellen en hogere limieten met een DuckDuckGo-"
-"abonnement"
+"Ontgrendel geavanceerde AI-modellen en hogere limieten met een "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22351,7 +22308,7 @@ msgstr "Ontgrendel geavanceerde AI met je abonnement!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Ontgrendel geavanceerde modellen"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22580,8 +22537,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
+msgstr "Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22691,8 +22647,7 @@ msgstr "Gebruik DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
+msgstr "Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22720,7 +22675,7 @@ msgstr "Gebruiken in Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Gebruik de Fire Button om een chat uit de geschiedenis te verwijderen."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22985,10 +22940,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open 'Duck.ai-"
-"instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en selecteer "
-"'Synchroniseren met een ander apparaat'. Of scan de QR-code op je herstel-"
-"PDF."
+"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open "
+"'Duck.ai-instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en "
+"selecteer 'Synchroniseren met een ander apparaat'. Of scan de QR-code op je "
+"herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23187,8 +23142,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Kijk in Duck Player om gepersonaliseerde advertenties op YouTube te "
-"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op YouTube-"
-"aanbevelingen."
+"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op "
+"YouTube-aanbevelingen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23281,14 +23236,12 @@ msgstr "We achtervolgen je niet met advertenties."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
+msgstr "We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
+msgstr "We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23314,8 +23267,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
+msgstr "We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23323,8 +23275,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
+msgstr "We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23411,8 +23362,7 @@ msgstr "De verbinding is verbroken. Probeer het later opnieuw."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
+msgstr "We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -23444,8 +23394,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
+msgstr "We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23468,8 +23417,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
+msgstr "We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23503,8 +23451,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
+msgstr "Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23614,8 +23561,7 @@ msgstr "Wekelijkse gebruikslimiet bereikt"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23668,8 +23614,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
+msgstr "Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23917,7 +23862,7 @@ msgstr "Waarom ben je weer teruggekeerd?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Wat kun je doen?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24346,6 +24291,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Met Duck.ai worden je chats geanonimiseerd en nooit gebruikt om AI te "
+"trainen. Schakel het op elk gewenst moment in of uit in het menu '%1$s'."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24698,8 +24645,7 @@ msgstr "Je kunt dit op elk moment wijzigen in %1$sZoekinstellingen%2$s"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
+msgstr "Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24781,7 +24727,7 @@ msgstr "Je kunt slechts %1$s afbeeldingen per gesprek bijvoegen."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Je kunt slechts %1$s tabbladen tegelijk bijvoegen."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24875,8 +24821,8 @@ msgid ""
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
 "Je hebt nu toegang tot geavanceerde AI-modellen. Je hebt toegang tot de VPN "
-"en andere beveiligingen van het DuckDuckGo-abonnement in de DuckDuckGo-"
-"browser."
+"en andere beveiligingen van het DuckDuckGo-abonnement in de "
+"DuckDuckGo-browser."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24933,7 +24879,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Je bent klaar!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24986,7 +24932,7 @@ msgstr "Je hebt 1 site geblokkeerd"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Je hebt de basis van Duck.ai onder de knie"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25028,8 +24974,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
+msgstr "Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25198,8 +25143,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -25207,8 +25152,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25241,8 +25186,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25394,6 +25339,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Je instellingen zijn opgeslagen, maar door cookies te verwijderen, worden ze "
+"gereset. Schakel de extensie %1$sDuckDuckGo No AI%2$s in om het permanent te "
+"maken."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25477,8 +25425,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
+msgstr "Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25561,8 +25508,7 @@ msgstr "door %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
+msgstr "Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25993,4 +25939,4 @@ msgstr "jr"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/nn_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nn_NO/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3682,6 +3714,11 @@ msgstr "Utklipp"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3717,6 +3754,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4024,6 +4066,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4078,6 +4125,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4115,6 +4167,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4211,6 +4268,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4245,6 +4307,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4370,6 +4439,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4606,9 +4680,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4636,6 +4720,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4889,6 +4978,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5055,6 +5149,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5230,6 +5329,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5337,6 +5441,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5825,6 +5934,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6066,6 +6180,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6199,6 +6318,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6280,6 +6409,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6611,6 +6745,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7032,6 +7171,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7061,6 +7205,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7078,6 +7232,11 @@ msgstr "Få denne songen på:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Få venane dine til å byta og hjelp oss å veksa!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7628,6 +7787,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8925,6 +9089,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8980,6 +9150,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9876,6 +10051,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Meir enn 20 minutt"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10270,6 +10450,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10820,6 +11005,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "På men utan nummer"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10990,6 +11180,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11590,9 +11785,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11607,6 +11812,11 @@ msgstr "Rosa"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11863,6 +12073,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12032,6 +12247,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12474,6 +12694,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12501,6 +12731,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12623,6 +12858,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12925,6 +13165,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Tilbakestill alle innstillingane"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12933,6 +13178,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13492,6 +13742,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Søk anonymt"
 
@@ -13774,6 +14029,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14177,6 +14437,11 @@ msgstr "Bruk som standard søkjemotor"
 msgid "Set as Homepage"
 msgstr "Vel som heimeside"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14229,6 +14494,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14259,6 +14534,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14307,6 +14588,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14418,6 +14704,11 @@ msgstr "Vis bokmerkeapp og innstillingsdata"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14542,6 +14833,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14570,6 +14866,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14868,6 +15169,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15100,6 +15406,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15578,6 +15889,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Byt til søkjemotoren som ikkje sporar deg. Nokosinne."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15690,6 +16008,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15760,6 +16083,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Ta tilbake personvernet ditt!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16128,9 +16465,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16231,6 +16578,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16489,6 +16850,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16826,9 +17192,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Prøv eit søk!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16882,6 +17258,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16892,6 +17273,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16915,6 +17301,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Prøv heimesida vår som aldri viser desse meldingane:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17114,6 +17505,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17402,6 +17798,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17698,6 +18099,11 @@ msgstr "Bruk i Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Bruk i Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18620,6 +19026,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Hva brakte deg tilbake i dag?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18959,6 +19370,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19305,6 +19723,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19413,6 +19837,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19447,6 +19876,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19750,6 +20184,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20222,6 +20663,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "reasons-to-use-duckduckgo"

--- a/locales/od_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/od_IN/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -486,6 +496,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "୧ ଦିନ ପୂର୍ବେ"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1225,6 +1240,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1848,6 +1870,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3082,6 +3109,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3678,6 +3710,11 @@ msgstr "କ୍ଲିପଆର୍ଟ"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3713,6 +3750,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4020,6 +4062,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4074,6 +4121,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4111,6 +4163,11 @@ msgstr "ଠିକଣା ପଟ୍ଟିରେ &amp; କପି କରି %sabout:
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4207,6 +4264,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4241,6 +4303,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4366,6 +4435,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4602,9 +4676,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4632,6 +4716,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4885,6 +4974,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5051,6 +5145,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5226,6 +5325,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5333,6 +5437,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5821,6 +5930,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6061,6 +6175,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6194,6 +6313,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6275,6 +6404,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6606,6 +6740,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7027,6 +7166,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7056,6 +7200,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7073,6 +7227,11 @@ msgstr "ଏହି ସଙ୍ଗୀତକୁ ପାଆନ୍ତୁ:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "ଆପଣଙ୍କର ସାଙ୍ଗକୁ ବଡ଼ାଇବାକୁ ଆଣନ୍ତୁ ଏବଂ ଆମକୁ ଆଗକୁ ବଢ଼ିବାରେ ସାହାର୍ଯ୍ୟ କରନ୍ତୁ!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7623,6 +7782,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8924,6 +9088,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "ଆପଣଙ୍କୁ ନାମହୀନ ଭାବେ ସନ୍ଧାନ କରିବାରେ DuckDuckGo  ସାହାର୍ଯ୍ୟ କରିଥାଏ"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8979,6 +9149,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9875,6 +10050,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "20 ମିନିଟରୁ ଅଧିକ ଲମ୍ବା ଭିଡିଓ"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10269,6 +10449,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10818,6 +11003,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "ଚାଲୁ କରନ୍ତୁ କିନ୍ତୁ କୌଣସି ଅଙ୍କ ଦିଅନ୍ତୁ ନାହିଁ"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10988,6 +11178,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11585,9 +11780,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11602,6 +11807,11 @@ msgstr "ଗୋଲାପୀ"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11858,6 +12068,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12027,6 +12242,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12469,6 +12689,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12496,6 +12726,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12618,6 +12853,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12920,6 +13160,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "ସମସ୍ତ ସେଟିଙ୍ଗ ରିସେଟ କରିଦିଅନ୍ତୁ"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12928,6 +13173,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13487,6 +13737,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "ଏକାନ୍ତରେ ଖୋଜନ୍ତୁ"
 
@@ -13769,6 +14024,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14171,6 +14431,11 @@ msgstr "ପୂର୍ବନିର୍ଦ୍ଧାରିତ ସର୍ଚ୍ଚ ଇ�
 msgid "Set as Homepage"
 msgstr "ମୁଖ୍ୟପୃଷ୍ଠା ବନାନ୍ତୁ"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14223,6 +14488,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14254,6 +14529,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14302,6 +14583,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14414,6 +14700,11 @@ msgstr "ବୁକମାର୍କଲେଟ ଏବଂ ସେଟିଙ୍ଗ ତଥ
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "ବିସ୍ତାରରେ ଦେଖାନ୍ତୁ"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14537,6 +14828,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14565,6 +14861,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14863,6 +15164,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15095,6 +15401,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15573,6 +15884,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "ଖୋଜାଖୋଜି ଇଞ୍ଜିନକୁ ଆସନ୍ତୁ ଯାହା ଆପଣଙ୍କର ଗତିବିଧିକୁ କେବେବି ନଜର ରଖେନାହିଁ । କଦାପି ନୁହେଁ ।"
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15685,6 +16003,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15755,6 +16078,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "ନିଜର ଗୋପନୀୟତାକୁ ଫେରିପାଆନ୍ତୁ!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16129,9 +16466,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16232,6 +16579,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16488,6 +16849,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16825,9 +17191,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "ଗୋଟିଏ ଖୋଜିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16881,6 +17257,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16891,6 +17272,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16914,6 +17300,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "ଆମର ଏହି ମୂଳପୃଷ୍ଠାଟି ଚେଷ୍ଟା କରନ୍ତୁ ଯେଉଁଥିରେ ଏହିଭଳି ବାର୍ତ୍ତା କେବେ ଦେଖାଯାଏନି:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17113,6 +17504,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17400,6 +17796,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17697,6 +18098,11 @@ msgstr "ଫାୟାରଫକ୍ସରେ ବ୍ୟବହାର କରନ୍ତ�
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "ସଫାରୀରେ ଉପଯୋଗ କରନ୍ତୁ"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18617,6 +19023,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "ଆପଣଙ୍କୁ ଆଜି କ'ଣ ଫେରାଇ ଆଣିଲା?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18956,6 +19367,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19302,6 +19720,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19410,6 +19834,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19446,6 +19875,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19749,6 +20183,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20223,6 +20664,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -122,6 +123,12 @@ msgstr "%1$s dni temu"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Wykryto język %1$s"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +362,12 @@ msgid "%s used"
 msgstr "%1$s wykorzystane"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s wyświetlenie"
@@ -489,7 +502,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
+msgstr ""
+"%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -602,6 +616,12 @@ msgstr "1 próba zablokowana przez DuckDuckGo w ciągu ostatnich 24 godzin"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 dzień temu"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -822,7 +842,8 @@ msgstr "Osiągnięto limit 6 godzin użytkowania."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -949,8 +970,8 @@ msgstr ""
 "Funkcja AI Chat umożliwia prowadzenie anonimowych rozmów z modelami czatu AI "
 "oferowanymi przez inne firmy. Wyłączenie tej opcji spowoduje ukrycie funkcji "
 "AI Chat w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do funkcji AI Chat na stronie "
-"%1$sduckduckgo.com/aichat%2$s."
+"możesz uzyskać dostęp do funkcji AI Chat na stronie %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1514,6 +1535,14 @@ msgid "Advanced Models"
 msgstr "Zaawansowane modele"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Reklamuj się w wyszukiwarce"
@@ -1850,7 +1879,8 @@ msgstr "To urządzenie jest już zsynchronizowane."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
+msgstr ""
+"Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2304,6 +2334,12 @@ msgid "Ask privately"
 msgstr "Zapytaj prywatnie"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2517,7 +2553,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
+msgstr ""
+"Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2904,7 +2941,8 @@ msgstr "Zablokuj tę witrynę we wszystkich wynikach"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
+msgstr ""
+"Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3244,7 +3282,8 @@ msgstr "Burundi"
 #. The first %s is the action button label ('Continue'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab.
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid "By clicking '%s' you agree to our %s."
-msgstr "Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
+msgstr ""
+"Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3635,7 +3674,8 @@ msgstr "Zmienia sposób wyświetlania adresów URL wyników"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
+msgstr ""
+"Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3654,7 +3694,8 @@ msgstr "Zmienia kolor tła na całej stronie"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
+msgstr ""
+"Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3787,8 +3828,8 @@ msgstr ""
 "rozmów z zewnętrznymi modelami czatu AI, obsługującymi modele OpenAI, "
 "Anthropic i inne. Wyłączenie tej opcji spowoduje ukrycie przycisków czatu i "
 "linków w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do czatu, przechodząc pod adres "
-"%1$shttps://duck.ai%2$s bezpośrednio."
+"możesz uzyskać dostęp do czatu, przechodząc pod adres %1$shttps://duck."
+"ai%2$s bezpośrednio."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3867,6 +3908,12 @@ msgstr "Czatuj prywatnie z %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Czatuj prywatnie z AI"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4666,6 +4713,12 @@ msgid "Close"
 msgstr "Zamknij"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4708,6 +4761,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Zamknij wyszukiwanie"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5081,6 +5140,12 @@ msgid "Continue Blocking Ads"
 msgstr "Kontynuuj blokowanie reklam"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5146,6 +5211,12 @@ msgid "Cookie data:"
 msgstr "Dane plików cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5191,6 +5262,12 @@ msgstr "Skopiuj i wklej %1$sabout:preferences#search%2$s do paska adresu"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Skopiuj kod"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5308,6 +5385,12 @@ msgid "Create Image"
 msgstr "Utwórz obraz"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5349,6 +5432,14 @@ msgstr "Utworzony przez"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Utworzony przez %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5504,6 +5595,12 @@ msgid "Customize responses"
 msgstr "Dostosuj odpowiedzi"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "Dostosuj tę stronę"
@@ -5568,7 +5665,8 @@ msgstr "Osiągnięto dzienny limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5788,10 +5886,22 @@ msgid "Delete Server Data?"
 msgstr "Usunąć dane serwera?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Usuń transkrypcję"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5824,6 +5934,12 @@ msgstr "Usuń obraz"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Usunąć obraz?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6134,6 +6250,12 @@ msgid "Dismiss promotion"
 msgstr "Odrzuć promocję"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6342,6 +6464,12 @@ msgstr "Pobieranie zakończone"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Pobierz DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6561,6 +6689,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai od DuckDuckGo. Prywatny czat AI. Bezpłatnie."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6652,7 +6786,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
+msgstr ""
+"Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6715,6 +6850,12 @@ msgid ""
 msgstr ""
 "Odpowiedzi Duck.ai nie są oparte na konkretnych źródłach ani sprawdzane pod "
 "kątem dokładności."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6919,7 +7060,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
+msgstr ""
+"DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7367,6 +7509,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Włącz opcję Najczęściej odwiedzane witryny"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7545,7 +7693,8 @@ msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
+msgstr ""
+"Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7672,6 +7821,12 @@ msgid "Entertainment guide"
 msgstr "Przewodnik rozrywkowy"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Gwinea Równikowa"
 
@@ -7679,7 +7834,8 @@ msgstr "Gwinea Równikowa"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
+msgstr ""
+"Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7739,7 +7895,8 @@ msgstr "Rozwiń mapę"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
+msgstr ""
+"Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7833,6 +7990,18 @@ msgstr "Rażąca zawartość"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Wulgarny tekst"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7934,6 +8103,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Bezpłatne"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8355,6 +8530,12 @@ msgid "Free Up Storage"
 msgstr "Zwolnienie miejsca przechowywania"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8364,7 +8545,8 @@ msgstr "Bezpłatne i prywatne czaty anonimizowane przez nas"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
+msgstr ""
+"Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8608,19 +8790,22 @@ msgstr "Ogólnego przeznaczenia"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8869,6 +9054,12 @@ msgid "Get computer help"
 msgstr "Uzyskaj pomoc dotyczącą komputera"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8906,6 +9097,18 @@ msgid "Get the Latest Version"
 msgstr "Pobierz najnowszą wersję"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8926,6 +9129,12 @@ msgstr "Znajdź ten utwór na:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Zaproś swoich znajomych i pomóż nam się rozwijać!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9000,7 +9209,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
+msgstr ""
+"Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9522,7 +9732,8 @@ msgstr "Podaj powód negatywnej oceny"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
+msgstr ""
+"Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -9611,6 +9822,12 @@ msgstr "Ukryj kroki"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Ukryj wskazówki"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10163,7 +10380,8 @@ msgstr "Jeśli chcesz nas wesprzeć, %1$spomóż nam rozpowszechnić DuckDuckGo%
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
+msgstr ""
+"Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10355,7 +10573,8 @@ msgstr "W menu na górze ekranu wybierz %1$sNarzędzia%2$s > %3$sUstawienia%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
+msgstr ""
+"W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10733,7 +10952,8 @@ msgstr "Jest szybki, bezpłatny i zapewnia Ci jeszcze większą ochronę online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
+msgstr ""
+"Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -10798,7 +11018,8 @@ msgstr "Dołącz do nas!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr "Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
+msgstr ""
+"Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11234,6 +11455,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Umożliwia anonimowe wyszukiwanie za pomocą DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11304,6 +11532,12 @@ msgid "Lineouts Won"
 msgstr "Wygrane auty"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Czcionka linków:"
@@ -11317,7 +11551,8 @@ msgstr "Linki:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
+msgstr ""
+"Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11428,7 +11663,8 @@ msgstr "Ładuj więcej obrazów podczas przewijania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
+msgstr ""
+"Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12187,7 +12423,8 @@ msgstr "Osiągnięty limit miesięczny"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12394,6 +12631,12 @@ msgstr "Więcej statystyk na %1$s"
 msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Ponad 20 minut"
+
+# smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12882,6 +13125,12 @@ msgstr "Nie, dziękuję"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Nie, dziękuję"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13546,6 +13795,12 @@ msgid "On but no numbers"
 msgstr "Włączone, ale bez liczb"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13760,6 +14015,12 @@ msgstr "Otwórz sugestie czatu"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Otwórz sugestie tworzenia i edycji obrazów"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14509,10 +14770,22 @@ msgid "Pin"
 msgstr "Przypnij"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Przypnij czaty tutaj z %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14530,6 +14803,12 @@ msgstr "Różowy"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Przypięte"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14853,6 +15132,12 @@ msgid "Poor formatting"
 msgstr "Słabe formatowanie"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15059,6 +15344,12 @@ msgstr "Poprzedni obraz"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Poprzednie karty"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15373,7 +15664,8 @@ msgstr "Chroń swoje dane podczas wyszukiwania i przeglądania."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
+msgstr ""
+"Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15586,19 +15878,34 @@ msgstr "Wnioskowanie AI"
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a high moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with high built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15634,6 +15941,12 @@ msgstr "Ostatnie karty"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Przechowywanie ostatnich czatów można dostosować w menu %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15789,6 +16102,12 @@ msgstr "Ponów wyszukiwanie bez tej witryny"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Zmniejsz użycie"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16169,6 +16488,12 @@ msgid "Reset All Settings"
 msgstr "Przywróć ustawienia domyślne"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16179,6 +16504,12 @@ msgstr "Reset za %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Rozdzielczość"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16674,8 +17005,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu "
-"end-to-end."
+"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu end-"
+"to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16883,6 +17214,12 @@ msgstr "Szukaj"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Wyszukaj %1$s, aby znaleźć wyniki w pobliżu."
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17247,7 +17584,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
+msgstr ""
+"Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17258,6 +17596,12 @@ msgid ""
 msgstr ""
 "Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym "
 "szyfrowaniem. Nikt poza Tobą nie może zobaczyć Twoich danych, nawet my."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17429,13 +17773,15 @@ msgstr "Wybierz %1$sDuckDuckGo%2$s i kliknij %3$sUstaw jako domyślną%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
+msgstr ""
+"Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
+msgstr ""
+"Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17526,7 +17872,8 @@ msgstr "Wybierz %1$sUstawienia%2$s z rozwijanego menu."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
+msgstr ""
+"Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17772,6 +18119,12 @@ msgid "Set as Homepage"
 msgstr "Ustaw jako stronę startową"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17839,6 +18192,18 @@ msgid "Seychelles"
 msgstr "Seszele"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17847,7 +18212,8 @@ msgstr "Udostępnij"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
+msgstr ""
+"Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17877,6 +18243,13 @@ msgstr ""
 "Udostępnij modelom AI informacje o lokalizacji na poziomie miasta, aby "
 "zwiększyć ich trafność. Duck.ai nigdy nie ujawnia Twojej dokładnej "
 "lokalizacji ani nam, ani modelom AI."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17935,6 +18308,12 @@ msgstr "Udostępnij adres URL strony"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Podziel się pozytywną opinią"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18070,6 +18449,12 @@ msgstr "Pokaż skryptozakładki i ustawienia"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Pokaż szczegół"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18221,6 +18606,12 @@ msgid "Show more"
 msgstr "Pokaż więcej"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18254,6 +18645,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Pokaż pasek boczny"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18330,7 +18727,8 @@ msgstr "Wyświetla poziome linie pomiędzy stronami z wynikami wyszukiwania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
+msgstr ""
+"Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18346,7 +18744,8 @@ msgstr "Wyświetla najczęściej odwiedzane łącza na stronie nowej karty"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
+msgstr ""
+"Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18632,6 +19031,12 @@ msgstr "Coś poszło nie tak podczas włączania Sync & Backup. Spróbuj ponowni
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Wystąpił błąd, spróbuj ponownie później."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18928,6 +19333,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Zacznij korzystać z limitu tygodniowego"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Zacznij szukać!"
@@ -19034,7 +19445,8 @@ msgstr "Zatrzymaj generowanie"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
+msgstr ""
+"Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19516,6 +19928,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Przejdź na wyszukiwarkę, która Cię nie śledzi. Nigdy."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19582,7 +20002,8 @@ msgstr "Sync & Backup włączone!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
+msgstr ""
+"Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19671,6 +20092,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Funkcja Sync & Backup jest tymczasowo niedostępna"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19756,6 +20183,22 @@ msgstr "Tadżykistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Odzyskaj swoją prywatność!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20045,7 +20488,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
+msgstr ""
+"Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20225,10 +20669,22 @@ msgid "This Month"
 msgstr "W tym miesiącu"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "W tym tygodniu"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20345,19 +20801,37 @@ msgstr "Tego obrazu nie dało się stworzyć."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
+msgstr ""
+"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
+msgstr ""
+"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Ta informacja nie jest przydatna"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20405,7 +20879,8 @@ msgstr "Ta strona do działania wymaga włączonego Javascriptu."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
+msgstr ""
+"Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20513,7 +20988,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
+msgstr ""
+"Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20638,7 +21114,8 @@ msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
+msgstr ""
+"Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20697,6 +21174,12 @@ msgstr "Dziś"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Dziś"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21110,9 +21593,21 @@ msgid "Try Them Out"
 msgstr "Wypróbuj je"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Spróbuj coś wyszukać!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21147,20 +21642,23 @@ msgstr "Spróbuj innych słów kluczowych."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
+msgstr ""
+"Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
+msgstr ""
+"Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
+msgstr ""
+"Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21177,6 +21675,12 @@ msgid "Try for free"
 msgstr "Wypróbuj bezpłatnie"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21191,6 +21695,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Wypróbuj bezpłatnie! Bezpieczna sieć VPN, zaawansowana i prywatna AI oraz "
 "wiele więcej."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21220,6 +21730,12 @@ msgid "Try our homepage that never shows these messages:"
 msgstr ""
 "Wypróbuj naszą stronę domową, która nigdy nie wyświetla poniższych "
 "komunikatów:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21463,7 +21979,8 @@ msgstr "Wyłącz:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
+msgstr ""
+"Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -21471,6 +21988,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr ""
 "Włącz Duck Player, aby oglądać treści w serwisie YouTube bez "
 "spersonalizowanych reklam"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21681,14 +22204,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
+msgstr ""
+"Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: "
-"https://duckduckgo.com"
+"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21698,13 +22222,15 @@ msgstr "Pod %1$sUstawienia wyszukiwania%2$s wybierz %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
+msgstr ""
+"Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
+msgstr ""
+"W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21818,7 +22344,8 @@ msgstr "Odblokuj za pomocą subskrypcji DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
+msgstr ""
+"Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21840,6 +22367,12 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "Odblokuj zaawansowane funkcje AI w subskrypcji!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -21851,7 +22384,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
+msgstr ""
+"Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22203,6 +22737,12 @@ msgid "Use in Safari"
 msgstr "Używaj w Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22225,7 +22765,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
+msgstr ""
+"Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -22767,7 +23308,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
+msgstr ""
+"Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22851,7 +23393,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
+msgstr ""
+"Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -22863,7 +23406,8 @@ msgstr "Nie śledzimy Cię. To jest nasza polityka prywatności w skrócie…"
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr "Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
+msgstr ""
+"Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23094,7 +23638,8 @@ msgstr "Osiągnięto tygodniowy limit użycia"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23391,6 +23936,12 @@ msgid "What brought you back today?"
 msgstr "Co Cię sprowadza?"
 
 # smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -23510,7 +24061,8 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
+msgstr ""
+"Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23585,7 +24137,8 @@ msgstr "Na jaki temat chcesz przekazać opinię?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
+msgstr ""
+"To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23807,6 +24360,14 @@ msgstr "Wygrane"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Zimowa pogoda"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24097,7 +24658,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
+msgstr ""
+"Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -24151,7 +24713,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
+msgstr ""
+"Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24196,7 +24759,8 @@ msgstr "Możesz kontynuować rozmowę, korzystając z limitu miesięcznego."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
+msgstr ""
+"Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24235,6 +24799,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Możesz dołączyć tylko %1$s zdjęć na każdą rozmowę."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24266,7 +24837,8 @@ msgstr "Można przywrócić swoje ustawienia po usunięciu plików cookie."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr "Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
+msgstr ""
+"Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -24379,6 +24951,12 @@ msgstr ""
 "aktualizacje aplikacji DuckDuckGo."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24427,6 +25005,12 @@ msgid "You've blocked 1 site"
 msgstr "Zablokowano 1 witrynę"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24452,7 +25036,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
+msgstr ""
+"Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -24585,8 +25170,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych "
-"witryn.DuckDuckGo nigdy nie ma dostępu do tych danych."
+"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych witryn."
+"DuckDuckGo nigdy nie ma dostępu do tych danych."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -24625,7 +25210,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
+msgstr ""
+"Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24825,6 +25411,14 @@ msgstr "Twoja rola"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Twoje wyszukiwania nie mogą być powiązane z Tobą"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25416,3 +26010,9 @@ msgstr "lat(a)"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "r."
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -128,7 +127,7 @@ msgstr "Wykryto język %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Użyto %1$s plików"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,7 +364,7 @@ msgstr "%1$s wykorzystane"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s zużywa limity do 2-5 razy szybciej niż podstawowe modele %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -502,8 +501,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
+msgstr "%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -621,7 +619,7 @@ msgstr "1 dzień temu"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "Użyto 1 pliku"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -842,8 +840,7 @@ msgstr "Osiągnięto limit 6 godzin użytkowania."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -970,8 +967,8 @@ msgstr ""
 "Funkcja AI Chat umożliwia prowadzenie anonimowych rozmów z modelami czatu AI "
 "oferowanymi przez inne firmy. Wyłączenie tej opcji spowoduje ukrycie funkcji "
 "AI Chat w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do funkcji AI Chat na stronie %1$sduckduckgo.com/"
-"aichat%2$s."
+"możesz uzyskać dostęp do funkcji AI Chat na stronie "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1541,6 +1538,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Zaawansowane modele mogą wykorzystywać limity 2–5 razy szybciej niż inne "
+"modele. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1879,8 +1878,7 @@ msgstr "To urządzenie jest już zsynchronizowane."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
+msgstr "Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2337,7 +2335,7 @@ msgstr "Zapytaj prywatnie"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Zapytaj prywatnie"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2553,8 +2551,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
+msgstr "Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2941,8 +2938,7 @@ msgstr "Zablokuj tę witrynę we wszystkich wynikach"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
+msgstr "Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3282,8 +3278,7 @@ msgstr "Burundi"
 #. The first %s is the action button label ('Continue'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab.
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid "By clicking '%s' you agree to our %s."
-msgstr ""
-"Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
+msgstr "Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3674,8 +3669,7 @@ msgstr "Zmienia sposób wyświetlania adresów URL wyników"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
+msgstr "Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3694,8 +3688,7 @@ msgstr "Zmienia kolor tła na całej stronie"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
+msgstr "Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3828,8 +3821,8 @@ msgstr ""
 "rozmów z zewnętrznymi modelami czatu AI, obsługującymi modele OpenAI, "
 "Anthropic i inne. Wyłączenie tej opcji spowoduje ukrycie przycisków czatu i "
 "linków w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do czatu, przechodząc pod adres %1$shttps://duck."
-"ai%2$s bezpośrednio."
+"możesz uzyskać dostęp do czatu, przechodząc pod adres "
+"%1$shttps://duck.ai%2$s bezpośrednio."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3913,7 +3906,7 @@ msgstr "Czatuj prywatnie z AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Czatuj prywatnie z popularnymi AI"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4716,7 +4709,7 @@ msgstr "Zamknij"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Zamknij"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4766,7 +4759,7 @@ msgstr "Zamknij wyszukiwanie"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Zamknij drugą opinię"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5143,7 +5136,7 @@ msgstr "Kontynuuj blokowanie reklam"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5214,7 +5207,7 @@ msgstr "Dane plików cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Skopiowano"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5267,7 +5260,7 @@ msgstr "Skopiuj kod"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopiuj link"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5388,7 +5381,7 @@ msgstr "Utwórz obraz"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Utwórz link do udostępnienia"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5440,6 +5433,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Utworzenie linku tworzy kopię czatu, którą może zobaczyć każdy, kto go "
+"otworzy."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5598,7 +5593,7 @@ msgstr "Dostosuj odpowiedzi"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Dostosuj odpowiedzi"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5665,8 +5660,7 @@ msgstr "Osiągnięto dzienny limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5889,7 +5883,7 @@ msgstr "Usunąć dane serwera?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Usuń udostępniony link"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5901,7 +5895,7 @@ msgstr "Usuń transkrypcję"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Usuń czat"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5939,7 +5933,7 @@ msgstr "Usunąć obraz?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Usuń mnie"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6253,7 +6247,7 @@ msgstr "Odrzuć promocję"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Odrzuć przewodnik"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6469,7 +6463,7 @@ msgstr "Pobierz DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Pobierz DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6692,7 +6686,7 @@ msgstr "Duck.ai od DuckDuckGo. Prywatny czat AI. Bezpłatnie."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai potrafi teraz analizować pliki PDF. Spróbuj!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6786,8 +6780,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
+msgstr "Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6855,7 +6848,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai obsługuje modele firm Anthropic, OpenAI i innych."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7060,8 +7053,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
+msgstr "DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7512,7 +7504,7 @@ msgstr "Włącz opcję Najczęściej odwiedzane witryny"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Włącz teraz"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7693,8 +7685,7 @@ msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
+msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7824,7 +7815,7 @@ msgstr "Przewodnik rozrywkowy"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Cały czat"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7834,8 +7825,7 @@ msgstr "Gwinea Równikowa"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
+msgstr "Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7895,8 +7885,7 @@ msgstr "Rozwiń mapę"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
+msgstr "Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7995,13 +7984,13 @@ msgstr "Wulgarny tekst"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Poznaj Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Poznaj Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8108,7 +8097,7 @@ msgstr "Bezpłatne"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "BEZPŁATNE I OPCJONALNE"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8533,7 +8522,7 @@ msgstr "Zwolnienie miejsca przechowywania"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Bezpłatne i zawsze prywatne"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8545,8 +8534,7 @@ msgstr "Bezpłatne i prywatne czaty anonimizowane przez nas"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
+msgstr "Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8790,22 +8778,19 @@ msgstr "Ogólnego przeznaczenia"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9057,7 +9042,7 @@ msgstr "Uzyskaj pomoc dotyczącą komputera"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Zyskaj wyższe limity użycia dzięki subskrypcji DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9100,13 +9085,15 @@ msgstr "Pobierz najnowszą wersję"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Pobierz aplikację"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9134,7 +9121,7 @@ msgstr "Zaproś swoich znajomych i pomóż nam się rozwijać!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Lista zadań na początek"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9209,8 +9196,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
+msgstr "Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9732,8 +9718,7 @@ msgstr "Podaj powód negatywnej oceny"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
+msgstr "Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -9827,7 +9812,7 @@ msgstr "Ukryj wskazówki"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Ukryj samouczek"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10380,8 +10365,7 @@ msgstr "Jeśli chcesz nas wesprzeć, %1$spomóż nam rozpowszechnić DuckDuckGo%
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
+msgstr "Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10573,8 +10557,7 @@ msgstr "W menu na górze ekranu wybierz %1$sNarzędzia%2$s > %3$sUstawienia%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
+msgstr "W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10952,8 +10935,7 @@ msgstr "Jest szybki, bezpłatny i zapewnia Ci jeszcze większą ochronę online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
+msgstr "Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11018,8 +11000,7 @@ msgstr "Dołącz do nas!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr ""
-"Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
+msgstr "Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11460,6 +11441,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Pozwala przełączać się między przesyłaniem zapytań wyszukiwania i promptów "
+"do Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11535,7 +11518,7 @@ msgstr "Wygrane auty"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Link wygasa za 7 dni."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11551,8 +11534,7 @@ msgstr "Linki:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
+msgstr "Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11663,8 +11645,7 @@ msgstr "Ładuj więcej obrazów podczas przewijania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
+msgstr "Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12423,8 +12404,7 @@ msgstr "Osiągnięty limit miesięczny"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12636,7 +12616,7 @@ msgstr "Ponad 20 minut"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Więcej porad"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13130,7 +13110,7 @@ msgstr "Nie, dziękuję"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nie, dziękuję"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13798,7 +13778,7 @@ msgstr "Włączone, ale bez liczb"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Onboarding zakończony"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -14020,7 +14000,7 @@ msgstr "Otwórz sugestie tworzenia i edycji obrazów"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Otwórz listę zadań na początek"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14773,7 +14753,7 @@ msgstr "Przypnij"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Przypnij czat"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14785,7 +14765,7 @@ msgstr "Przypnij czaty tutaj z %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Przypnij mnie"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14808,7 +14788,7 @@ msgstr "Przypięte"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Przypięte czaty pojawią się na górze Twoich ostatnich czatów."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15136,6 +15116,8 @@ msgstr "Słabe formatowanie"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Dostępne popularne modele AI. Konto nie jest wymagane. Czaty są "
+"anonimizowane przez nas."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15349,7 +15331,7 @@ msgstr "Poprzednie karty"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Poprzednie porady"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15664,8 +15646,7 @@ msgstr "Chroń swoje dane podczas wyszukiwania i przeglądania."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
+msgstr "Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15878,34 +15859,31 @@ msgstr "Wnioskowanie AI"
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a high moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with high built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Rozumowanie może dać lepsze odpowiedzi na złożone pytania."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15946,7 +15924,7 @@ msgstr "Przechowywanie ostatnich czatów można dostosować w menu %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Ostatnie czaty"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16107,7 +16085,7 @@ msgstr "Zmniejsz użycie"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Zmniejsz użycie dzięki bardziej wydajnemu modelowi"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16491,7 +16469,7 @@ msgstr "Przywróć ustawienia domyślne"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Zresetuj samouczek"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16509,7 +16487,7 @@ msgstr "Rozdzielczość"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Odpowiedź"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -17005,8 +16983,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu end-"
-"to-end."
+"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17219,7 +17197,7 @@ msgstr "Wyszukaj %1$s, aby znaleźć wyniki w pobliżu."
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Przełącz między wyszukiwaniem a Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17584,8 +17562,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
+msgstr "Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17601,7 +17578,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Bezpieczne przechowywanie na naszym zaszyfrowanym serwerze."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17773,15 +17750,13 @@ msgstr "Wybierz %1$sDuckDuckGo%2$s i kliknij %3$sUstaw jako domyślną%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
+msgstr "Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
+msgstr "Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17872,8 +17847,7 @@ msgstr "Wybierz %1$sUstawienia%2$s z rozwijanego menu."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
+msgstr "Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18122,7 +18096,7 @@ msgstr "Ustaw jako stronę startową"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Ustaw ton i styl odpowiedzi Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18195,13 +18169,13 @@ msgstr "Seszele"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Udostępnij"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Udostępnij"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18212,8 +18186,7 @@ msgstr "Udostępnij"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
+msgstr "Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18249,7 +18222,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Udostępnij czat"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18313,7 +18286,7 @@ msgstr "Podziel się pozytywną opinią"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Zakres udostępniania"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18454,7 +18427,7 @@ msgstr "Pokaż szczegół"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Pokaż samouczek Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18609,7 +18582,7 @@ msgstr "Pokaż więcej"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Pokaż więcej modeli"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18650,7 +18623,7 @@ msgstr "Pokaż pasek boczny"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Pokaż wskazówki krok po kroku, jak najlepiej wykorzystać Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18727,8 +18700,7 @@ msgstr "Wyświetla poziome linie pomiędzy stronami z wynikami wyszukiwania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
+msgstr "Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18744,8 +18716,7 @@ msgstr "Wyświetla najczęściej odwiedzane łącza na stronie nowej karty"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
+msgstr "Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19036,7 +19007,7 @@ msgstr "Wystąpił błąd, spróbuj ponownie później."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Wystąpił błąd. Spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19336,7 +19307,7 @@ msgstr "Zacznij korzystać z limitu tygodniowego"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Rozpocznij nowy czat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19445,8 +19416,7 @@ msgstr "Zatrzymaj generowanie"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
+msgstr "Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19933,7 +19903,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Przełącz na tę drugą opinię"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20002,8 +19972,7 @@ msgstr "Sync & Backup włączone!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
+msgstr "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20095,7 +20064,7 @@ msgstr "Funkcja Sync & Backup jest tymczasowo niedostępna"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Synchronizuj czaty pomiędzy urządzeniami"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20191,6 +20160,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Zabierz Duck.ai ze sobą wszędzie. Pobierz ją w naszej bezpłatnej aplikacji, "
+"aby mieć szybszy dostęp, gdziekolwiek jesteś."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20199,6 +20170,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Zabierz Duck.ai ze sobą wszędzie. Pobierz ją w naszej bezpłatnej "
+"przeglądarce, aby mieć szybszy dostęp, gdziekolwiek przeglądasz strony."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20488,8 +20461,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
+msgstr "Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20672,7 +20644,7 @@ msgstr "W tym miesiącu"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Ta odpowiedź"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20684,7 +20656,7 @@ msgstr "W tym tygodniu"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Ten czat zostaje w Duck.ai i pozostaje dla Ciebie prywatny."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20801,16 +20773,14 @@ msgstr "Tego obrazu nie dało się stworzyć."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
+msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
+msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20824,6 +20794,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"To tylko przykładowy czat. Otwórz jego menu (trzy kropki), a następnie "
+"wybierz Przypnij, aby zachować go na górze listy Twoich czatów."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20832,6 +20804,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"To tylko przykładowy czat. Użyj przycisku Fire Button w menu bocznym, aby go "
+"usunąć."
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20879,8 +20853,7 @@ msgstr "Ta strona do działania wymaga włączonego Javascriptu."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
+msgstr "Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20988,8 +20961,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
+msgstr "Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21114,8 +21086,7 @@ msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
+msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21179,7 +21150,7 @@ msgstr "Dziś"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
+msgstr "Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21596,7 +21567,7 @@ msgstr "Wypróbuj je"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Wypróbuj inny model"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21607,7 +21578,7 @@ msgstr "Spróbuj coś wyszukać!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Wypróbuj sugestię"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21642,23 +21613,20 @@ msgstr "Spróbuj innych słów kluczowych."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
+msgstr "Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
+msgstr "Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
+msgstr "Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21678,7 +21646,7 @@ msgstr "Wypróbuj bezpłatnie"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Wypróbuj bezpłatnie"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21700,7 +21668,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Wypróbuj za darmo przez 7 dni"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21735,7 +21703,7 @@ msgstr ""
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Wypróbuj rozumowanie"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21979,8 +21947,7 @@ msgstr "Wyłącz:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
+msgstr "Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -21993,7 +21960,7 @@ msgstr ""
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Włącz przełącznik Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22204,15 +22171,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
+msgstr "Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: https://"
-"duckduckgo.com"
+"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22222,15 +22188,13 @@ msgstr "Pod %1$sUstawienia wyszukiwania%2$s wybierz %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
+msgstr "Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
+msgstr "W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22344,8 +22308,7 @@ msgstr "Odblokuj za pomocą subskrypcji DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
+msgstr "Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22370,7 +22333,7 @@ msgstr "Odblokuj zaawansowane funkcje AI w subskrypcji!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Odblokuj zaawansowane modele"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22384,8 +22347,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
+msgstr "Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22740,7 +22702,7 @@ msgstr "Używaj w Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Użyj przycisku Fire Button, aby usunąć czat z historii."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22765,8 +22727,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
+msgstr "Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23308,8 +23269,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
+msgstr "Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23393,8 +23353,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
+msgstr "Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -23406,8 +23365,7 @@ msgstr "Nie śledzimy Cię. To jest nasza polityka prywatności w skrócie…"
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr ""
-"Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
+msgstr "Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23638,8 +23596,7 @@ msgstr "Osiągnięto tygodniowy limit użycia"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23939,7 +23896,7 @@ msgstr "Co Cię sprowadza?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Co potrafisz zrobić?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24061,8 +24018,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
+msgstr "Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24137,8 +24093,7 @@ msgstr "Na jaki temat chcesz przekazać opinię?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
+msgstr "To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24368,6 +24323,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Dzięki Duck.ai Twoje czaty są anonimizowane i nigdy nie są wykorzystywane do "
+"trenowania AI. Możesz włączyć lub wyłączyć tę funkcję w dowolnym momencie w "
+"menu %1$s."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24658,8 +24616,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
+msgstr "Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -24713,8 +24670,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
+msgstr "Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24759,8 +24715,7 @@ msgstr "Możesz kontynuować rozmowę, korzystając z limitu miesięcznego."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
+msgstr "Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24803,7 +24758,7 @@ msgstr "Możesz dołączyć tylko %1$s zdjęć na każdą rozmowę."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Jednocześnie możesz załączyć tylko następującą liczbę kart: %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24837,8 +24792,7 @@ msgstr "Można przywrócić swoje ustawienia po usunięciu plików cookie."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr ""
-"Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
+msgstr "Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -24954,7 +24908,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Wszystko gotowe!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -25008,7 +24962,7 @@ msgstr "Zablokowano 1 witrynę"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Udało Ci się opanować podstawy Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25036,8 +24990,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
+msgstr "Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -25170,8 +25123,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych witryn."
-"DuckDuckGo nigdy nie ma dostępu do tych danych."
+"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych "
+"witryn.DuckDuckGo nigdy nie ma dostępu do tych danych."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -25210,8 +25163,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
+msgstr "Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25419,6 +25371,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Twoje ustawienia zostały zapisane, ale usunięcie plików cookie je zresetuje. "
+"Włącz rozszerzenie %1$sDuckDuckGo No AI%2$s, aby zapisać je na stałe."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26015,4 +25969,4 @@ msgstr "r."
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ps_AF/LC_MESSAGES/duckduckgo.po
+++ b/locales/ps_AF/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4013,6 +4055,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4067,6 +4114,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4104,6 +4156,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4200,6 +4257,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4234,6 +4296,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4359,6 +4428,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4595,9 +4669,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4625,6 +4709,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4878,6 +4967,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5044,6 +5138,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5219,6 +5318,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5326,6 +5430,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5814,6 +5923,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6053,6 +6167,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6186,6 +6305,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6267,6 +6396,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6596,6 +6730,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7017,6 +7156,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7046,6 +7190,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7062,6 +7216,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7613,6 +7772,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8908,6 +9072,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8963,6 +9133,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9859,6 +10034,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10253,6 +10433,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10801,6 +10986,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr ""
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10969,6 +11159,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11565,9 +11760,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11582,6 +11787,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11838,6 +12048,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12007,6 +12222,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12449,6 +12669,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12476,6 +12706,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12598,6 +12833,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12900,6 +13140,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12908,6 +13153,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13465,6 +13715,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13745,6 +14000,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14142,6 +14402,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14194,6 +14459,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14223,6 +14498,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14271,6 +14552,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14382,6 +14668,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14506,6 +14797,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14534,6 +14830,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14832,6 +15133,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15064,6 +15370,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15542,6 +15853,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15654,6 +15972,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15723,6 +16046,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16092,9 +16429,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16195,6 +16542,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16451,6 +16812,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16788,8 +17154,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16844,6 +17220,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16854,6 +17235,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16876,6 +17262,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17076,6 +17467,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17360,6 +17756,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17655,6 +18056,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18568,6 +18974,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18907,6 +19318,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19251,6 +19669,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19359,6 +19783,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19393,6 +19822,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19690,6 +20124,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20162,4 +20603,9 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""

--- a/locales/pt_BR/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_BR/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%s detectado"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -491,6 +501,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 dia atrás"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1232,6 +1247,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1860,6 +1882,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3108,6 +3135,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3717,6 +3749,11 @@ msgstr "Clipart"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3752,6 +3789,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4060,6 +4102,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4114,6 +4161,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr "Dados do cookie:"
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4151,6 +4203,11 @@ msgstr "Copie e cole %sabout:preferences#search%s dentro da barra de endereço"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4247,6 +4304,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4281,6 +4343,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4406,6 +4475,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4642,9 +4716,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4672,6 +4756,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4925,6 +5014,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5092,6 +5186,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5267,6 +5366,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5374,6 +5478,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5874,6 +5983,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6127,6 +6241,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6260,6 +6379,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6341,6 +6470,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6672,6 +6806,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7093,6 +7232,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7124,6 +7268,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7141,6 +7295,11 @@ msgstr "Obtenha essa música em:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Faça seus amigos mudarem e nos ajude a crescer!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7691,6 +7850,11 @@ msgstr "Ocultar passos"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -9013,6 +9177,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Permite pesquisar anonimamente com DuckDuckGo"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9068,6 +9238,11 @@ msgstr "Desenho de Linha"
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9967,6 +10142,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Mais de 20 minutos"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10361,6 +10541,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10911,6 +11096,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Ativado, mas sem números"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11083,6 +11273,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11688,9 +11883,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11705,6 +11910,11 @@ msgstr "Rosa"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11961,6 +12171,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12130,6 +12345,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12574,6 +12794,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12601,6 +12831,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12723,6 +12958,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -13025,6 +13265,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Redefinir todas as configurações"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -13033,6 +13278,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13595,6 +13845,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Pesquise anonimamente"
 
@@ -13881,6 +14136,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14289,6 +14549,11 @@ msgstr "Define como ferramenta de busca padrão"
 msgid "Set as Homepage"
 msgstr "Definir como página inicial"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14343,6 +14608,16 @@ msgstr "Configurações atualizadas"
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14374,6 +14649,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14422,6 +14703,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14534,6 +14820,11 @@ msgstr "Mostrar marcadores e configurações de dados"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Mostrar detalhes"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14657,6 +14948,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14685,6 +14981,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14993,6 +15294,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15225,6 +15531,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15703,6 +16014,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Mude para a ferramenta de busca que não te rastreia. Nunca."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15815,6 +16133,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15885,6 +16208,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Recupere a sua privacidade!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16261,9 +16598,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16364,6 +16711,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16624,6 +16985,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16961,9 +17327,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Faça uma pesquisa!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -17018,6 +17394,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -17028,6 +17409,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -17051,6 +17437,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Experimente nossa página inicial, que nunca exibe essas mensagens:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17250,6 +17641,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17541,6 +17937,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17837,6 +18238,11 @@ msgstr "Use no Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Use no Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18765,6 +19171,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "O que te trouxe de volta hoje?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19106,6 +19517,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19454,6 +19872,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19563,6 +19987,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19601,6 +20030,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19909,6 +20343,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20384,6 +20825,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "ano"
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
 
 #~ msgctxt "SERP footer content"
 #~ msgid "%s Billion Searches"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s detetado"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s ficheiros usados"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,6 +365,8 @@ msgstr "%1$s utilizado"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
+"O %1$s usa os limites até 2 a 5 vezes mais depressa do que os modelos "
+"básicos %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -501,8 +503,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
+msgstr "%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -620,7 +621,7 @@ msgstr "Há um dia"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 ficheiro utilizado"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1274,8 +1275,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr ""
-"Os cliques em anúncios não são usados para criar perfis de utilizadores"
+msgstr "Os cliques em anúncios não são usados para criar perfis de utilizadores"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1543,6 +1543,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Os modelos avançados podem usar os limites 2 a 5 vezes mais depressa do que "
+"outros modelos. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1829,8 +1831,7 @@ msgstr "Permitir a revisão anónima de ficheiros neste chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
+msgstr "Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2341,7 +2342,7 @@ msgstr "Perguntar em privado"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Perguntar em privado"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2535,8 +2536,7 @@ msgstr "Resposta automática"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
+msgstr "Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2791,8 +2791,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Antes de guardar este relatório, o DuckDuckGo irá anonimizar a tua conversa "
-"removendo informações de identificação pessoal, como nomes, endereços de e-"
-"mail e metadados identificativos."
+"removendo informações de identificação pessoal, como nomes, endereços de "
+"e-mail e metadados identificativos."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3683,8 +3683,7 @@ msgstr "Modifica a cor de fundo em todo o site"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
+msgstr "Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3902,7 +3901,7 @@ msgstr "Conversar em privado com a IA"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Conversa em privado com IAs populares"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4067,8 +4066,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Consulta a página de estado para atualizações sobre esta indisponibilidade."
+msgstr "Consulta a página de estado para atualizações sobre esta indisponibilidade."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4541,8 +4539,7 @@ msgstr "Clica em %1$sFornecedores de Pesquisa%2$s em tipos de Add-on"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
+msgstr "No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4702,7 +4699,7 @@ msgstr "Fechar"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Fechar"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4752,7 +4749,7 @@ msgstr "Fechar pesquisa"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Fechar segunda opinião"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5129,7 +5126,7 @@ msgstr "Continuar a bloquear anúncios"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Continua as conversas recentes aqui. Ou elimina-as com o Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5200,7 +5197,7 @@ msgstr "Dados dos cookies:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Copiado"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5253,7 +5250,7 @@ msgstr "Copiar código"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Copiar link"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5374,7 +5371,7 @@ msgstr "Criar imagem"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Criar link de partilha"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5426,6 +5423,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Criar um link gera uma cópia da conversa que pode ser vista por qualquer "
+"pessoa que o abra."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5584,7 +5583,7 @@ msgstr "Personaliza as respostas"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Personalizar respostas"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5651,8 +5650,7 @@ msgstr "Limite diário atingido"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização diária atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização diária atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5875,7 +5873,7 @@ msgstr "Eliminar dados do servidor?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Eliminar link partilhado"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5887,7 +5885,7 @@ msgstr "Eliminar transcrição"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Eliminar uma conversa"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5925,7 +5923,7 @@ msgstr "Eliminar imagem?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Elimina-me"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6239,7 +6237,7 @@ msgstr "Ignorar promoção"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Ignorar visita guiada"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6456,7 +6454,7 @@ msgstr "Transferir DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Transferir DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6677,7 +6675,7 @@ msgstr "Duck.ai da DuckDuckGo. Chat privado de IA. Gratuito."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "O Duck.ai já consegue analisar PDFs. Experimenta!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6778,8 +6776,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
+msgstr "O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6841,7 +6838,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "O Duck.ai suporta modelos da Anthropic, OpenAI e outros."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6859,8 +6856,7 @@ msgstr "Duck.ai atualizado!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
+msgstr "O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7268,8 +7264,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
+msgstr "As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7498,7 +7493,7 @@ msgstr "Ativar os sites mais visitados"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Ativar agora"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7668,22 +7663,19 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
+msgstr "Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
+msgstr "Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
+msgstr "Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7723,15 +7715,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Certifica-te de que o teu navegador tem permissão para aceder à localização"
+msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Certifica-te de que o teu navegador tem permissão para aceder à localização."
+msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7815,7 +7805,7 @@ msgstr "Guia de entretenimento"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Conversa completa"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7988,13 +7978,13 @@ msgstr "Letras explícitas"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Explorar o Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Explora o Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8103,7 +8093,7 @@ msgstr "Grátis"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRÁTIS E OPCIONAL"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8526,7 +8516,7 @@ msgstr "Liberta o armazenamento"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Grátis e sempre privado"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8538,8 +8528,7 @@ msgstr "Chats gratuitos e privados, anonimizados por nós"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
+msgstr "Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9049,7 +9038,7 @@ msgstr "Obter ajuda informática"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9092,13 +9081,15 @@ msgstr "Obter a versão mais recente"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Descarrega a aplicação"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9126,7 +9117,7 @@ msgstr "Convida os teus amigos a trocar e ajuda-nos a crescer!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Lista de verificação para começar"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9817,7 +9808,7 @@ msgstr "Ocultar sugestões"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Ocultar tutorial"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10938,8 +10929,7 @@ msgstr "É rápido, gratuito e oferece ainda mais proteção online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
+msgstr "Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11326,8 +11316,7 @@ msgstr "Saber mais sobre a Proteção de privacidade ativa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
+msgstr "Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11443,7 +11432,7 @@ msgstr "Deixa-te pesquisar anonimamente com o DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11519,7 +11508,7 @@ msgstr "Lineouts Ganhos"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "O link expira em 7 dias."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11535,8 +11524,7 @@ msgstr "Ligações:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
+msgstr "Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11828,8 +11816,8 @@ msgstr "Certifica-te de que todas as palavras estão escritas corretamente."
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar pré-"
-"definido\"%2$s"
+"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar "
+"pré-definido\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12349,8 +12337,7 @@ msgstr "Capitalização do mercado"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Mobile Instructions (not displayed on settings page)"
-msgstr ""
-"Instruções para dispositivos móveis (não disponível na página de definições)"
+msgstr "Instruções para dispositivos móveis (não disponível na página de definições)"
 
 # smartling.placeholder_format=C
 #. A short label indicating that a user is a moderator of a discussion.
@@ -12409,8 +12396,7 @@ msgstr "Limite mensal atingido"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12622,7 +12608,7 @@ msgstr "Mais de 20 minutos"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Mais dicas"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13116,7 +13102,7 @@ msgstr "Não, obrigado"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Não, obrigado"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13786,7 +13772,7 @@ msgstr "Ligado, mas sem números"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Integração concluída"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -14008,7 +13994,7 @@ msgstr "Abrir sugestões para criar e editar imagens"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Abrir lista de verificação para começar"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14762,7 +14748,7 @@ msgstr "Afixar"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Fixar uma conversa"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14774,7 +14760,7 @@ msgstr "Coloca aqui as conversas do %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Afixa-me"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14797,7 +14783,7 @@ msgstr "Afixado"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "As conversas fixadas aparecerão no topo das tuas conversas recentes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14856,8 +14842,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
+msgstr "Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15124,6 +15109,8 @@ msgstr "Má formatação"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Modelos populares de IA disponíveis. Não precisas de uma conta. Chats "
+"anonimizados por nós."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15337,7 +15324,7 @@ msgstr "Separadores anteriores"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Dicas anteriores"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15883,13 +15870,15 @@ msgstr "IA de raciocínio com moderação média integrada"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "O raciocínio pode dar melhores respostas a perguntas complexas."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"O raciocínio é mais aprofundado, mas consome limites 2 a 5 vezes mais "
+"rapidamente. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15930,7 +15919,7 @@ msgstr "O armazenamento de conversas recentes pode ser ajustado em %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Conversas recentes"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16091,7 +16080,7 @@ msgstr "Reduzir utilização"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Reduz a utilização com um modelo mais eficiente"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16241,8 +16230,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão &quot;"
-"Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
+"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão "
+"&quot;Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16252,8 +16241,7 @@ msgstr "Memorizar a minha opção"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
+msgstr "Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16475,7 +16463,7 @@ msgstr "Restaurar todas as definições"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Repor tutorial"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16493,7 +16481,7 @@ msgstr "Resolução"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Resposta"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16622,8 +16610,7 @@ msgstr "Os resultados excluem informações de sites bloqueados."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
+msgstr "Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16981,8 +16968,7 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
+msgstr "Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17168,8 +17154,7 @@ msgstr "Desce na página e localiza %1$so teu navegador%2$s na lista."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
+msgstr "Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17205,7 +17190,7 @@ msgstr "Pesquisar %1$s para encontrar resultados mais perto de ti?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Alternador de Pesquisa e Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17589,7 +17574,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Armazenado de forma segura no nosso servidor encriptado."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17742,8 +17727,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
+msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17760,8 +17744,7 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sPredefinir%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
+msgstr "Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17781,8 +17764,7 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s na lista de fornecedores de pesquisa"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
+msgstr "Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17867,8 +17849,7 @@ msgstr "Seleciona %1$sDefinições%2$s e depois %3$sDefinições Avançadas%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
+msgstr "Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18113,7 +18094,7 @@ msgstr "Definir como página inicial"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Define o tom e o estilo das respostas do Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18186,13 +18167,13 @@ msgstr "Seicheles"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Partilhar"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Partilhar"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18203,8 +18184,7 @@ msgstr "Partilhar"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
+msgstr "Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18240,7 +18220,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Partilhar conversa"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18304,7 +18284,7 @@ msgstr "Partilhar comentário positivo"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Âmbito de partilha"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18445,7 +18425,7 @@ msgstr "Mostrar detalhes"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Mostrar tutorial do Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18575,8 +18555,7 @@ msgstr "Mostrar todos os resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
+msgstr "Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18601,7 +18580,7 @@ msgstr "Mostrar mais"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Mostrar mais modelos"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18642,7 +18621,7 @@ msgstr "Mostrar barra lateral"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Mostra dicas passo a passo para tirares o máximo partido do Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18718,8 +18697,7 @@ msgstr "Mostrar linhas horizontais nas quebras de página de resultados"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
+msgstr "Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18735,14 +18713,12 @@ msgstr "Mostra os links mais visitados na página de um novo separador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
+msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
+msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18773,8 +18749,7 @@ msgstr "Mostra sugestões na caixa de pesquisa enquanto digitas"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
+msgstr "Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18784,8 +18759,7 @@ msgstr "Mostra o fundo do botão de pesquisa"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
+msgstr "Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19030,7 +19004,7 @@ msgstr "Ocorreu um erro, tenta novamente mais tarde."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Ocorreu um erro. Tenta novamente."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19098,8 +19072,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"Este código é inválido. Confirma que introduziste ou leste o código correto."
+msgstr "Este código é inválido. Confirma que introduziste ou leste o código correto."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19333,7 +19306,7 @@ msgstr "Começar a usar o limite semanal"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Inicia um novo chat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19386,22 +19359,19 @@ msgstr "Fica no DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
+msgstr "Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19444,8 +19414,7 @@ msgstr "Bloqueia os rastreadores ocultos que se escondem noutros sites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
+msgstr "Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19618,8 +19587,7 @@ msgstr "Sugere um título para uma publicação num blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
+msgstr "Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19924,7 +19892,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Mudar para esta segunda opinião"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20088,7 +20056,7 @@ msgstr "O Sync & Backup está temporariamente indisponível"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sincronizar conversas entre dispositivos"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20184,6 +20152,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Leva o Duck.ai contigo para todo o lado. Obtém-no integrado na nossa "
+"aplicação gratuita para um acesso mais rápido, onde quer que estejas."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20192,6 +20162,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Leva o Duck.ai contigo para todo o lado. Obtém-no integrado no nosso "
+"navegador gratuito para um acesso mais rápido, onde quer que estejas a "
+"navegar."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20653,8 +20626,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
+msgstr "Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20666,7 +20638,7 @@ msgstr "Este mês"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Esta resposta"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20678,7 +20650,7 @@ msgstr "Esta Semana"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Esta conversa permanece no Duck.ai e continua privada para ti."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20730,15 +20702,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
+msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
+msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20818,6 +20788,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Esta é apenas uma conversa de exemplo. Abre o menu (os três pontos) e "
+"escolhe Afixar para a manteres no topo das tuas conversas!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20826,6 +20798,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Esta é apenas uma conversa de exemplo. Utiliza o Fire Button no menu lateral "
+"para a eliminar!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20945,8 +20919,7 @@ msgstr "Esta tradução está errada"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
+msgstr "Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20980,8 +20953,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
+msgstr "Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21108,8 +21080,7 @@ msgstr "Para continuar, tens de concordar com a %1$s e os %2$sdo Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
+msgstr "Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21174,6 +21145,8 @@ msgstr "Hoje"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21521,8 +21494,7 @@ msgstr "Experimenta %1$s para deixar de ver mensagens como esta."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
+msgstr "Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21591,7 +21563,7 @@ msgstr "Experimenta-os"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Experimenta um modelo diferente"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21602,7 +21574,7 @@ msgstr "Tenta uma pesquisa!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Experimenta uma sugestão"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21645,8 +21617,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Tenta permitir a localização anónima para obter resultados mais específicos."
+msgstr "Tenta permitir a localização anónima para obter resultados mais específicos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21673,7 +21644,7 @@ msgstr "Experimenta gratuitamente"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Experimenta gratuitamente"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21695,7 +21666,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Experimenta grátis durante 7 dias"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21728,7 +21699,7 @@ msgstr "Experimenta a nossa página, que nunca mostra estas mensagens:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Experimenta o raciocínio"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21797,8 +21768,7 @@ msgstr "Experimenta o novo chat privado de voz em tempo real!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
+msgstr "Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -21986,7 +21956,7 @@ msgstr "Ativa o Duck Player para ver o YouTube sem anúncios personalizados"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Ativar botão para ativar/desativar o Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22197,14 +22167,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
+msgstr "Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
+msgstr "Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22363,14 +22331,13 @@ msgstr "Desbloqueia a IA avançada com a tua subscrição!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Desbloqueia modelos avançados"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
+msgstr "Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -22733,7 +22700,7 @@ msgstr "Usa no Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Usa o Fire Button para eliminar uma conversa do histórico."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22944,8 +22911,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
+msgstr "Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23627,8 +23593,7 @@ msgstr "Limite de utilização semanal atingido"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23773,15 +23738,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Quais são alguns fatores a considerar ao comprar um monitor de computador?"
+msgstr "Quais são alguns fatores a considerar ao comprar um monitor de computador?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
+msgstr "Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23900,8 +23863,7 @@ msgstr "Quais são os pratos que tens de experimentar aqui?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Quais são os horários de funcionamento, localização e contactos deste local?"
+msgstr "Quais são os horários de funcionamento, localização e contactos deste local?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23931,7 +23893,7 @@ msgstr "O que te trouxe de volta hoje?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "O que podes fazer?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24051,8 +24013,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
+msgstr "O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24127,8 +24088,7 @@ msgstr "Sobre o que gostarias de dar feedback?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
+msgstr "O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24358,6 +24318,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Com o Duck.ai, as tuas conversas são anonimizadas e nunca são utilizadas "
+"para treinar a IA. Ativa ou desativa em qualquer altura no menu \"%1$s\"."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24704,8 +24666,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
+msgstr "Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24750,8 +24711,7 @@ msgstr "Podes continuar a conversar usando o teu limite mensal."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
+msgstr "Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24794,7 +24754,7 @@ msgstr "Só podes anexar %1$s imagens por conversa."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Só podes anexar %1$s separadores de cada vez."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24943,7 +24903,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Tudo pronto!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24996,7 +24956,7 @@ msgstr "Bloqueaste 1 site"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Dominaste os conceitos básicos do Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25036,8 +24996,7 @@ msgstr "Atingiste o limite de chat de voz para hoje. Tente novamente amanhã."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
+msgstr "Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25262,8 +25221,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
+msgstr "Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25406,6 +25364,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"As tuas definições estão guardadas, mas eliminar os cookies vai repô-las. "
+"Ativa a extensão %1$sDuckDuckGo No AI%2$s para a tornar permanente."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25481,15 +25441,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
+msgstr "Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
+msgstr "Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25572,8 +25530,7 @@ msgstr "por %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
+msgstr "DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26004,4 +25961,4 @@ msgstr "ano"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "Há %1$s dias"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s detetado"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +361,12 @@ msgid "%s used"
 msgstr "%1$s utilizado"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s visualização"
@@ -489,7 +501,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
+msgstr ""
+"%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -602,6 +615,12 @@ msgstr "1 tentativa bloqueada pelo DuckDuckGo nas últimas 24 horas"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Há um dia"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1255,7 +1274,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr "Os cliques em anúncios não são usados para criar perfis de utilizadores"
+msgstr ""
+"Os cliques em anúncios não são usados para criar perfis de utilizadores"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1515,6 +1535,14 @@ msgctxt ""
 "app variant)"
 msgid "Advanced Models"
 msgstr "Modelos avançados"
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1801,7 +1829,8 @@ msgstr "Permitir a revisão anónima de ficheiros neste chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
+msgstr ""
+"Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2309,6 +2338,12 @@ msgid "Ask privately"
 msgstr "Perguntar em privado"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2500,7 +2535,8 @@ msgstr "Resposta automática"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
+msgstr ""
+"Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2755,8 +2791,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Antes de guardar este relatório, o DuckDuckGo irá anonimizar a tua conversa "
-"removendo informações de identificação pessoal, como nomes, endereços de "
-"e-mail e metadados identificativos."
+"removendo informações de identificação pessoal, como nomes, endereços de e-"
+"mail e metadados identificativos."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3647,7 +3683,8 @@ msgstr "Modifica a cor de fundo em todo o site"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
+msgstr ""
+"Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3862,6 +3899,12 @@ msgid "Chat privately with AI"
 msgstr "Conversar em privado com a IA"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4024,7 +4067,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Consulta a página de estado para atualizações sobre esta indisponibilidade."
+msgstr ""
+"Consulta a página de estado para atualizações sobre esta indisponibilidade."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4497,7 +4541,8 @@ msgstr "Clica em %1$sFornecedores de Pesquisa%2$s em tipos de Add-on"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
+msgstr ""
+"No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4654,6 +4699,12 @@ msgid "Close"
 msgstr "Fechar"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4696,6 +4747,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Fechar pesquisa"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5069,6 +5126,12 @@ msgid "Continue Blocking Ads"
 msgstr "Continuar a bloquear anúncios"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5134,6 +5197,12 @@ msgid "Cookie data:"
 msgstr "Dados dos cookies:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5179,6 +5248,12 @@ msgstr "Copia e cola %1$sabout:preferences#search%2$s na barra de endereço"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Copiar código"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5296,6 +5371,12 @@ msgid "Create Image"
 msgstr "Criar imagem"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5337,6 +5418,14 @@ msgstr "Criado por"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Criado por %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5492,6 +5581,12 @@ msgid "Customize responses"
 msgstr "Personaliza as respostas"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "Personalizar esta página"
@@ -5556,7 +5651,8 @@ msgstr "Limite diário atingido"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização diária atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização diária atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5776,10 +5872,22 @@ msgid "Delete Server Data?"
 msgstr "Eliminar dados do servidor?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Eliminar transcrição"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5812,6 +5920,12 @@ msgstr "Eliminar imagem"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Eliminar imagem?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6122,6 +6236,12 @@ msgid "Dismiss promotion"
 msgstr "Ignorar promoção"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6331,6 +6451,12 @@ msgstr "Transferência concluída"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Transferir DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6548,6 +6674,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai da DuckDuckGo. Chat privado de IA. Gratuito."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6646,7 +6778,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
+msgstr ""
+"O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6705,6 +6838,12 @@ msgstr ""
 "verificadas quanto à precisão."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6720,7 +6859,8 @@ msgstr "Duck.ai atualizado!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
+msgstr ""
+"O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7128,7 +7268,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
+msgstr ""
+"As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7354,6 +7495,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Ativar os sites mais visitados"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7521,19 +7668,22 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
+msgstr ""
+"Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
+msgstr ""
+"Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
+msgstr ""
+"Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -7573,13 +7723,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização"
+msgstr ""
+"Certifica-te de que o teu navegador tem permissão para aceder à localização"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização."
+msgstr ""
+"Certifica-te de que o teu navegador tem permissão para aceder à localização."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -7658,6 +7810,12 @@ msgstr "Introduz a tua frase secreta para carregar as tuas definições."
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "Guia de entretenimento"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7827,6 +7985,18 @@ msgid "Explicit lyrics"
 msgstr "Letras explícitas"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7928,6 +8098,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Grátis"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8347,6 +8523,12 @@ msgid "Free Up Storage"
 msgstr "Liberta o armazenamento"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8356,7 +8538,8 @@ msgstr "Chats gratuitos e privados, anonimizados por nós"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
+msgstr ""
+"Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8863,6 +9046,12 @@ msgid "Get computer help"
 msgstr "Obter ajuda informática"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8900,6 +9089,18 @@ msgid "Get the Latest Version"
 msgstr "Obter a versão mais recente"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8920,6 +9121,12 @@ msgstr "Obter esta música em:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Convida os teus amigos a trocar e ajuda-nos a crescer!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9605,6 +9812,12 @@ msgstr "Ocultar passos"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Ocultar sugestões"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10725,7 +10938,8 @@ msgstr "É rápido, gratuito e oferece ainda mais proteção online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
+msgstr ""
+"Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11112,7 +11326,8 @@ msgstr "Saber mais sobre a Proteção de privacidade ativa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
+msgstr ""
+"Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11224,6 +11439,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Deixa-te pesquisar anonimamente com o DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Libéria"
 
@@ -11294,6 +11516,12 @@ msgid "Lineouts Won"
 msgstr "Lineouts Ganhos"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Tipo de letra das ligações:"
@@ -11307,7 +11535,8 @@ msgstr "Ligações:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
+msgstr ""
+"Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11599,8 +11828,8 @@ msgstr "Certifica-te de que todas as palavras estão escritas corretamente."
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar "
-"pré-definido\"%2$s"
+"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar pré-"
+"definido\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12120,7 +12349,8 @@ msgstr "Capitalização do mercado"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Mobile Instructions (not displayed on settings page)"
-msgstr "Instruções para dispositivos móveis (não disponível na página de definições)"
+msgstr ""
+"Instruções para dispositivos móveis (não disponível na página de definições)"
 
 # smartling.placeholder_format=C
 #. A short label indicating that a user is a moderator of a discussion.
@@ -12179,7 +12409,8 @@ msgstr "Limite mensal atingido"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12386,6 +12617,12 @@ msgstr "Mais estatísticas sobre %1$s"
 msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Mais de 20 minutos"
+
+# smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12874,6 +13111,12 @@ msgstr "Não, obrigado"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Não, obrigado"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13540,6 +13783,12 @@ msgid "On but no numbers"
 msgstr "Ligado, mas sem números"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13754,6 +14003,12 @@ msgstr "Abrir sugestões do chat"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Abrir sugestões para criar e editar imagens"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14504,10 +14759,22 @@ msgid "Pin"
 msgstr "Afixar"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Coloca aqui as conversas do %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14525,6 +14792,12 @@ msgstr "Cor de rosa"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Afixado"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14583,7 +14856,8 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
+msgstr ""
+"Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14846,6 +15120,12 @@ msgid "Poor formatting"
 msgstr "Má formatação"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15052,6 +15332,12 @@ msgstr "Imagem anterior"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Separadores anteriores"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15594,6 +15880,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "IA de raciocínio com moderação média integrada"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15627,6 +15925,12 @@ msgstr "Separadores Recentes"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "O armazenamento de conversas recentes pode ser ajustado em %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15784,6 +16088,12 @@ msgid "Reduce Usage"
 msgstr "Reduzir utilização"
 
 # smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
@@ -15931,8 +16241,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão "
-"&quot;Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
+"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão &quot;"
+"Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15942,7 +16252,8 @@ msgstr "Memorizar a minha opção"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
+msgstr ""
+"Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16161,6 +16472,12 @@ msgid "Reset All Settings"
 msgstr "Restaurar todas as definições"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16171,6 +16488,12 @@ msgstr "Reposição dentro de %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Resolução"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16299,7 +16622,8 @@ msgstr "Os resultados excluem informações de sites bloqueados."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
+msgstr ""
+"Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16657,7 +16981,8 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
+msgstr ""
+"Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -16843,7 +17168,8 @@ msgstr "Desce na página e localiza %1$so teu navegador%2$s na lista."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
+msgstr ""
+"Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -16874,6 +17200,12 @@ msgstr "Pesquisar"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Pesquisar %1$s para encontrar resultados mais perto de ti?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17254,6 +17586,12 @@ msgstr ""
 "ponta a ponta. Ninguém além de ti pode ver os teus dados, nem mesmo nós."
 
 # smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "Security issue"
 msgstr "Problema de Segurança"
@@ -17404,7 +17742,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17421,7 +17760,8 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sPredefinir%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17441,7 +17781,8 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s na lista de fornecedores de pesquisa"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17526,7 +17867,8 @@ msgstr "Seleciona %1$sDefinições%2$s e depois %3$sDefinições Avançadas%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
+msgstr ""
+"Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17768,6 +18110,12 @@ msgid "Set as Homepage"
 msgstr "Definir como página inicial"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17835,6 +18183,18 @@ msgid "Seychelles"
 msgstr "Seicheles"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17843,7 +18203,8 @@ msgstr "Partilhar"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
+msgstr ""
+"Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17873,6 +18234,13 @@ msgstr ""
 "Partilha uma localização ao nível da cidade com os modelos de IA para "
 "melhorar a relevância. O Duck.ai nunca revela a tua localização precisa a "
 "nós ou aos modelos de IA."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17931,6 +18299,12 @@ msgstr "Partilhar URL da página"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Partilhar comentário positivo"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18068,6 +18442,12 @@ msgid "Show Detail"
 msgstr "Mostrar detalhes"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "Mostrar o DuckAssist <sup>BETA</sup>"
@@ -18195,7 +18575,8 @@ msgstr "Mostrar todos os resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
+msgstr ""
+"Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18215,6 +18596,12 @@ msgstr "Mostrar mapa"
 msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr "Mostrar mais"
+
+# smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18250,6 +18637,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Mostrar barra lateral"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18325,7 +18718,8 @@ msgstr "Mostrar linhas horizontais nas quebras de página de resultados"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
+msgstr ""
+"Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18341,12 +18735,14 @@ msgstr "Mostra os links mais visitados na página de um novo separador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
+msgstr ""
+"Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
+msgstr ""
+"Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18377,7 +18773,8 @@ msgstr "Mostra sugestões na caixa de pesquisa enquanto digitas"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
+msgstr ""
+"Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18387,7 +18784,8 @@ msgstr "Mostra o fundo do botão de pesquisa"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
+msgstr ""
+"Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18629,6 +19027,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Ocorreu um erro, tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18694,7 +19098,8 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "Este código é inválido. Confirma que introduziste ou leste o código correto."
+msgstr ""
+"Este código é inválido. Confirma que introduziste ou leste o código correto."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -18925,6 +19330,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Começar a usar o limite semanal"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Começa a procurar!"
@@ -18975,19 +19386,22 @@ msgstr "Fica no DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19030,7 +19444,8 @@ msgstr "Bloqueia os rastreadores ocultos que se escondem noutros sites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
+msgstr ""
+"Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19203,7 +19618,8 @@ msgstr "Sugere um título para uma publicação num blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
+msgstr ""
+"Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19503,6 +19919,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Muda para o motor de busca que não te rastreia. Nunca."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19661,6 +20085,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "O Sync & Backup está temporariamente indisponível"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19746,6 +20176,22 @@ msgstr "Tajiquistão"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Recupera a tua privacidade!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20207,7 +20653,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
+msgstr ""
+"Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20216,10 +20663,22 @@ msgid "This Month"
 msgstr "Este mês"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Esta Semana"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20271,13 +20730,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
+msgstr ""
+"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
+msgstr ""
+"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20349,6 +20810,22 @@ msgstr "Este tipo de imagem não é compatível. Anexa um JPG, PNG, WebP ou GIF.
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Esta informação não é útil"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20468,7 +20945,8 @@ msgstr "Esta tradução está errada"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
+msgstr ""
+"Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20502,7 +20980,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
+msgstr ""
+"Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20629,7 +21108,8 @@ msgstr "Para continuar, tens de concordar com a %1$s e os %2$sdo Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
+msgstr ""
+"Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -20688,6 +21168,12 @@ msgstr "Hoje"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Hoje"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21035,7 +21521,8 @@ msgstr "Experimenta %1$s para deixar de ver mensagens como esta."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
+msgstr ""
+"Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21101,9 +21588,21 @@ msgid "Try Them Out"
 msgstr "Experimenta-os"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Tenta uma pesquisa!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21146,7 +21645,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Tenta permitir a localização anónima para obter resultados mais específicos."
+msgstr ""
+"Tenta permitir a localização anónima para obter resultados mais específicos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21170,6 +21670,12 @@ msgid "Try for free"
 msgstr "Experimenta gratuitamente"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21184,6 +21690,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Experimenta gratuitamente! Uma VPN segura, IA avançada e privada, e muito "
 "mais."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21211,6 +21723,12 @@ msgstr "Experimenta o nosso navegador"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Experimenta a nossa página, que nunca mostra estas mensagens:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21279,7 +21797,8 @@ msgstr "Experimenta o novo chat privado de voz em tempo real!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
+msgstr ""
+"Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -21462,6 +21981,12 @@ msgstr "Ativa a opção %1$sLocalização exata%2$s para resultados mais preciso
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Ativa o Duck Player para ver o YouTube sem anúncios personalizados"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21672,12 +22197,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
+msgstr ""
+"Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
+msgstr ""
+"Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21833,10 +22360,17 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "Desbloqueia a IA avançada com a tua subscrição!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
+msgstr ""
+"Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -22196,6 +22730,12 @@ msgid "Use in Safari"
 msgstr "Usa no Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
@@ -22404,7 +22944,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
+msgstr ""
+"Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23086,7 +23627,8 @@ msgstr "Limite de utilização semanal atingido"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23231,13 +23773,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Quais são alguns fatores a considerar ao comprar um monitor de computador?"
+msgstr ""
+"Quais são alguns fatores a considerar ao comprar um monitor de computador?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
+msgstr ""
+"Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23356,7 +23900,8 @@ msgstr "Quais são os pratos que tens de experimentar aqui?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Quais são os horários de funcionamento, localização e contactos deste local?"
+msgstr ""
+"Quais são os horários de funcionamento, localização e contactos deste local?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23381,6 +23926,12 @@ msgstr "O que te incomodou mais?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "O que te trouxe de volta hoje?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23500,7 +24051,8 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
+msgstr ""
+"O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23575,7 +24127,8 @@ msgstr "Sobre o que gostarias de dar feedback?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
+msgstr ""
+"O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23797,6 +24350,14 @@ msgstr "Vitórias"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Mistura invernal"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24143,7 +24704,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
+msgstr ""
+"Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24188,7 +24750,8 @@ msgstr "Podes continuar a conversar usando o teu limite mensal."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
+msgstr ""
+"Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24225,6 +24788,13 @@ msgstr "Só podes anexar %1$s imagens por conversa"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Só podes anexar %1$s imagens por conversa."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24370,6 +24940,12 @@ msgstr ""
 "a versão mais recente."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24417,6 +24993,12 @@ msgid "You've blocked 1 site"
 msgstr "Bloqueaste 1 site"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24454,7 +25036,8 @@ msgstr "Atingiste o limite de chat de voz para hoje. Tente novamente amanhã."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
+msgstr ""
+"Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24679,7 +25262,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
+msgstr ""
+"Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24816,6 +25400,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "As tuas pesquisas não podem ser associadas a ti"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24889,13 +25481,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
+msgstr ""
+"Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
+msgstr ""
+"Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24978,7 +25572,8 @@ msgstr "por %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
+msgstr ""
+"DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25404,3 +25999,9 @@ msgstr "anos"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "ano"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
-"20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -128,7 +127,7 @@ msgstr "%1$s detectată"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s fișiere utilizate"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -366,6 +365,8 @@ msgstr "%1$s utilizat"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
+"%1$s folosește limitele de până la 2–5 ori mai rapid decât modelele de bază "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -502,8 +503,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
+msgstr "%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -623,7 +623,7 @@ msgstr "1 zi în urmă"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 fișier utilizat"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1547,6 +1547,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Modelele avansate pot folosi limitele de 2-5 ori mai rapid decât alte "
+"modele. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1995,8 +1997,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
-"source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
+"open-source."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2005,8 +2007,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
-"source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
+"open-source."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2168,8 +2170,7 @@ msgstr "Ești încă acolo?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
+msgstr "Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2342,7 +2343,7 @@ msgstr "Întreabă în mod privat"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Întreabă în mod privat"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2495,8 +2496,7 @@ msgstr "Sunetul nu este stocat de noi sau de OpenAI după încheierea chatului."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
+msgstr "Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2537,8 +2537,7 @@ msgstr "Răspuns automat"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Generat automat pe baza surselor menționate. Poate conține inexactități."
+msgstr "Generat automat pe baza surselor menționate. Poate conține inexactități."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2915,8 +2914,7 @@ msgstr "Blochează ferestrele pop-up enervante privind modulele cookie"
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
-"Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
+msgstr "Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3002,8 +3000,7 @@ msgstr "Blocat:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr ""
-"Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
+msgstr "Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3909,7 +3906,7 @@ msgstr "Chat privat cu AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Fă chat în mod privat cu modele IA populare"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4074,8 +4071,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Verifică pagina de stare pentru actualizări despre această întrerupere."
+msgstr "Verifică pagina de stare pentru actualizări despre această întrerupere."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4467,8 +4463,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
+msgstr "Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4495,8 +4490,7 @@ msgstr "Fă click pe %1$sSetări%2$s în meniul vertical."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
+msgstr "Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4552,8 +4546,7 @@ msgstr "Fă click pe %1$sFurnizori căutare%2$s sub Tipuri Add-on-uri"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
+msgstr "Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4628,8 +4621,7 @@ msgstr "Apasă pe pictograma %1$spermisiuni%2$s din bara de adrese"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
+msgstr "Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4681,8 +4673,7 @@ msgstr "Fă click pe lupa din bara de căutare"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
+msgstr "Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -4715,7 +4706,7 @@ msgstr "Închidere"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Închide"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4765,7 +4756,7 @@ msgstr "Închide căutarea"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Închide a doua opinie"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5142,7 +5133,7 @@ msgstr "Continuă să blochezi reclamele"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Continuă chaturile recente aici. Sau șterge-le cu Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5213,7 +5204,7 @@ msgstr "Date cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Copiat"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5266,7 +5257,7 @@ msgstr "Copiază codul"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Copiază linkul"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5336,8 +5327,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
+msgstr "Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5386,7 +5376,7 @@ msgstr "Creează imaginea"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Creează linkul de distribuire"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5438,6 +5428,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Crearea unui link generează o copie a chatului care poate fi văzută de "
+"oricine îl deschide."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5596,7 +5588,7 @@ msgstr "Personalizează răspunsurile"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Personalizează răspunsurile"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5888,7 +5880,7 @@ msgstr "Dorești să ștergi datele serverului?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Șterge linkul distribuit"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5900,7 +5892,7 @@ msgstr "Șterge transcrierea"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Șterge un chat"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5938,7 +5930,7 @@ msgstr "Ștergi imaginea?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Șterge-mă"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6167,8 +6159,7 @@ msgstr "Dezactivare și deconectare"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
+msgstr "Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6255,7 +6246,7 @@ msgstr "Ignoră promoția"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Omite turul"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6471,7 +6462,7 @@ msgstr "Descarcă DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Descarcă DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6663,8 +6654,8 @@ msgstr "Duck.ai"
 msgctxt "Text on link to the Duck.ai Privacy Policy & Terms of Service page."
 msgid "Duck.ai Privacy Policy and Terms of Service"
 msgstr ""
-"Politica de confidențialitate și Condițiile de utilizare a serviciului Duck."
-"ai"
+"Politica de confidențialitate și Condițiile de utilizare a serviciului "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title of the modal that contains settings for Duck.ai.
@@ -6688,14 +6679,13 @@ msgstr "Condiții de utilizare Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
+msgstr "Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai poate acum să analizeze fișiere PDF. Încearcă!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6858,7 +6848,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai acceptă modele de la Anthropic, OpenAI și altele."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7061,8 +7051,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
+msgstr "DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7413,8 +7402,7 @@ msgstr "Se editează imaginea..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
+msgstr "Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7514,7 +7502,7 @@ msgstr "Activează Cele mai accesate site-uri"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Activează acum"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7719,8 +7707,7 @@ msgstr "Asigură-te că accesul la locație este %1$spermis%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
+msgstr "Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7822,7 +7809,7 @@ msgstr "Ghid de divertisment"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Întregul chat"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7925,8 +7912,7 @@ msgstr "Explică răspunsul acceptat în termeni simpli."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
+msgstr "Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7992,13 +7978,13 @@ msgstr "Versuri explicite"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Explorează Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Explorează Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8107,7 +8093,7 @@ msgstr "Gratuit"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRATUIT ȘI OPȚIONAL"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8533,7 +8519,7 @@ msgstr "Eliberează spațiu de stocare"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Gratuit și întotdeauna privat"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8545,8 +8531,7 @@ msgstr "Chaturi gratuite și private, anonimizate de noi"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
+msgstr "Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8576,8 +8561,7 @@ msgstr "Fără restricții de distrubuire și utilizare comercială"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
+msgstr "Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8658,9 +8642,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Din bara de meniu a aplicației pe Mac, selectează <strong>DuckDuckGo</"
-"strong> &gt; <strong>Caută actualizări...</strong>, apoi selectează "
-"<strong>Instalează actualizările</strong>."
+"Din bara de meniu a aplicației pe Mac, selectează "
+"<strong>DuckDuckGo</strong> &gt; <strong>Caută actualizări...</strong>, apoi "
+"selectează <strong>Instalează actualizările</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9057,7 +9041,7 @@ msgstr "Obține ajutor de la computer"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Obține limite mai mari de utilizare cu un abonament DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9100,13 +9084,15 @@ msgstr "Obține cea mai recentă versiune"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Descarcă aplicația"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9134,7 +9120,7 @@ msgstr "Convinge-ți prietenii să ne aleagă și să ne ajute să creștem!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Lista de verificare pentru a începe"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9208,8 +9194,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
+msgstr "Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9480,8 +9465,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
+msgstr "Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9827,7 +9811,7 @@ msgstr "Ascunde sfaturile"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Ascunde tutorialul"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10124,8 +10108,7 @@ msgstr "Cât de mult vrei să apară răspunsurile asistate de AI?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
+msgstr "Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10367,8 +10350,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
+msgstr "Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10897,8 +10879,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
+msgstr "E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11452,6 +11433,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Îți permite să comuți între trimiterea interogărilor de căutare și a "
+"solicitărilor către Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11527,7 +11510,7 @@ msgstr "Aruncări la margine câștigate"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Linkul expiră peste 7 zile."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11656,8 +11639,7 @@ msgstr "Încarcă mai multe imagini rezultate când derulezi"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
+msgstr "Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12416,8 +12398,7 @@ msgstr "Limita lunară a fost atinsă"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
+msgstr "Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12629,7 +12610,7 @@ msgstr "Mai mult de 20 de minute"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Mai multe sfaturi"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12807,8 +12788,7 @@ msgstr "Namibia"
 #. Title of the divisional championship series for the National League division of Major League Baseball
 msgctxt "Sports module"
 msgid "National League Championship Series"
-msgstr ""
-"National League Championship Series (Seria Campionatului Ligii Naționale)"
+msgstr "National League Championship Series (Seria Campionatului Ligii Naționale)"
 
 # smartling.placeholder_format=C
 #. Title of the divisional semi-final series for the National League division of Major League Baseball
@@ -13124,7 +13104,7 @@ msgstr "Nu, mulțumesc"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nu, mulțumesc"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13792,7 +13772,7 @@ msgstr "Activat dar fără paginare"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Înregistrare finalizată"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13906,8 +13886,7 @@ msgstr "Deschide website-ul %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
+msgstr "Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14011,7 +13990,7 @@ msgstr "Deschide, creează și editează sugestiile de imagini"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Deschide lista de verificare pentru a începe"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14764,7 +14743,7 @@ msgstr "Fixare"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Fixează un chat"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14776,7 +14755,7 @@ msgstr "Fixează chaturile aici din %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Fixează-mă"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14799,7 +14778,7 @@ msgstr "Fixat"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15123,6 +15102,8 @@ msgstr "Formatare inadecvată"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Modele IA populare disponibile. Nu este nevoie să ai un cont. Chaturi "
+"anonimizate de noi."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15336,7 +15317,7 @@ msgstr "Filele anterioare"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Sfaturi anterioare"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15882,13 +15863,15 @@ msgstr "AI cu raționament, cu moderare medie încorporată"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Raționamentul poate oferi răspunsuri mai bune la întrebări complexe."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Raționamentul este mai aprofundat, dar consumă limitele de 2–5 ori mai "
+"rapid. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15929,7 +15912,7 @@ msgstr "Stocarea chaturilor recente poate fi ajustată în %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Chaturi recente"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16090,7 +16073,7 @@ msgstr "Redu utilizarea"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Redu utilizarea cu un model mai eficient"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16251,8 +16234,7 @@ msgstr "Reține alegerea mea"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
+msgstr "Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16475,7 +16457,7 @@ msgstr "Resetează toate setările"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Resetează tutorialul"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16493,7 +16475,7 @@ msgstr "Rezoluție"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Răspuns"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16621,8 +16603,7 @@ msgstr "Rezultatele exclud informațiile de pe site-urile blocate."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
+msgstr "Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16978,16 +16959,14 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
+msgstr "Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
+msgstr "Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17202,7 +17181,7 @@ msgstr "Cauți %1$s pentru a găsi rezultate mai aproape de tine?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Comutator Căutare și Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17516,8 +17495,7 @@ msgstr "A doua opinie"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
+msgstr "Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17582,7 +17560,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Stocată în siguranță pe serverul nostru criptat."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17675,8 +17653,7 @@ msgstr "Vezi mai multe pe %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr ""
-"Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
+msgstr "Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -17694,8 +17671,7 @@ msgstr "Vezi câteva dintre cele mai recente actualizări ale noastre"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
+msgstr "Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17722,8 +17698,7 @@ msgstr "Selectează %1$s%2$s%3$s, apoi %4$sMotor de căutare%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
+msgstr "Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17736,35 +17711,30 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
+msgstr "Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr "Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17776,8 +17746,7 @@ msgstr "Selectează %1$sDuckDuckGo%2$s din lista de furnizori de căutare"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
+msgstr "Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17788,8 +17757,7 @@ msgstr "Selectează %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
+msgstr "Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17885,8 +17853,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr "Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17958,8 +17925,7 @@ msgstr "Text selectat din %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
+msgstr "Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18106,7 +18072,7 @@ msgstr "Setează ca Pagină de pornire"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Setează tonul și stilul răspunsurilor Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18179,13 +18145,13 @@ msgstr "Seychelles"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Distribuie"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Distribuie"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18234,7 +18200,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Distribuie chatul"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18298,7 +18264,7 @@ msgstr "Distribuie feedback pozitiv"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Aplicabilitatea distribuirii"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18439,7 +18405,7 @@ msgstr "Arată detaliat"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Afișează tutorialul Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18450,8 +18416,7 @@ msgstr "Afișează DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
+msgstr "Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18593,7 +18558,7 @@ msgstr "Arată mai multe"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Arată mai multe modele"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18634,7 +18599,7 @@ msgstr "Arată bara laterală"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Afișează sfaturi pas cu pas pentru a profita la maximum de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18711,8 +18676,7 @@ msgstr "Afișează linii orizontale la sfârșitul paginilor de rezultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
+msgstr "Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18866,8 +18830,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
+msgstr "Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19012,8 +18975,7 @@ msgstr "Ceva nu a funcționat, te rugăm să încerci din nou."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
+msgstr "A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19025,7 +18987,7 @@ msgstr "S-a produs o problemă, te rugăm să reîncerci mai târziu."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Ceva nu a funcționat. Încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19068,8 +19030,7 @@ msgstr "Ne pare rău, a survenit o eroare neașteptată."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
+msgstr "Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -19118,8 +19079,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
+msgstr "Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19327,7 +19287,7 @@ msgstr "Începe să folosești limita săptămânală"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Începe un nou chat"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19388,15 +19348,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19439,8 +19397,7 @@ msgstr "Oprește instrumentele de urmărire ascunse de pe alte site-uri."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
+msgstr "Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19614,8 +19571,7 @@ msgstr "Sugerează un titlu pentru o postare pe blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sugerează articole sau subiecte similare care merită explorate în continuare."
+msgstr "Sugerează articole sau subiecte similare care merită explorate în continuare."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19920,7 +19876,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Comută la această a doua opinie"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19989,8 +19945,7 @@ msgstr "Sync & Backup activat!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
+msgstr "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20081,7 +20036,7 @@ msgstr "Funcția de Sincronizare și backup este temporar indisponibilă"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sincronizează chaturile pe mai multe dispozitive"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20177,6 +20132,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Ia Duck.ai cu tine pretutindeni. Integrează-l în aplicația noastră gratuită "
+"pentru un acces mai rapid, oriunde te-ai afla."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20185,6 +20142,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Ia Duck.ai cu tine pretutindeni. Integrează-l în browserul nostru gratuit "
+"pentru un acces mai rapid, oriunde navighezi."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20208,8 +20167,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți Duck."
-"ai."
+"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20458,8 +20417,7 @@ msgstr "Fișierele atașate depășesc limita totală de %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
+msgstr "Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20647,8 +20605,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
+msgstr "Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20660,7 +20617,7 @@ msgstr "Luna aceasta"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Acest răspuns"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20672,7 +20629,7 @@ msgstr "Săptămâna aceasta"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Acest chat rămâne în Duck.ai și rămâne privat pentru tine."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20724,15 +20681,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
+msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
+msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20816,6 +20771,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Acesta este doar un chat exemplificativ. Deschide meniul aferent (cele trei "
+"puncte), apoi alege Fixează pentru a-l păstra în partea de sus a chaturilor!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20824,6 +20781,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Acesta este doar un chat exemplificativ. Folosește Fire Button din meniul "
+"lateral pentru a-l șterge!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20872,8 +20831,7 @@ msgstr "Această pagină necesită JavaScript pentru a funcționa."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
+msgstr "Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20976,8 +20934,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
+msgstr "Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21113,8 +21070,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Pentru a tipări indicații de orientare:%1$sîntoarce-te la hartă."
-"%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
+"Pentru a tipări indicații de orientare:%1$sîntoarce-te la "
+"hartă.%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
 "pictograma de tipărire.%4$s"
 
 # smartling.placeholder_format=C
@@ -21170,6 +21127,8 @@ msgstr "Astăzi"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Comută pentru a încerca chatul privat cu IA sau %1$sdezactivează-l din "
+"meniul %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21334,8 +21293,7 @@ msgstr "Instrumente de urmărire blocate în ultima oră"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
+msgstr "Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21589,7 +21547,7 @@ msgstr "Încearcă-le"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Încearcă un alt model"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21600,7 +21558,7 @@ msgstr "Încearcă o căutare!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Încearcă o sugestie"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21672,7 +21630,7 @@ msgstr "Încearcă gratis"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Încearcă gratis"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21686,14 +21644,13 @@ msgstr "Încearcă gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
+msgstr "Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Încearcă gratuit 7 zile"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21720,14 +21677,13 @@ msgstr "Încearcă browserul nostru"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
+msgstr "Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Încearcă raționamentul"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21974,14 +21930,13 @@ msgstr "Activează %1$sLocație precisă%2$s pentru rezultate mai precise"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
+msgstr "Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Activează comutatorul Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22192,14 +22147,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
+msgstr "Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
+msgstr "Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22209,8 +22162,7 @@ msgstr "Sub %1$sSetări de căutare%2$s selectează %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
+msgstr "Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22224,15 +22176,13 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
+msgstr "Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
+msgstr "Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22361,7 +22311,7 @@ msgstr "Deblochează inteligența artificială avansată cu abonamentul tău!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Deblochează modele avansate"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22688,9 +22638,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. Protejează-"
-"ți chaturile împotriva hackerilor, a escrocilor și a companiilor. Păstrează "
-"informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
+"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. "
+"Protejează-ți chaturile împotriva hackerilor, a escrocilor și a companiilor. "
+"Păstrează informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22732,7 +22682,7 @@ msgstr "Folosește în Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Folosește Fire Button pentru a șterge un chat din istoric."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23237,8 +23187,7 @@ msgstr "Anonimizăm"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
+msgstr "Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23385,8 +23334,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
+msgstr "Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -23400,8 +23348,7 @@ msgstr ""
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr ""
-"Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
+msgstr "Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23461,8 +23408,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
+msgstr "Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23757,8 +23703,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea Duck."
-"ai. Încearcă să reîncarci pagina."
+"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea "
+"Duck.ai. Încearcă să reîncarci pagina."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23821,10 +23767,10 @@ msgid ""
 msgstr ""
 "Care sunt beneficiile descărcării browserului DuckDuckGo pentru tine, dacă "
 "vrei să folosești Duck.ai? Citește doar surse oficiale DuckDuckGo. Împarte "
-"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările Duck."
-"ai și pe protecția confidențialității. Păstrează-l destul de scurt, simplu "
-"și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau în "
-"domeniul tehnic."
+"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările "
+"Duck.ai și pe protecția confidențialității. Păstrează-l destul de scurt, "
+"simplu și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau "
+"în domeniul tehnic."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23890,8 +23836,7 @@ msgstr "Care sunt principalele lucruri pe care le voi învăța din acest curs?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
-"Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
+msgstr "Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -23942,7 +23887,7 @@ msgstr "Ce te-a adus astăzi înapoi?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Ce poți face?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24063,8 +24008,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de bookmarklet-"
-"ul cu parametri URL?"
+"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de "
+"bookmarklet-ul cu parametri URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24173,8 +24118,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
+msgstr "Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24192,8 +24136,7 @@ msgstr "Unde să urmărești <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
+msgstr "Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24373,6 +24316,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Cu Duck.ai, chaturile tale sunt anonimizate și nu sunt niciodată folosite "
+"pentru a antrena IA. Activează-l sau dezactivează-l oricând din meniul "
+"„%1$s”."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24807,7 +24753,7 @@ msgstr "Poți atașa doar %1$s imagini per conversație."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Poți atașa doar %1$s file odată."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24954,7 +24900,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Ești gata!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -25007,7 +24953,7 @@ msgstr "Ai blocat 1 site"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Ai stăpânit noțiunile de bază ale Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25027,8 +24973,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
+msgstr "Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25055,8 +25000,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile Duck."
-"ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
+"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile "
+"Duck.ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
 "sincronizarea. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
@@ -25271,8 +25216,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
+msgstr "Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25319,8 +25263,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
+msgstr "Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25416,6 +25359,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Setările tale sunt salvate, dar ștergerea modulelor cookie le va reseta. "
+"Activează extensia %1$sDuckDuckGo No AI%2$s pentru a le face permanente."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25492,15 +25437,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
+msgstr "Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
+msgstr "Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26016,4 +25959,4 @@ msgstr "a"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -122,6 +123,12 @@ msgstr "%1$s zile în urmă"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s detectată"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +362,12 @@ msgid "%s used"
 msgstr "%1$s utilizat"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s vizualizare"
@@ -489,7 +502,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
+msgstr ""
+"%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -604,6 +618,12 @@ msgstr "1 încercare blocată de DuckDuckGo în ultimele 24 de ore"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 zi în urmă"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1521,6 +1541,14 @@ msgid "Advanced Models"
 msgstr "Modele avansate"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Adaugă un anunț în pagina de căutare"
@@ -1967,8 +1995,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
-"open-source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
+"source."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1977,8 +2005,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
-"open-source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
+"source."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2140,7 +2168,8 @@ msgstr "Ești încă acolo?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
+msgstr ""
+"Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2310,6 +2339,12 @@ msgid "Ask privately"
 msgstr "Întreabă în mod privat"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2460,7 +2495,8 @@ msgstr "Sunetul nu este stocat de noi sau de OpenAI după încheierea chatului."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
+msgstr ""
+"Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2501,7 +2537,8 @@ msgstr "Răspuns automat"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Generat automat pe baza surselor menționate. Poate conține inexactități."
+msgstr ""
+"Generat automat pe baza surselor menționate. Poate conține inexactități."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2878,7 +2915,8 @@ msgstr "Blochează ferestrele pop-up enervante privind modulele cookie"
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr "Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
+msgstr ""
+"Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -2964,7 +3002,8 @@ msgstr "Blocat:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr "Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
+msgstr ""
+"Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3867,6 +3906,12 @@ msgid "Chat privately with AI"
 msgstr "Chat privat cu AI"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4029,7 +4074,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Verifică pagina de stare pentru actualizări despre această întrerupere."
+msgstr ""
+"Verifică pagina de stare pentru actualizări despre această întrerupere."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4421,7 +4467,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
+msgstr ""
+"Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4448,7 +4495,8 @@ msgstr "Fă click pe %1$sSetări%2$s în meniul vertical."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
+msgstr ""
+"Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4504,7 +4552,8 @@ msgstr "Fă click pe %1$sFurnizori căutare%2$s sub Tipuri Add-on-uri"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
+msgstr ""
+"Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4579,7 +4628,8 @@ msgstr "Apasă pe pictograma %1$spermisiuni%2$s din bara de adrese"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
+msgstr ""
+"Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4631,7 +4681,8 @@ msgstr "Fă click pe lupa din bara de căutare"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
+msgstr ""
+"Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -4659,6 +4710,12 @@ msgstr "Clipart"
 #. An accessible label for a button that closes a modal dialog
 msgid "Close"
 msgstr "Închidere"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4703,6 +4760,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Închide căutarea"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5076,6 +5139,12 @@ msgid "Continue Blocking Ads"
 msgstr "Continuă să blochezi reclamele"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5141,6 +5210,12 @@ msgid "Cookie data:"
 msgstr "Date cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5186,6 +5261,12 @@ msgstr "Copiază și lipește %1$sdespre:preferințe#caută%2$s în bara de adre
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Copiază codul"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5255,7 +5336,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
+msgstr ""
+"Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5301,6 +5383,12 @@ msgid "Create Image"
 msgstr "Creează imaginea"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5342,6 +5430,14 @@ msgstr "Creat de"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Creat de %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5495,6 +5591,12 @@ msgstr "Personalizează răspunsurile"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Personalizează răspunsurile"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5783,10 +5885,22 @@ msgid "Delete Server Data?"
 msgstr "Dorești să ștergi datele serverului?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Șterge transcrierea"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5819,6 +5933,12 @@ msgstr "Șterge imaginea"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Ștergi imaginea?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6047,7 +6167,8 @@ msgstr "Dezactivare și deconectare"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
+msgstr ""
+"Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6129,6 +6250,12 @@ msgstr "Ignoră pentru totdeauna"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Ignoră promoția"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6341,6 +6468,12 @@ msgid "Download DuckDuckGo"
 msgstr "Descarcă DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo Browser"
@@ -6530,8 +6663,8 @@ msgstr "Duck.ai"
 msgctxt "Text on link to the Duck.ai Privacy Policy & Terms of Service page."
 msgid "Duck.ai Privacy Policy and Terms of Service"
 msgstr ""
-"Politica de confidențialitate și Condițiile de utilizare a serviciului "
-"Duck.ai"
+"Politica de confidențialitate și Condițiile de utilizare a serviciului Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Title of the modal that contains settings for Duck.ai.
@@ -6555,7 +6688,14 @@ msgstr "Condiții de utilizare Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
+msgstr ""
+"Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
+
+# smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6713,6 +6853,12 @@ msgid ""
 msgstr ""
 "Răspunsurile Duck.ai nu se bazează pe surse specifice și acuratețea lor nu "
 "este verificată."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6915,7 +7061,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
+msgstr ""
+"DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7266,7 +7413,8 @@ msgstr "Se editează imaginea..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
+msgstr ""
+"Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7361,6 +7509,12 @@ msgstr "Activează Cele mai accesate site-uri"
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Activează Cele mai accesate site-uri"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7565,7 +7719,8 @@ msgstr "Asigură-te că accesul la locație este %1$spermis%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
+msgstr ""
+"Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7662,6 +7817,12 @@ msgstr "Introdu parola pentru a încărca setările."
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "Ghid de divertisment"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7764,7 +7925,8 @@ msgstr "Explică răspunsul acceptat în termeni simpli."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
+msgstr ""
+"Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7825,6 +7987,18 @@ msgstr "Conținut explicit"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Versuri explicite"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7928,6 +8102,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Gratuit"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8350,6 +8530,12 @@ msgid "Free Up Storage"
 msgstr "Eliberează spațiu de stocare"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8359,7 +8545,8 @@ msgstr "Chaturi gratuite și private, anonimizate de noi"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
+msgstr ""
+"Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8389,7 +8576,8 @@ msgstr "Fără restricții de distrubuire și utilizare comercială"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
+msgstr ""
+"Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8470,9 +8658,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Din bara de meniu a aplicației pe Mac, selectează "
-"<strong>DuckDuckGo</strong> &gt; <strong>Caută actualizări...</strong>, apoi "
-"selectează <strong>Instalează actualizările</strong>."
+"Din bara de meniu a aplicației pe Mac, selectează <strong>DuckDuckGo</"
+"strong> &gt; <strong>Caută actualizări...</strong>, apoi selectează "
+"<strong>Instalează actualizările</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8866,6 +9054,12 @@ msgid "Get computer help"
 msgstr "Obține ajutor de la computer"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8903,6 +9097,18 @@ msgid "Get the Latest Version"
 msgstr "Obține cea mai recentă versiune"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8923,6 +9129,12 @@ msgstr "Obține piesa de pe:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Convinge-ți prietenii să ne aleagă și să ne ajute să creștem!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8996,7 +9208,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
+msgstr ""
+"Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9267,7 +9480,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
+msgstr ""
+"Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9610,6 +9824,12 @@ msgid "Hide Tips"
 msgstr "Ascunde sfaturile"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9904,7 +10124,8 @@ msgstr "Cât de mult vrei să apară răspunsurile asistate de AI?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
+msgstr ""
+"Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10146,7 +10367,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
+msgstr ""
+"Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10675,7 +10897,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
+msgstr ""
+"E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11224,6 +11447,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Permite căutarea anonimă folosind DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11292,6 +11522,12 @@ msgstr "Desen cu linii"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Aruncări la margine câștigate"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11420,7 +11656,8 @@ msgstr "Încarcă mai multe imagini rezultate când derulezi"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
+msgstr ""
+"Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12179,7 +12416,8 @@ msgstr "Limita lunară a fost atinsă"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
+msgstr ""
+"Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12388,6 +12626,12 @@ msgid "More than 20 minutes"
 msgstr "Mai mult de 20 de minute"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12563,7 +12807,8 @@ msgstr "Namibia"
 #. Title of the divisional championship series for the National League division of Major League Baseball
 msgctxt "Sports module"
 msgid "National League Championship Series"
-msgstr "National League Championship Series (Seria Campionatului Ligii Naționale)"
+msgstr ""
+"National League Championship Series (Seria Campionatului Ligii Naționale)"
 
 # smartling.placeholder_format=C
 #. Title of the divisional semi-final series for the National League division of Major League Baseball
@@ -12874,6 +13119,12 @@ msgstr "Nu, mulțumesc"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Nu, mulțumesc"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13538,6 +13789,12 @@ msgid "On but no numbers"
 msgstr "Activat dar fără paginare"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13649,7 +13906,8 @@ msgstr "Deschide website-ul %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
+msgstr ""
+"Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13748,6 +14006,12 @@ msgstr "Deschide sugestiile pentru chat"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Deschide, creează și editează sugestiile de imagini"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14497,10 +14761,22 @@ msgid "Pin"
 msgstr "Fixare"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Fixează chaturile aici din %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14518,6 +14794,12 @@ msgstr "Roz"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Fixat"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14837,6 +15119,12 @@ msgid "Poor formatting"
 msgstr "Formatare inadecvată"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15043,6 +15331,12 @@ msgstr "Imaginea anterioară"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Filele anterioare"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15585,6 +15879,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "AI cu raționament, cu moderare medie încorporată"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15618,6 +15924,12 @@ msgstr "File recente"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Stocarea chaturilor recente poate fi ajustată în %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15773,6 +16085,12 @@ msgstr "Reia căutarea fără acest site"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Redu utilizarea"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15933,7 +16251,8 @@ msgstr "Reține alegerea mea"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
+msgstr ""
+"Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16153,6 +16472,12 @@ msgid "Reset All Settings"
 msgstr "Resetează toate setările"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16163,6 +16488,12 @@ msgstr "Se resetează în %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Rezoluție"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16290,7 +16621,8 @@ msgstr "Rezultatele exclud informațiile de pe site-urile blocate."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
+msgstr ""
+"Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16646,14 +16978,16 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
+msgstr ""
+"Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
+msgstr ""
+"Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16863,6 +17197,12 @@ msgstr "Caută"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Cauți %1$s pentru a găsi rezultate mai aproape de tine?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17176,7 +17516,8 @@ msgstr "A doua opinie"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
+msgstr ""
+"Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17236,6 +17577,12 @@ msgid ""
 msgstr ""
 "Stocate în siguranță pe serverul DuckDuckGo cu criptare end-to-end. Nimeni "
 "în afară de tine nu-ți poate vedea datele, nici măcar noi."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17328,7 +17675,8 @@ msgstr "Vezi mai multe pe %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr "Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
+msgstr ""
+"Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -17346,7 +17694,8 @@ msgstr "Vezi câteva dintre cele mai recente actualizări ale noastre"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
+msgstr ""
+"Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17373,7 +17722,8 @@ msgstr "Selectează %1$s%2$s%3$s, apoi %4$sMotor de căutare%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
+msgstr ""
+"Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -17386,30 +17736,35 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17421,7 +17776,8 @@ msgstr "Selectează %1$sDuckDuckGo%2$s din lista de furnizori de căutare"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17432,7 +17788,8 @@ msgstr "Selectează %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
+msgstr ""
+"Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17528,7 +17885,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr ""
+"Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17600,7 +17958,8 @@ msgstr "Text selectat din %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
+msgstr ""
+"Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17744,6 +18103,12 @@ msgid "Set as Homepage"
 msgstr "Setează ca Pagină de pornire"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17811,6 +18176,18 @@ msgid "Seychelles"
 msgstr "Seychelles"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17851,6 +18228,13 @@ msgstr ""
 "Împarte o locație la nivel de oraș cu modelele AI pentru a îmbunătăți "
 "relevanța. Duck.ai nu îți dezvăluie niciodată locația exactă nouă sau "
 "modelelor AI."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17909,6 +18293,12 @@ msgstr "Partajează URL-ul paginii"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Distribuie feedback pozitiv"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18046,6 +18436,12 @@ msgid "Show Detail"
 msgstr "Arată detaliat"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "Afișează DuckAssist <sup>BETA</sup>"
@@ -18054,7 +18450,8 @@ msgstr "Afișează DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
+msgstr ""
+"Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18193,6 +18590,12 @@ msgid "Show more"
 msgstr "Arată mai multe"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18226,6 +18629,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Arată bara laterală"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18302,7 +18711,8 @@ msgstr "Afișează linii orizontale la sfârșitul paginilor de rezultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
+msgstr ""
+"Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18456,7 +18866,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
+msgstr ""
+"Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18601,13 +19012,20 @@ msgstr "Ceva nu a funcționat, te rugăm să încerci din nou."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
+msgstr ""
+"A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "S-a produs o problemă, te rugăm să reîncerci mai târziu."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18650,7 +19068,8 @@ msgstr "Ne pare rău, a survenit o eroare neașteptată."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
+msgstr ""
+"Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -18699,7 +19118,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
+msgstr ""
+"Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18904,6 +19324,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Începe să folosești limita săptămânală"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Începe să cauți!"
@@ -18962,13 +19388,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr ""
+"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr ""
+"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -19011,7 +19439,8 @@ msgstr "Oprește instrumentele de urmărire ascunse de pe alte site-uri."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
+msgstr ""
+"Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19185,7 +19614,8 @@ msgstr "Sugerează un titlu pentru o postare pe blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Sugerează articole sau subiecte similare care merită explorate în continuare."
+msgstr ""
+"Sugerează articole sau subiecte similare care merită explorate în continuare."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19485,6 +19915,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Folosește motorul de căutare care nu te urmărește. Niciodată."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19551,7 +19989,8 @@ msgstr "Sync & Backup activat!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
+msgstr ""
+"Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19637,6 +20076,12 @@ msgstr "Sincronizează cu un alt dispozitiv"
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "Funcția de Sincronizare și backup este temporar indisponibilă"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19726,6 +20171,22 @@ msgid "Take Back Your Privacy!"
 msgstr "Recuperează-ți confidențialitatea!"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19747,8 +20208,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți "
-"Duck.ai."
+"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19997,7 +20458,8 @@ msgstr "Fișierele atașate depășesc limita totală de %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
+msgstr ""
+"Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -20185,7 +20647,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
+msgstr ""
+"Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20194,10 +20657,22 @@ msgid "This Month"
 msgstr "Luna aceasta"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Săptămâna aceasta"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20249,13 +20724,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
+msgstr ""
+"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
+msgstr ""
+"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -20333,6 +20810,22 @@ msgid "This information isn’t useful"
 msgstr "Aceste informații nu sunt utile"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20379,7 +20872,8 @@ msgstr "Această pagină necesită JavaScript pentru a funcționa."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
+msgstr ""
+"Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20482,7 +20976,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
+msgstr ""
+"Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -20618,8 +21113,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Pentru a tipări indicații de orientare:%1$sîntoarce-te la "
-"hartă.%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
+"Pentru a tipări indicații de orientare:%1$sîntoarce-te la hartă."
+"%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
 "pictograma de tipărire.%4$s"
 
 # smartling.placeholder_format=C
@@ -20669,6 +21164,12 @@ msgstr "Astăzi"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Astăzi"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20833,7 +21334,8 @@ msgstr "Instrumente de urmărire blocate în ultima oră"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
+msgstr ""
+"Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21084,9 +21586,21 @@ msgid "Try Them Out"
 msgstr "Încearcă-le"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Încearcă o căutare!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21155,6 +21669,12 @@ msgid "Try for free"
 msgstr "Încearcă gratis"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21166,7 +21686,14 @@ msgstr "Încearcă gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
+msgstr ""
+"Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21193,7 +21720,14 @@ msgstr "Încearcă browserul nostru"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
+msgstr ""
+"Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21440,7 +21974,14 @@ msgstr "Activează %1$sLocație precisă%2$s pentru rezultate mai precise"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
+msgstr ""
+"Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21651,12 +22192,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
+msgstr ""
+"Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
+msgstr ""
+"Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21666,7 +22209,8 @@ msgstr "Sub %1$sSetări de căutare%2$s selectează %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
+msgstr ""
+"Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21680,13 +22224,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
+msgstr ""
+"Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
+msgstr ""
+"Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21810,6 +22356,12 @@ msgstr ""
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Deblochează inteligența artificială avansată cu abonamentul tău!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22136,9 +22688,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. "
-"Protejează-ți chaturile împotriva hackerilor, a escrocilor și a companiilor. "
-"Păstrează informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
+"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. Protejează-"
+"ți chaturile împotriva hackerilor, a escrocilor și a companiilor. Păstrează "
+"informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22175,6 +22727,12 @@ msgstr "Folosește în Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Folosește în Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22679,7 +23237,8 @@ msgstr "Anonimizăm"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
+msgstr ""
+"Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22826,7 +23385,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
+msgstr ""
+"Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -22840,7 +23400,8 @@ msgstr ""
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr "Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
+msgstr ""
+"Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -22900,7 +23461,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
+msgstr ""
+"Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23195,8 +23757,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea "
-"Duck.ai. Încearcă să reîncarci pagina."
+"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea Duck."
+"ai. Încearcă să reîncarci pagina."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23259,10 +23821,10 @@ msgid ""
 msgstr ""
 "Care sunt beneficiile descărcării browserului DuckDuckGo pentru tine, dacă "
 "vrei să folosești Duck.ai? Citește doar surse oficiale DuckDuckGo. Împarte "
-"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările "
-"Duck.ai și pe protecția confidențialității. Păstrează-l destul de scurt, "
-"simplu și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau "
-"în domeniul tehnic."
+"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările Duck."
+"ai și pe protecția confidențialității. Păstrează-l destul de scurt, simplu "
+"și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau în "
+"domeniul tehnic."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23328,7 +23890,8 @@ msgstr "Care sunt principalele lucruri pe care le voi învăța din acest curs?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr "Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
+msgstr ""
+"Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -23374,6 +23937,12 @@ msgstr "Ce te-a deranjat cel mai mult?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Ce te-a adus astăzi înapoi?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23494,8 +24063,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de "
-"bookmarklet-ul cu parametri URL?"
+"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de bookmarklet-"
+"ul cu parametri URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23604,7 +24173,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
+msgstr ""
+"Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23622,7 +24192,8 @@ msgstr "Unde să urmărești <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
+msgstr ""
+"Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23794,6 +24365,14 @@ msgstr "Victorii"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Lapoviță și ninsoare"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24224,6 +24803,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Poți atașa doar %1$s imagini per conversație."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24365,6 +24951,12 @@ msgstr ""
 "recentă versiune."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24412,6 +25004,12 @@ msgid "You've blocked 1 site"
 msgstr "Ai blocat 1 site"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24429,7 +25027,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
+msgstr ""
+"Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24456,8 +25055,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile "
-"Duck.ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
+"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile Duck."
+"ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
 "sincronizarea. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
@@ -24672,7 +25271,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
+msgstr ""
+"Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24719,7 +25319,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
+msgstr ""
+"Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24809,6 +25410,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Căutările tale nu pot fi asociate cu tine"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24883,13 +25492,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
+msgstr ""
+"Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
+msgstr ""
+"Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25400,3 +26011,9 @@ msgstr "ani"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "a"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -128,7 +127,7 @@ msgstr "Определен язык: %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Использовано файлов: %1$s"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -248,8 +247,7 @@ msgstr "Лайков: %1$s"
 #. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
 msgctxt "Disclaimer bellow chat input - mobile"
 msgid "%s may display inaccurate or offensive information."
-msgstr ""
-"ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
+msgstr "ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
 
 # smartling.placeholder_format=C
 #. Label showing how many members a discussion has. To be displayed on a card about that discussion.
@@ -366,7 +364,7 @@ msgstr "%1$s использовано"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s расходует лимиты в 2–5 раз быстрее, чем базовые модели %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -487,15 +485,13 @@ msgstr "%1$sКак мы сохраняем конфиденциальность 
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
+msgstr "%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
+msgstr "%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -621,7 +617,7 @@ msgstr "1 день назад"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "Использован 1 файл"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -968,8 +964,8 @@ msgid ""
 msgstr ""
 "Функция AI Chat позволяет анонимно общаться с нашим чат-ботом на базе "
 "сторонних моделей ИИ. Если отключить эту функцию, она не будет отображаться "
-"в поиске DuckDuckGo Search, но останется доступной по ссылке %1$sduckduckgo."
-"com/aichat%2$s."
+"в поиске DuckDuckGo Search, но останется доступной по ссылке "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1085,8 +1081,7 @@ msgstr "Не добавлять в браузер"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "ATB related (not displayed on settings page)"
-msgstr ""
-"Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
+msgstr "Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
 
 # smartling.placeholder_format=C
 #. Golf rankings column: average points
@@ -1540,6 +1535,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Продвинутые модели могут расходовать лимиты в 2–5 раз быстрее, чем другие "
+"модели. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1837,8 +1834,8 @@ msgid ""
 msgstr ""
 "Позволяет %1$s выполнить поиск в Интернете, чтобы улучшить ответы на "
 "релевантные запросы. Отправляет в поисковую систему только сгенерированные "
-"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s по-"
-"прежнему имеют %3$sнулевую видимость провайдера%4$s."
+"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s "
+"по-прежнему имеют %3$sнулевую видимость провайдера%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2332,7 +2329,7 @@ msgstr "Задать вопрос (конфиденциально)"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Задать вопрос (конфиденциально)"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2372,10 +2369,9 @@ msgstr ""
 "интеллекта. Вы можете самостоятельно проконтролировать, как часто будут "
 "появляться ответы Assist: «никогда» (интерфейс Assist полностью исключается "
 "из поисковых запросов), «по запросу» (ответы ИИ отображаются при нажатии "
-"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или "
-"«часто» (чаще и в отношении более широкого спектра запросов). Пока что "
-"ответы на базе ИИ предоставляются только на территории США (на английском "
-"языке)."
+"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или «часто» "
+"(чаще и в отношении более широкого спектра запросов). Пока что ответы на "
+"базе ИИ предоставляются только на территории США (на английском языке)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2911,8 +2907,7 @@ msgstr "Блокировка почтовых трекеров и скрытие
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Список блокировки не является исчерпывающим и может содержать неточности."
+msgstr "Список блокировки не является исчерпывающим и может содержать неточности."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3810,11 +3805,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними чат-"
-"моделями на базе ИИ от OpenAI, Anthropic и других компаний. При отключении "
-"этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка «Чат» и "
-"ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, посетив "
-"его страницу напрямую: %1$shttps://duck.ai%2$s."
+"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними "
+"чат-моделями на базе ИИ от OpenAI, Anthropic и других компаний. При "
+"отключении этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка "
+"«Чат» и ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, "
+"посетив его страницу напрямую: %1$shttps://duck.ai%2$s."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3898,7 +3893,7 @@ msgstr "Приватный чат с ИИ"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Приватный чат с популярными ИИ"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4053,8 +4048,7 @@ msgstr "Проверьте орфографию"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
+msgstr "Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4482,8 +4476,7 @@ msgstr "Нажмите %1$sНастройки%2$s в выпадающем мен
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
+msgstr "Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4699,7 +4692,7 @@ msgstr "Закрыть"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Закрыть"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4749,7 +4742,7 @@ msgstr "Закрыть поиск"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Закрыть «Второе мнение»"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5127,6 +5120,8 @@ msgstr "Продолжить блокировку"
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
+"Продолжайте недавние чаты здесь. Или удаляйте их с помощью кнопки Fire "
+"Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5197,7 +5192,7 @@ msgstr "Данные cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Скопировано"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5238,8 +5233,7 @@ msgstr "Копировать"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
+msgstr "Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5251,7 +5245,7 @@ msgstr "Копировать код"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Копировать ссылку"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5372,14 +5366,13 @@ msgstr "Создать изображение"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Создать ссылку для доступа"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
-"Создай список покупок с указанием количества ингредиентов из этого рецепта."
+msgstr "Создай список покупок с указанием количества ингредиентов из этого рецепта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5425,6 +5418,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"При создании ссылки создаётся копия чата, которую сможет просмотреть любой, "
+"кто её откроет."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5583,7 +5578,7 @@ msgstr "Настрой ответы"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Настроить параметры ответов"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5875,7 +5870,7 @@ msgstr "Удалить данные с сервера?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Удалить общую ссылку"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5887,7 +5882,7 @@ msgstr "Удалить расшифровку"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Удалить чат"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5925,7 +5920,7 @@ msgstr "Удалить изображение?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Удали меня"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6051,8 +6046,7 @@ msgstr "Диктовка в Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
+msgstr "Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6238,7 +6232,7 @@ msgstr "Закрыть рекламу"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Закрыть подсказки"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6455,7 +6449,7 @@ msgstr "Скачать DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Скачать DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6542,8 +6536,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
+msgstr "Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6565,8 +6558,7 @@ msgstr "Подготовь пост для соцсетей"
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Drag %sThis Button%s on top of the home icon:"
-msgstr ""
-"Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
+msgstr "Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
 
 # smartling.placeholder_format=C
 #. Indicates this is the number of draws for this team in e.g. soccer
@@ -6678,7 +6670,7 @@ msgstr "Duck.ai от DuckDuckGo — приватный чат с ИИ, бесп
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai теперь умеет анализировать PDF-файлы. Попробуйте!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6787,8 +6779,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai позволяет вести приватные беседы с популярными ИИ-моделями. При "
-"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы по-"
-"прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
+"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы "
+"по-прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
 "напрямую."
 
 # smartling.placeholder_format=C
@@ -6841,7 +6833,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai поддерживает модели от Anthropic, OpenAI и других."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6872,8 +6864,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, приватный чат-бот, бесплатный чат с ИИ, анонимный "
-"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, ИИ-"
-"модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
+"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, "
+"ИИ-модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7049,8 +7041,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
+msgstr "Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7327,8 +7318,8 @@ msgid ""
 msgstr ""
 "Каждый раз, когда вы просите нас порекомендовать парольную фразу, мы "
 "запрашиваем с серверов DuckDuckGo длинный список случайных слов. Затем в "
-"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум 18–"
-"20 символов."
+"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум "
+"18–20 символов."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7502,7 +7493,7 @@ msgstr "Включить часто посещаемые сайты"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Включить сейчас"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7808,7 +7799,7 @@ msgstr "Гид по развлечениям"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Весь чат"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7979,13 +7970,13 @@ msgstr "Нецензурный текст"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Познакомьтесь с Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Познакомьтесь с Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8092,7 +8083,7 @@ msgstr "Бесплатно"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "БЕСПЛАТНО И НЕОБЯЗАТЕЛЬНО"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8517,7 +8508,7 @@ msgstr "Освободите место в хранилище"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Бесплатно и всегда конфиденциально"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -9039,7 +9030,7 @@ msgstr "Помощь с компьютером"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Получите более высокие лимиты использования с подпиской на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9080,13 +9071,15 @@ msgstr "Скачать последнюю версию"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Скачать приложение"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Скачайте бесплатный браузер DuckDuckGo, %1$sчтобы блокировать рекламу на "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9114,7 +9107,7 @@ msgstr "Пригласите своих друзей и попросите их 
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Чек-лист «С чего начать»"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9730,8 +9723,7 @@ msgstr "Ответ пригодился"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr ""
-"Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
+msgstr "Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -9807,7 +9799,7 @@ msgstr "Скрыть подсказки"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Скрыть руководство"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10450,8 +10442,7 @@ msgstr "Изображения по запросу «%1$s»"
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for images has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Images for %s blocked by safe search"
-msgstr ""
-"Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr "Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the image results for a certain query, ex. Images for <b>beach</b>
@@ -11326,8 +11317,7 @@ msgstr "Подробнее об активной защите конфиденц
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Получайте рекомендации о защите персональных данных на электронную почту."
+msgstr "Получайте рекомендации о защите персональных данных на электронную почту."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11381,8 +11371,7 @@ msgstr "Подробнее о работе этой функции"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
+msgstr "Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11445,6 +11434,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Позволяет переключаться между отправкой поисковых запросов и промптов для "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11520,7 +11511,7 @@ msgstr "Выигранные лайнауты"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Ссылка истекает через 7 дней."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12624,7 +12615,7 @@ msgstr "Более 20 минут"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Больше подсказок"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13117,7 +13108,7 @@ msgstr "Нет, спасибо"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Нет, спасибо"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13734,8 +13725,7 @@ msgstr "Оман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
+msgstr "Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13786,7 +13776,7 @@ msgstr "Вкл., но без цифр"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Обучение завершено"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13900,8 +13890,7 @@ msgstr "Открыть сайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
+msgstr "Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14005,7 +13994,7 @@ msgstr "Открыть предложения по созданию и реда�
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Открыть чек-лист «С чего начать»"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14070,8 +14059,7 @@ msgstr "Открыть панель «Как работает Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
+msgstr "Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14758,7 +14746,7 @@ msgstr "Закрепить"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Закрепить чат"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14770,7 +14758,7 @@ msgstr "Закрепи чаты здесь из %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Закрепите меня"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14793,7 +14781,7 @@ msgstr "Закреплено"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Закрепленные чаты будут отображаться над вашими недавними чатами."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15119,6 +15107,8 @@ msgstr "Плохое форматирование"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Популярные ИИ-модели. Учетная запись не требуется. Чаты с анонимностью от "
+"DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15332,7 +15322,7 @@ msgstr "Предыдущие вкладки"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Предыдущие советы"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15555,8 +15545,7 @@ msgstr "Приватные чаты без сохранения"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr ""
-"Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
+msgstr "Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -15879,13 +15868,13 @@ msgstr "Аналитическая ИИ-модель со средним уро�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15926,7 +15915,7 @@ msgstr "Правила хранения последних чатов можно
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Последние чаты"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16086,7 +16075,7 @@ msgstr "Сократить использование"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Сократить расход, используя более эффективную модель"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16468,7 +16457,7 @@ msgstr "Сбросить все настройки"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Сбросить обучение"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16486,7 +16475,7 @@ msgstr "Разрешение"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Ответ"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -17197,7 +17186,7 @@ msgstr "Искать «%1$s», чтобы найти результаты поб
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Переключатель «Поиск и Duck.ai»"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17558,8 +17547,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
+msgstr "Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17575,7 +17563,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Надежно хранится на нашем зашифрованном сервере."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17743,8 +17731,7 @@ msgstr "Выберите %1$sDuckDuckGo%2$s и нажмите %3$sУстанов
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
+msgstr "Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17764,8 +17751,7 @@ msgstr "Выберите %1$sDuckDuckGo%2$s в списке поисковых �
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
+msgstr "Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17850,8 +17836,7 @@ msgstr "Выберите %1$sНастройки%2$s, затем %3$sДополн
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
+msgstr "Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17947,8 +17932,7 @@ msgstr "Выбранный текст со страницы %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
+msgstr "Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18094,7 +18078,7 @@ msgstr "Сделать стартовой страницей"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Настройка тона и стиля ответов Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18167,13 +18151,13 @@ msgstr "Сейшельские Острова"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Поделиться"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Поделиться"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18184,8 +18168,7 @@ msgstr "Поделиться"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
+msgstr "Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18221,7 +18204,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Поделиться чатом"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18285,7 +18268,7 @@ msgstr "Отправить положительный отзыв"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Область общего доступа"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18426,7 +18409,7 @@ msgstr "Показать информацию"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Показать руководство по Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18583,7 +18566,7 @@ msgstr "Подробнее"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Показать больше моделей"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18625,6 +18608,8 @@ msgstr "Показать боковую панель"
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
+"Показывать пошаговые советы о том, как максимально эффективно использовать "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18751,8 +18736,7 @@ msgstr "Показывает поисковые подсказки при вво
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
+msgstr "Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18846,8 +18830,7 @@ msgstr "Поиск по сайту временно недоступен. Мы �
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
+msgstr "Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18986,8 +18969,7 @@ msgstr "Что-то пошло не так"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
+msgstr "Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19005,7 +18987,7 @@ msgstr "Что-то пошло не так. Повторите попытку п
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Что-то пошло не так. Повторите попытку."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19089,8 +19071,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
+msgstr "При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -19304,7 +19285,7 @@ msgstr "Начать использовать недельный лимит"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Начать новый чат"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19890,7 +19871,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Выбрать второе мнение"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20053,7 +20034,7 @@ msgstr "Функция «Синхронизация и резервное коп
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Синхронизировать чаты между устройствами"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20149,6 +20130,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
+"ИИ-помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20157,6 +20140,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
+"ИИ-помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20461,8 +20446,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
+msgstr "Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20597,8 +20581,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
+msgstr "Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20626,7 +20609,7 @@ msgstr "В этом месяце"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Этот ответ"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20639,6 +20622,8 @@ msgstr "На этой неделе"
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
+"Этот чат будет сохранен только в Duck.ai и останется полностью "
+"конфиденциальным."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20763,8 +20748,7 @@ msgstr ""
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
+msgstr "Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20778,6 +20762,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Это — пример чата. Чтобы он всегда отображался над всеми вашими чатами, "
+"откройте меню этого чата (нажав на три точки) и выберите «Закрепить»."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20786,6 +20772,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Это — пример чата. Чтобы удалить его, просто нажмите на кнопку Fire Button в "
+"боковом меню!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20833,8 +20821,7 @@ msgstr "Для нормальной работы данной странице �
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
+msgstr "Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20910,8 +20897,7 @@ msgstr "Здесь это видео пока недоступно. Его мо�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
+msgstr "Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21058,8 +21044,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
+msgstr "Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21133,6 +21118,8 @@ msgstr "Сегодня"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Воспользуйтесь переключателем, чтобы открыть приватный чат с ИИ, или "
+"%1$sотключите его в меню «%2$s».%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21480,13 +21467,11 @@ msgstr "Чтобы не получать подобные сообщения, п
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
+msgstr "Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
+msgstr "Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -21551,7 +21536,7 @@ msgstr "Попробуй их"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Попробовать другую модель"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21562,7 +21547,7 @@ msgstr "Попробуйте поискать!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Воспользоваться рекомендацией"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21605,16 +21590,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Для более точных результатов попробуйте использовать анонимную геопозицию."
+msgstr "Для более точных результатов попробуйте использовать анонимную геопозицию."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
+msgstr "Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21634,7 +21617,7 @@ msgstr "Попробовать бесплатно"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Попробовать бесплатно"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21656,7 +21639,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Пробная версия на 7 дней"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21691,7 +21674,7 @@ msgstr ""
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Использовать рассуждения"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21772,8 +21755,7 @@ msgstr "Новинки платформы: ИИ-модели с открытым
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Попробуйте начать с готовых запросов или введите собственный вариант ниже."
+msgstr "Попробуйте начать с готовых запросов или введите собственный вариант ниже."
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21945,14 +21927,13 @@ msgstr "Duck Player — просмотр YouTube без целевой рекл�
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Активировать переключатель Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
-msgstr ""
-"Для получения более точных результатов выберите вариант «Точная геопозиция»."
+msgstr "Для получения более точных результатов выберите вариант «Точная геопозиция»."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -22159,15 +22140,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
+msgstr "Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"В меню %1$sПри запуске > Домашняя страница%2$s введите: https://duckduckgo."
-"com"
+"В меню %1$sПри запуске > Домашняя страница%2$s введите: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22177,16 +22157,15 @@ msgstr "В меню %1$sНастройки поиска%2$s выберите %3$
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
+msgstr "В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми системами..."
-"%4$s"
+"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми "
+"системами...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22200,8 +22179,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
+msgstr "В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22328,7 +22306,7 @@ msgstr "Разблокируй продвинутый ИИ с твоей под�
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Разблокировать продвинутые модели"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22424,8 +22402,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми ИИ-"
-"моделями, обновите браузер DuckDuckGo."
+"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми "
+"ИИ-моделями, обновите браузер DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22667,8 +22645,7 @@ msgstr "Используйте DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
+msgstr "Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22696,7 +22673,7 @@ msgstr "Использовать в Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Используйте кнопку Fire Button, чтобы удалить чат из истории."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22796,8 +22773,7 @@ msgstr "Видеоролики заблокированы в рамках без
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for videos has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Videos for %s blocked by safe search"
-msgstr ""
-"Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr "Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the video results for a certain query, ex. Videos for <b>japan</b>
@@ -23316,8 +23292,7 @@ msgstr "Мы не отслеживаем вас. Никогда."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
+msgstr "Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23358,8 +23333,7 @@ msgstr "Мы не следим за вами, ни в режиме приват�
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
+msgstr "Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23445,8 +23419,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
+msgstr "Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23836,8 +23809,7 @@ msgstr "Чему я научусь на этом курсе?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
-"Каковы основные контраргументы или критические замечания по этому поводу?"
+msgstr "Каковы основные контраргументы или критические замечания по этому поводу?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -23886,7 +23858,7 @@ msgstr "Что привело вас сюда сегодня?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Что ты умеешь?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24115,8 +24087,7 @@ msgstr "На какие бренды обратить внимание нови�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
+msgstr "При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24314,6 +24285,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"С Duck.ai ваши чаты анонимны и никогда не используются для обучения ИИ. "
+"Включить или отключить его можно в любой момент в меню «%1$s»."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24629,8 +24602,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
+msgstr "Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -24659,8 +24631,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
+msgstr "Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24705,8 +24676,7 @@ msgstr "Вы можете продолжить чат, используя сво
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
+msgstr "Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24724,36 +24694,32 @@ msgstr "Число файлов, прикрепляемых к одной бес
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time"
-msgstr ""
-"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time."
-msgstr ""
-"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation"
-msgstr ""
-"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
-msgstr ""
-"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Число вкладок, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24900,7 +24866,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Всё готово!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24954,7 +24920,7 @@ msgstr "Ты заблокировал 1 сайт"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Ты освоил основы Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24992,8 +24958,7 @@ msgstr "Вы исчерпали голосовой лимит на сегодн�
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Вы достигли лимита использования функции диктовки. Повторите попытку позже."
+msgstr "Вы достигли лимита использования функции диктовки. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25154,8 +25119,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
+msgstr "Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25177,8 +25141,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения ИИ-"
-"моделей."
+"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения "
+"ИИ-моделей."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25212,8 +25176,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в Duck."
-"ai."
+"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25357,6 +25321,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Ваши настройки сохранены, но при удалении файлов cookie они будут сброшены. "
+"Включите расширение браузера %1$sDuckDuckGo No AI%2$s, чтобы сохранить "
+"настройки навсегда."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25954,4 +25921,4 @@ msgstr "г."
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -122,6 +123,12 @@ msgstr "%1$s дн. назад"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Определен язык: %1$s"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -241,7 +248,8 @@ msgstr "Лайков: %1$s"
 #. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
 msgctxt "Disclaimer bellow chat input - mobile"
 msgid "%s may display inaccurate or offensive information."
-msgstr "ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
+msgstr ""
+"ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
 
 # smartling.placeholder_format=C
 #. Label showing how many members a discussion has. To be displayed on a card about that discussion.
@@ -353,6 +361,12 @@ msgstr "Пресечено попыток отслеживания: %1$s"
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
 msgstr "%1$s использовано"
+
+# smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -473,13 +487,15 @@ msgstr "%1$sКак мы сохраняем конфиденциальность 
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
+msgstr ""
+"%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
+msgstr ""
+"%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -600,6 +616,12 @@ msgstr "За последние 24 часа DuckDuckGo заблокировал
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 день назад"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -946,8 +968,8 @@ msgid ""
 msgstr ""
 "Функция AI Chat позволяет анонимно общаться с нашим чат-ботом на базе "
 "сторонних моделей ИИ. Если отключить эту функцию, она не будет отображаться "
-"в поиске DuckDuckGo Search, но останется доступной по ссылке "
-"%1$sduckduckgo.com/aichat%2$s."
+"в поиске DuckDuckGo Search, но останется доступной по ссылке %1$sduckduckgo."
+"com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1063,7 +1085,8 @@ msgstr "Не добавлять в браузер"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "ATB related (not displayed on settings page)"
-msgstr "Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
+msgstr ""
+"Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
 
 # smartling.placeholder_format=C
 #. Golf rankings column: average points
@@ -1511,6 +1534,14 @@ msgid "Advanced Models"
 msgstr "Продвинутые модели"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Реклама в результатах поиска"
@@ -1806,8 +1837,8 @@ msgid ""
 msgstr ""
 "Позволяет %1$s выполнить поиск в Интернете, чтобы улучшить ответы на "
 "релевантные запросы. Отправляет в поисковую систему только сгенерированные "
-"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s "
-"по-прежнему имеют %3$sнулевую видимость провайдера%4$s."
+"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s по-"
+"прежнему имеют %3$sнулевую видимость провайдера%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2298,6 +2329,12 @@ msgid "Ask privately"
 msgstr "Задать вопрос (конфиденциально)"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2335,9 +2372,10 @@ msgstr ""
 "интеллекта. Вы можете самостоятельно проконтролировать, как часто будут "
 "появляться ответы Assist: «никогда» (интерфейс Assist полностью исключается "
 "из поисковых запросов), «по запросу» (ответы ИИ отображаются при нажатии "
-"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или «часто» "
-"(чаще и в отношении более широкого спектра запросов). Пока что ответы на "
-"базе ИИ предоставляются только на территории США (на английском языке)."
+"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или "
+"«часто» (чаще и в отношении более широкого спектра запросов). Пока что "
+"ответы на базе ИИ предоставляются только на территории США (на английском "
+"языке)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2873,7 +2911,8 @@ msgstr "Блокировка почтовых трекеров и скрытие
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Список блокировки не является исчерпывающим и может содержать неточности."
+msgstr ""
+"Список блокировки не является исчерпывающим и может содержать неточности."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3771,11 +3810,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними "
-"чат-моделями на базе ИИ от OpenAI, Anthropic и других компаний. При "
-"отключении этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка "
-"«Чат» и ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, "
-"посетив его страницу напрямую: %1$shttps://duck.ai%2$s."
+"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними чат-"
+"моделями на базе ИИ от OpenAI, Anthropic и других компаний. При отключении "
+"этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка «Чат» и "
+"ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, посетив "
+"его страницу напрямую: %1$shttps://duck.ai%2$s."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3854,6 +3893,12 @@ msgstr "Приватный чат с %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Приватный чат с ИИ"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4008,7 +4053,8 @@ msgstr "Проверьте орфографию"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
+msgstr ""
+"Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4436,7 +4482,8 @@ msgstr "Нажмите %1$sНастройки%2$s в выпадающем мен
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
+msgstr ""
+"Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4649,6 +4696,12 @@ msgid "Close"
 msgstr "Закрыть"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4691,6 +4744,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Закрыть поиск"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5064,6 +5123,12 @@ msgid "Continue Blocking Ads"
 msgstr "Продолжить блокировку"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5129,6 +5194,12 @@ msgid "Cookie data:"
 msgstr "Данные cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5167,13 +5238,20 @@ msgstr "Копировать"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
+msgstr ""
+"Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Копировать код"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5291,10 +5369,17 @@ msgid "Create Image"
 msgstr "Создать изображение"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr "Создай список покупок с указанием количества ингредиентов из этого рецепта."
+msgstr ""
+"Создай список покупок с указанием количества ингредиентов из этого рецепта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5332,6 +5417,14 @@ msgstr "Создатель:"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Создана компанией %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5485,6 +5578,12 @@ msgstr "Настрой ответы"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Настрой ответы"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5773,10 +5872,22 @@ msgid "Delete Server Data?"
 msgstr "Удалить данные с сервера?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Удалить расшифровку"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5809,6 +5920,12 @@ msgstr "Удалить изображение"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Удалить изображение?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5934,7 +6051,8 @@ msgstr "Диктовка в Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
+msgstr ""
+"Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6115,6 +6233,12 @@ msgstr "Не показывать снова"
 msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr "Закрыть рекламу"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6328,6 +6452,12 @@ msgid "Download DuckDuckGo"
 msgstr "Скачать DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo Browser"
@@ -6412,7 +6542,8 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
+msgstr ""
+"Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6434,7 +6565,8 @@ msgstr "Подготовь пост для соцсетей"
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Drag %sThis Button%s on top of the home icon:"
-msgstr "Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
+msgstr ""
+"Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
 
 # smartling.placeholder_format=C
 #. Indicates this is the number of draws for this team in e.g. soccer
@@ -6543,6 +6675,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai от DuckDuckGo — приватный чат с ИИ, бесплатно"
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6649,8 +6787,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai позволяет вести приватные беседы с популярными ИИ-моделями. При "
-"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы "
-"по-прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
+"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы по-"
+"прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
 "напрямую."
 
 # smartling.placeholder_format=C
@@ -6700,6 +6838,12 @@ msgstr ""
 "точность."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6728,8 +6872,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, приватный чат-бот, бесплатный чат с ИИ, анонимный "
-"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, "
-"ИИ-модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
+"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, ИИ-"
+"модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6905,7 +7049,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
+msgstr ""
+"Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7182,8 +7327,8 @@ msgid ""
 msgstr ""
 "Каждый раз, когда вы просите нас порекомендовать парольную фразу, мы "
 "запрашиваем с серверов DuckDuckGo длинный список случайных слов. Затем в "
-"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум "
-"18–20 символов."
+"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум 18–"
+"20 символов."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7352,6 +7497,12 @@ msgstr "Включить часто посещаемые сайты"
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Включить часто посещаемые сайты"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7654,6 +7805,12 @@ msgid "Entertainment guide"
 msgstr "Гид по развлечениям"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Экваториальная Гвинея"
 
@@ -7819,6 +7976,18 @@ msgid "Explicit lyrics"
 msgstr "Нецензурный текст"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7918,6 +8087,12 @@ msgstr "ГПМ"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Бесплатно"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8337,6 +8512,12 @@ msgstr "Бесплатный план"
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
 msgstr "Освободите место в хранилище"
+
+# smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8855,6 +9036,12 @@ msgid "Get computer help"
 msgstr "Помощь с компьютером"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8890,6 +9077,18 @@ msgid "Get the Latest Version"
 msgstr "Скачать последнюю версию"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8910,6 +9109,12 @@ msgstr "Слушать эту песню на:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Пригласите своих друзей и попросите их помочь в этом!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9525,7 +9730,8 @@ msgstr "Ответ пригодился"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr "Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
+msgstr ""
+"Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -9596,6 +9802,12 @@ msgstr "Скрыть шаги"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Скрыть подсказки"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10238,7 +10450,8 @@ msgstr "Изображения по запросу «%1$s»"
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for images has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Images for %s blocked by safe search"
-msgstr "Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr ""
+"Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the image results for a certain query, ex. Images for <b>beach</b>
@@ -11113,7 +11326,8 @@ msgstr "Подробнее об активной защите конфиденц
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Получайте рекомендации о защите персональных данных на электронную почту."
+msgstr ""
+"Получайте рекомендации о защите персональных данных на электронную почту."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11167,7 +11381,8 @@ msgstr "Подробнее о работе этой функции"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
+msgstr ""
+"Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11223,6 +11438,13 @@ msgstr "Давайте вернем вас обратно."
 msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Сделайте ваш поиск анонимным вместе с DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11293,6 +11515,12 @@ msgstr "Линейный рисунок"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Выигранные лайнауты"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12393,6 +12621,12 @@ msgid "More than 20 minutes"
 msgstr "Более 20 минут"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12878,6 +13112,12 @@ msgstr "Нет, спасибо"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Нет, спасибо"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13494,7 +13734,8 @@ msgstr "Оман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
+msgstr ""
+"Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -13540,6 +13781,12 @@ msgstr ""
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Вкл., но без цифр"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13653,7 +13900,8 @@ msgstr "Открыть сайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
+msgstr ""
+"Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13754,6 +14002,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Открыть предложения по созданию и редактированию изображений"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13816,7 +14070,8 @@ msgstr "Открыть панель «Как работает Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
+msgstr ""
+"Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14500,10 +14755,22 @@ msgid "Pin"
 msgstr "Закрепить"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Закрепи чаты здесь из %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14521,6 +14788,12 @@ msgstr "Розовый"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Закреплено"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14842,6 +15115,12 @@ msgid "Poor formatting"
 msgstr "Плохое форматирование"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15048,6 +15327,12 @@ msgstr "Предыдущее изображение"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Предыдущие вкладки"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15270,7 +15555,8 @@ msgstr "Приватные чаты без сохранения"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr "Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
+msgstr ""
+"Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -15590,6 +15876,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Аналитическая ИИ-модель со средним уровнем встроенной модерации"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15623,6 +15921,12 @@ msgstr "Последние вкладки"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Правила хранения последних чатов можно изменить в разделе «%1$s»."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15777,6 +16081,12 @@ msgstr "Повторить поиск без этого сайта"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Сократить использование"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16155,6 +16465,12 @@ msgid "Reset All Settings"
 msgstr "Сбросить все настройки"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16165,6 +16481,12 @@ msgstr "Сброс через %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Разрешение"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16872,6 +17194,12 @@ msgid "Search %s to find results closer to you?"
 msgstr "Искать «%1$s», чтобы найти результаты поблизости?"
 
 # smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Search Anonymously"
 msgstr "Ищите анонимно"
 
@@ -17230,7 +17558,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
+msgstr ""
+"Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -17241,6 +17570,12 @@ msgid ""
 msgstr ""
 "Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования. "
 "Никто, кроме вас, их не увидит. Даже мы."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17408,7 +17743,8 @@ msgstr "Выберите %1$sDuckDuckGo%2$s и нажмите %3$sУстанов
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
+msgstr ""
+"Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -17428,7 +17764,8 @@ msgstr "Выберите %1$sDuckDuckGo%2$s в списке поисковых �
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
+msgstr ""
+"Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17513,7 +17850,8 @@ msgstr "Выберите %1$sНастройки%2$s, затем %3$sДополн
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
+msgstr ""
+"Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -17609,7 +17947,8 @@ msgstr "Выбранный текст со страницы %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
+msgstr ""
+"Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17752,6 +18091,12 @@ msgid "Set as Homepage"
 msgstr "Сделать стартовой страницей"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17819,6 +18164,18 @@ msgid "Seychelles"
 msgstr "Сейшельские Острова"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17827,7 +18184,8 @@ msgstr "Поделиться"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
+msgstr ""
+"Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17857,6 +18215,13 @@ msgstr ""
 "Для повышения качества результатов передавать ИИ-модели ваше местоположение "
 "с точностью до города. Duck.ai ни в коем случае не разглашает ваши точные "
 "координаты ни нам, ни ИИ-моделям."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17915,6 +18280,12 @@ msgstr "Поделиться адресом страницы"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Отправить положительный отзыв"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18050,6 +18421,12 @@ msgstr "Показать букмарклет и данные настроек"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Показать информацию"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18203,6 +18580,12 @@ msgid "Show more"
 msgstr "Подробнее"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18236,6 +18619,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Показать боковую панель"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18362,7 +18751,8 @@ msgstr "Показывает поисковые подсказки при вво
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
+msgstr ""
+"Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18456,7 +18846,8 @@ msgstr "Поиск по сайту временно недоступен. Мы �
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
+msgstr ""
+"Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -18595,7 +18986,8 @@ msgstr "Что-то пошло не так"
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
+msgstr ""
+"Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -18608,6 +19000,12 @@ msgstr "Что-то пошло не так при включении Sync & Back
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Что-то пошло не так. Повторите попытку позже."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18691,7 +19089,8 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
+msgstr ""
+"При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18900,6 +19299,12 @@ msgstr "Начать использовать месячный лимит"
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "Начать использовать недельный лимит"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19480,6 +19885,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Переходите на поисковую систему, которая вас не отслеживает. Никогда."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19637,6 +20050,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Функция «Синхронизация и резервное копирование» временно недоступна"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19722,6 +20141,22 @@ msgstr "Таджикистан"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Верните свою конфиденциальность!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20026,7 +20461,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
+msgstr ""
+"Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20161,7 +20597,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
+msgstr ""
+"Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20186,10 +20623,22 @@ msgid "This Month"
 msgstr "В этом месяце"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "На этой неделе"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20314,12 +20763,29 @@ msgstr ""
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
+msgstr ""
+"Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Эта информация бесполезна"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20367,7 +20833,8 @@ msgstr "Для нормальной работы данной странице �
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
+msgstr ""
+"Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20443,7 +20910,8 @@ msgstr "Здесь это видео пока недоступно. Его мо�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
+msgstr ""
+"Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20590,7 +21058,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
+msgstr ""
+"Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20658,6 +21127,12 @@ msgstr "Сегодня"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Сегодня"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21005,11 +21480,13 @@ msgstr "Чтобы не получать подобные сообщения, п
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
+msgstr ""
+"Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
+msgstr ""
+"Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -21071,9 +21548,21 @@ msgid "Try Them Out"
 msgstr "Попробуй их"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Попробуйте поискать!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21116,14 +21605,16 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Для более точных результатов попробуйте использовать анонимную геопозицию."
+msgstr ""
+"Для более точных результатов попробуйте использовать анонимную геопозицию."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
+msgstr ""
+"Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21140,6 +21631,12 @@ msgid "Try for free"
 msgstr "Попробовать бесплатно"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21154,6 +21651,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Ознакомление бесплатное! Безопасный VPN, продвинутый и конфиденциальный ИИ и "
 "многое другое."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21183,6 +21686,12 @@ msgid "Try our homepage that never shows these messages:"
 msgstr ""
 "Попробуйте нашу стартовую страницу! Там вы никогда не увидите подобных "
 "сообщений:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21263,7 +21772,8 @@ msgstr "Новинки платформы: ИИ-модели с открытым
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Попробуйте начать с готовых запросов или введите собственный вариант ниже."
+msgstr ""
+"Попробуйте начать с готовых запросов или введите собственный вариант ниже."
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21432,10 +21942,17 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Duck Player — просмотр YouTube без целевой рекламы"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
-msgstr "Для получения более точных результатов выберите вариант «Точная геопозиция»."
+msgstr ""
+"Для получения более точных результатов выберите вариант «Точная геопозиция»."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -21642,14 +22159,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
+msgstr ""
+"Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"В меню %1$sПри запуске > Домашняя страница%2$s введите: "
-"https://duckduckgo.com"
+"В меню %1$sПри запуске > Домашняя страница%2$s введите: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21659,15 +22177,16 @@ msgstr "В меню %1$sНастройки поиска%2$s выберите %3$
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
+msgstr ""
+"В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми "
-"системами...%4$s"
+"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми системами..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21681,7 +22200,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
+msgstr ""
+"В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21805,6 +22325,12 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "Разблокируй продвинутый ИИ с твоей подпиской!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -21898,8 +22424,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми "
-"ИИ-моделями, обновите браузер DuckDuckGo."
+"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми ИИ-"
+"моделями, обновите браузер DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22141,7 +22667,8 @@ msgstr "Используйте DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
+msgstr ""
+"Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22164,6 +22691,12 @@ msgstr "Использовать в Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Использовать в Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22263,7 +22796,8 @@ msgstr "Видеоролики заблокированы в рамках без
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for videos has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Videos for %s blocked by safe search"
-msgstr "Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr ""
+"Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the video results for a certain query, ex. Videos for <b>japan</b>
@@ -22782,7 +23316,8 @@ msgstr "Мы не отслеживаем вас. Никогда."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
+msgstr ""
+"Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22823,7 +23358,8 @@ msgstr "Мы не следим за вами, ни в режиме приват�
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
+msgstr ""
+"Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -22909,7 +23445,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
+msgstr ""
+"Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23299,7 +23836,8 @@ msgstr "Чему я научусь на этом курсе?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr "Каковы основные контраргументы или критические замечания по этому поводу?"
+msgstr ""
+"Каковы основные контраргументы или критические замечания по этому поводу?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -23343,6 +23881,12 @@ msgstr "Что тебя больше всего беспокоило?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Что привело вас сюда сегодня?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23571,7 +24115,8 @@ msgstr "На какие бренды обратить внимание нови�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
+msgstr ""
+"При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23761,6 +24306,14 @@ msgstr "Победы"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Снег с дождём"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24076,7 +24629,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
+msgstr ""
+"Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -24105,7 +24659,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
+msgstr ""
+"Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -24150,7 +24705,8 @@ msgstr "Вы можете продолжить чат, используя сво
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
+msgstr ""
+"Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24168,25 +24724,36 @@ msgstr "Число файлов, прикрепляемых к одной бес
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time"
-msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time."
-msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation"
-msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
-msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24330,6 +24897,12 @@ msgstr ""
 "автоматически."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24378,6 +24951,12 @@ msgid "You've blocked 1 site"
 msgstr "Ты заблокировал 1 сайт"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24413,7 +24992,8 @@ msgstr "Вы исчерпали голосовой лимит на сегодн�
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Вы достигли лимита использования функции диктовки. Повторите попытку позже."
+msgstr ""
+"Вы достигли лимита использования функции диктовки. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24574,7 +25154,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
+msgstr ""
+"Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24596,8 +25177,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения "
-"ИИ-моделей."
+"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения ИИ-"
+"моделей."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24631,8 +25212,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в "
-"Duck.ai."
+"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24768,6 +25349,14 @@ msgstr "Твоя роль"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Ваши поисковые запросы не привязываются к вам"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25360,3 +25949,9 @@ msgstr "г./лет"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "г."
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/sc_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/sc_IT/LC_MESSAGES/duckduckgo.po
@@ -102,6 +102,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%s rilevadu"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -283,6 +288,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -485,6 +495,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 die a oe"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1228,6 +1243,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1857,6 +1879,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3111,6 +3138,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3747,6 +3779,11 @@ msgstr "Archìviu de immàgines"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3782,6 +3819,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4090,6 +4132,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4144,6 +4191,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr "Datos de is testimonios:"
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4182,6 +4234,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4278,6 +4335,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4312,6 +4374,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4437,6 +4506,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4673,9 +4747,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4703,6 +4787,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4956,6 +5045,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5124,6 +5218,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5300,6 +5399,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5407,6 +5511,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5908,6 +6017,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6157,6 +6271,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6290,6 +6409,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6372,6 +6501,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6707,6 +6841,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7128,6 +7267,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7158,6 +7302,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7175,6 +7329,11 @@ msgstr "Otene custa cantzone dae:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Agiuda·si a crèschere chistionende de nois a is amistades tuas."
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr "Ghana"
@@ -7729,6 +7888,11 @@ msgstr "Cua is passos"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -9067,6 +9231,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Ti permitit de chircare in manera anònima cun DuckDuckGo"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9122,6 +9292,11 @@ msgstr "Disinnu de lìnia"
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -10024,6 +10199,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Prus de 20 minutos"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10418,6 +10598,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10969,6 +11154,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Ativadu, però sena nùmeros"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11144,6 +11334,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11750,9 +11945,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11767,6 +11972,11 @@ msgstr "Rosa"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12026,6 +12236,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12196,6 +12411,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12640,6 +12860,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12667,6 +12897,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12789,6 +13024,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -13096,6 +13336,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Reseta totu is cunfiguratziones"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -13104,6 +13349,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13671,6 +13921,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr "Boles chircare %s pro agatare resurtados prus acanta de tue?"
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Chirca in manera anònima"
 
@@ -13956,6 +14211,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14386,6 +14646,11 @@ msgstr "Cunfigura comente motore de chirca predefinidu"
 msgid "Set as Homepage"
 msgstr "Cunfigura comente pàgina printzipale"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14440,6 +14705,16 @@ msgstr "Cunfiguratziones atualizadas"
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14471,6 +14746,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14519,6 +14800,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14631,6 +14917,11 @@ msgstr "Ammustra marcadore e datos de cunfiguratziones"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Ammustra detàllios"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14754,6 +15045,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14782,6 +15078,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -15094,6 +15395,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15326,6 +15632,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15804,6 +16115,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Cola a su motore de chirca chi non ti sighit. Mai."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15916,6 +16234,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15986,6 +16309,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Recùpera sa riservadesa tua!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16364,9 +16701,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16467,6 +16814,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16728,6 +17089,11 @@ msgstr "Oe"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -17065,9 +17431,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Proa una chirca!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -17122,6 +17498,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -17132,6 +17513,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -17156,6 +17542,11 @@ msgstr ""
 msgid "Try our homepage that never shows these messages:"
 msgstr ""
 "Pro sa pàgina printzipale nostra, chi no ammustrat mai custos messàgios:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17355,6 +17746,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17656,6 +18052,11 @@ msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr ""
 
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -17951,6 +18352,11 @@ msgstr "Imprea in Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Imprea in Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18883,6 +19289,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Ite ti portat torra inoghe, oe?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19225,6 +19636,13 @@ msgstr "Bentos"
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19572,6 +19990,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19685,6 +20109,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19724,6 +20153,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -20033,6 +20467,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20511,6 +20952,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "annu"
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
 
 #~ msgctxt "SERP footer content"
 #~ msgid "%s Billion Searches"

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr "%1$s අනාවරණය විය"
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -177,8 +183,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
-"ප්‍රකාරයකට මාරු වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -189,8 +195,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
-"ප්‍රකාරයකට මාරු වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -207,8 +213,7 @@ msgid ""
 "model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ DuckDuckGo දායකත්වයක් සමඟ පමණි. චැට් දිගටම කරගෙන යාමට මෙම "
-"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු "
-"වන්න."
+"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -217,8 +222,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව "
-"නැවත උත්සාහ කරන්න."
+"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -309,9 +314,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් "
-"අදහස් කරන්නේ ආකෘති සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ "
-"මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට නොහැකි බවයි."
+"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් අදහස් කරන්නේ ආකෘති "
+"සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට "
+"නොහැකි බවයි."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -355,6 +360,12 @@ msgid "%s used"
 msgstr "%1$sක් භාවිතා කර ඇත"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s දර්ශනය"
@@ -391,8 +402,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම "
-"කරගෙන යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
+"යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -403,8 +414,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
-"යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන යාමට "
+"ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -417,8 +428,8 @@ msgstr "%1$s වචන"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව "
-"%6$sහරි%7$sක්ලික් කරන්න"
+"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව %6$sහරි%7$sක්ලික් "
+"කරන්න"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -426,8 +437,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි "
-"ලකුණ දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
+"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි ලකුණ "
+"දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -447,8 +458,7 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට "
-"%1$sමෙතන ක්ලික් කරන්න%2$s."
+"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට %1$sමෙතන ක්ලික් කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -474,8 +484,7 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර "
-"ඉගෙන ගන්න."
+"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර ඉගෙන ගන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -494,8 +503,8 @@ msgstr "මුල් තිරයේ ඇති DuckDuckGo යෙදුම් න
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s "
-"සහ නැවත උත්සාහ කරන්න."
+"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s සහ නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -602,6 +611,12 @@ msgstr "පසුගිය පැය 24 තුළ DuckDuckGo විසින් 
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 දවසකට පෙර"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -823,8 +838,7 @@ msgstr "පැය 6ක පරිශීලන සීමාවට ළඟා වී
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
-"හැක."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -832,8 +846,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට "
-"ම කතාබස් කළ හැකි ය."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට ම කතාබස් කළ "
+"හැකි ය."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -887,8 +901,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. "
-"කරුණාකර ඔබේ සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
+"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. කරුණාකර ඔබේ "
+"සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -896,8 +910,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
 msgstr ""
-"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
-"නැවත නැවුම් කරන්න."
+"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -905,8 +919,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
 msgstr ""
-"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
-"නැවත නැවුම් කරන්න."
+"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -950,10 +964,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. "
-"මෙය ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. "
-"මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI "
-"Chat වෙත ප්‍රවේශ විය හැකිය."
+"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. මෙය "
+"ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. මෙම සැකසුම ක්‍රියා "
+"විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI Chat වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1014,10 +1027,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ "
-"වෙතත්, අපි පසු විපරම් ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය "
-"වෙත සබැඳෙමු, එය OpenAI සහ Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය "
-"දක්වන අපගේ පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ වෙතත්, අපි පසු විපරම් "
+"ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය වෙත සබැඳෙමු, එය OpenAI සහ "
+"Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය දක්වන අපගේ පෞද්ගලික AI බලයෙන් "
+"ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1202,8 +1215,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් "
-"නොමිලේ ආකෘතියකට මාරු වන්න."
+"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට "
+"මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1239,8 +1252,8 @@ msgstr "දැන්වීම"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය "
-"මගින් වන අතර ඒවා ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
+"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය මගින් වන අතර ඒවා "
+"ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1248,8 +1261,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය "
-"විසිනි, ඒවා ඔබව පැතිකඩ කිරීමට භාවිතා නොකෙරේ."
+"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය විසිනි, ඒවා ඔබව පැතිකඩ "
+"කිරීමට භාවිතා නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1300,8 +1313,7 @@ msgstr "DuckDuckGo දිගුව එක් කරන්න"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් "
-"කරන්න:"
+"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් කරන්න:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1516,6 +1528,14 @@ msgid "Advanced Models"
 msgstr "උසස් ආකෘති"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "සෙවීම පිළිබඳ ප්රචාරය කරන්න"
@@ -1691,8 +1711,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo "
-"හෝ ආකෘති සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
+"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo හෝ ආකෘති "
+"සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1739,8 +1759,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, "
-"ඔබගේ IP ලිපිනය) ඉවත් කරනු ලැබේ."
+"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, ඔබගේ IP ලිපිනය) "
+"ඉවත් කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1772,8 +1792,7 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය "
-"ලබා දෙන්න."
+"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1805,10 +1824,9 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ "
-"දෙයි. සීමිත දත්ත රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් "
-"පමණක් යවයි. %2$s සහිත විමසීම් සහ ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ "
-"දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
+"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ දෙයි. සීමිත දත්ත "
+"රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් පමණක් යවයි. %2$s සහිත විමසීම් සහ "
+"ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1816,8 +1834,7 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට "
-"අවශ්‍ය වේ)"
+"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1955,8 +1972,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
-"නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1965,8 +1981,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
-"නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1980,9 +1995,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. "
-"එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම "
-"අක්‍රිය කරන්න."
+"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. එය කොපමණ වාර ගණනක් "
+"පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2029,8 +2043,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම "
-"විටම කරුණු මට කියන්න"
+"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම විටම කරුණු "
+"මට කියන්න"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2150,8 +2164,7 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, "
-"සියලුම කතා මකා දමනු ඇත."
+"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, සියලුම කතා මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2160,8 +2173,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද "
-"ඕනෑම මෑත කාලීන කතාබස් ද මකා දමනු ඇත."
+"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද ඕනෑම මෑත "
+"කාලීන කතාබස් ද මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2199,9 +2212,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම "
-"රැස්කර හෝ හුවමාරුකර නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු "
-"වේ."
+"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම රැස්කර හෝ හුවමාරුකර "
+"නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු වේ."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2299,6 +2311,12 @@ msgid "Ask privately"
 msgstr "පෞද්ගලිකව අසන්න"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2331,14 +2349,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා "
-"AI-සහය සහිත පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් "
-"Assist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් "
-"ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම මත (ඔබ Assist "
-"බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
-"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක "
-"සෙවුම් මත නිතර පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් "
-"ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
+"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා AI-සහය සහිත "
+"පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් Assist පෙනී සිටීමට අවශ්‍ය දැ යි "
+"ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම "
+"මත (ඔබ Assist බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
+"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
+"පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2350,12 +2366,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු "
-"කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ "
-"තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා "
-"තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
-"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් විමසුම් "
+"සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා "
+"වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-"
+"බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව "
+"ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2493,9 +2508,7 @@ msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදන
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් "
-"තිබිය හැක."
+msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් තිබිය හැක."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2520,9 +2533,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර "
-"සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist "
-"ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර "
+"වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල "
+"පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2531,17 +2544,15 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව "
-"සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, "
-"DuckAssist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව සමහර සෙවීම් "
+"වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, DuckAssist ලබා ගත "
+"හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව "
-"ධාවනය කරන්න."
+msgstr "ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව ධාවනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2741,8 +2752,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත "
-"හැකි පාරදත්ත වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
+"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත හැකි පාරදත්ත "
+"වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3123,18 +3134,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ "
-"සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s "
-"දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
+"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් "
-"යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s "
-"දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3142,9 +3151,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන "
-"බ්‍රවුසර්%2$s සඳහා පුද්ගලික සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය "
-"යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන බ්‍රවුසර්%2$s සඳහා පුද්ගලික "
+"සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3251,11 +3259,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ "
-"බ්‍රව්සරයේ). ඔබේ සැකසීම් වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික "
-"Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත "
-"හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි විටෙකත් ඔබගේ "
-"බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ බ්‍රව්සරයේ). ඔබේ සැකසීම් "
+"වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති "
+"දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි "
+"විටෙකත් ඔබගේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3263,8 +3270,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ "
-"දත්ත OpenAI වෙත යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ දත්ත OpenAI වෙත "
+"යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3273,8 +3280,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත "
-"OpenAI වෙත යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත OpenAI වෙත "
+"යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3309,9 +3316,7 @@ msgstr "කැමරූන්"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ "
-"හැකිද?"
+msgstr "කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ හැකිද?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3760,11 +3765,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික "
-"සංවාද කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. "
-"මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු "
-"ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් "
-"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත ප්‍රවේශ විය හැකිය."
+"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික සංවාද "
+"කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. මෙම සැකසුම අක්‍රිය "
+"කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම "
+"ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත "
+"ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3820,8 +3825,7 @@ msgstr "පෞද්ගලිකව චැට් කරන්න"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ "
-"යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3829,8 +3833,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක "
-"පුද්ගලිකව කතාබහේ යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක පුද්ගලිකව කතාබහේ "
+"යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3843,6 +3847,12 @@ msgstr "%1$sසමඟ පෞද්ගලිකව චැට් කරන්න"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "AI සමඟ පෞද්ගලිකව චැට් කරන්න"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3893,8 +3903,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් "
-"ගබඩා කර ඇත. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
+"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් ගබඩා කර ඇත. "
+"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3906,11 +3916,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
-"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
-"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. "
-"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ "
-"ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් "
+"නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
+"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ "
+"කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3933,9 +3942,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන "
-"සියලුම ගොනු %2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව "
-"සමාලෝචනය කරනු ලැබේ."
+"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන සියලුම ගොනු "
+"%2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව සමාලෝචනය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -3943,8 +3951,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට "
-"ගබඩාවේ ඉඩ නිදහස් කරගන්න."
+"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට ගබඩාවේ ඉඩ නිදහස් "
+"කරගන්න."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4108,9 +4116,7 @@ msgstr "සේවාවක් තෝරන්න"
 msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
-msgstr ""
-"ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම "
-"තෝරන්න"
+msgstr "ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම තෝරන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4291,9 +4297,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන "
-"කතාබස් කාලය නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා "
-"ස්වයංක්‍රීයව මකා දැමිය හැකි ය."
+"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන කතාබස් කාලය "
+"නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා ස්වයංක්‍රීයව මකා දැමිය හැකි "
+"ය."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4303,9 +4309,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, "
-"ඔබේ බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ "
-"ස්වයංක්‍රීයව මකා දැමිය හැකිය."
+"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, ඔබේ "
+"බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ ස්වයංක්‍රීයව මකා දැමිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4314,8 +4319,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ "
-"අවහිර ලැයිස්තුව අපගේ ගාස්තු රහිත බ්‍රවුසරයේ"
+"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ අවහිර ලැයිස්තුව අපගේ "
+"ගාස්තු රහිත බ්‍රවුසරයේ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4324,9 +4329,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ "
-"%1$sDuck.ai%2$s හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ "
-"ආයතනවලින් චැට් ආකෘතිවලට සහය දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
+"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ %1$sDuck.ai%2$s "
+"හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ ආයතනවලින් චැට් ආකෘතිවලට සහය "
+"දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4400,8 +4405,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ "
-"දකුණු පස %3$sgears icon%4$s මත ක්ලික් කරන්න)"
+"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ දකුණු පස "
+"%3$sgears icon%4$s මත ක්ලික් කරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4431,8 +4436,7 @@ msgstr "%1$sYes%2$s කලික් කරන්න"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් "
-"කරන්න."
+"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් කරන්න."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4494,9 +4498,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
-"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
-"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
+"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4507,9 +4510,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
-"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
-"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
+"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4578,8 +4580,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් "
-"මෙනුව ක්ලික් කර %3$sDuckDuckGo%4$s තෝරන්න."
+"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් මෙනුව ක්ලික් කර "
+"%3$sDuckDuckGo%4$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4587,8 +4589,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ "
-"ඉහළ දකුණු කෙළවරේ තියෙනවා."
+"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ ඉහළ දකුණු කෙළවරේ "
+"තියෙනවා."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4629,6 +4631,12 @@ msgstr "කාටූන් චිත්‍ර"
 #. An accessible label for a button that closes a modal dialog
 msgid "Close"
 msgstr "වසන්න"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4673,6 +4681,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "සෙවුම වසන්න"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4777,8 +4791,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු "
-"කිරීමට හැකියාව Cloud Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
+"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු කිරීමට හැකියාව Cloud "
+"Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5046,6 +5060,12 @@ msgid "Continue Blocking Ads"
 msgstr "දැන්වීම් අවහිර කිරීම දිගටම කරමු"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5111,6 +5131,12 @@ msgid "Cookie data:"
 msgstr "කුකී දත්ත:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5156,6 +5182,12 @@ msgstr "ලිපිනය ඇතුළත් කරන තීරුවට %1$sa
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "කේතය පිටපත් කරන්න"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5226,8 +5258,7 @@ msgstr "කොස්ටාරිකාව"
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
 msgstr ""
-"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ "
-"කරන්න."
+"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5273,6 +5304,12 @@ msgid "Create Image"
 msgstr "රූපය සාදන්න"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5314,6 +5351,14 @@ msgstr "නිර්මාණය කරන ලද්දේ"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "%1$s විසින් නිර්මාණය කරන ලදී"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5469,6 +5514,12 @@ msgid "Customize responses"
 msgstr "ප්‍රතිචාර අභිරුචි කරන්න"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "මෙම පිටුව සිතැඟි පරිදි සකසන්න"
@@ -5541,8 +5592,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් "
-"කරගෙන යා හැකිය."
+"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් කරගෙන යා හැකිය."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5753,10 +5803,22 @@ msgid "Delete Server Data?"
 msgstr "සර්වර දත්ත මකා දමන්න ද?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "පිටපත මකන්න"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5789,6 +5851,12 @@ msgstr "රූපය මකන්න"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "රූපය මකා දමන්න ද?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5915,8 +5983,8 @@ msgstr "Duck.ai අසා ලිවීම"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට "
-"කිසිවිටෙකත් භාවිතා කරනු නොලැබේ."
+"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට කිසිවිටෙකත් භාවිතා කරනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -5934,8 +6002,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා "
-"කරන බැවින්, ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
+"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා කරන බැවින්, "
+"ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6099,6 +6167,12 @@ msgid "Dismiss promotion"
 msgstr "ප්‍රවර්ධනය ඉවත ලන්න"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6241,8 +6315,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන "
-"අතර AI-ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන අතර AI-"
+"ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6251,8 +6325,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ "
-"AI රූප පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ AI රූප "
+"පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6309,6 +6383,12 @@ msgid "Download DuckDuckGo"
 msgstr "DuckDuckGo බාගත කරන්න"
 
 # smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo Browser"
@@ -6362,8 +6442,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින "
-"විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
+"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6372,8 +6452,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට "
-"සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
+"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6394,8 +6474,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප "
-"කිහිපයක් කෙටුම්පත් කරන්න."
+"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප කිහිපයක් කෙටුම්පත් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6404,8 +6484,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් "
-"සඳහා විකල්ප කිහිපයක් කෙටුම්පත් කරන්න."
+"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් සඳහා විකල්ප "
+"කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6524,6 +6604,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "DuckDuckGo වෙතින් Duck.ai. පුද්ගලික AI කතාබස්. ගාස්තු රහිතයි."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6531,9 +6617,8 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. "
-"සැකසුම් තුළ පිටු ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය "
-"ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
+"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. සැකසුම් තුළ පිටු "
+"ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6543,9 +6628,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ "
-"බ්‍රවුසර සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය "
-"කර නැවත උත්සාහ කරන්න."
+"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ බ්‍රවුසර "
+"සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6554,8 +6638,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම "
-"කතාබස් දිගටම කරගෙන යන්න."
+"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම "
+"කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6571,9 +6655,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය "
-"නැවතත් සියතට ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන "
-"ස්වාධීන සමාගමක් ලෙස අපි කටයුතු කරමු."
+"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය නැවතත් සියතට "
+"ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන ස්වාධීන සමාගමක් ලෙස අපි "
+"කටයුතු කරමු."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6588,8 +6672,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් "
-"පිටුවක් සමගින් අන්තර්ජාලයේ: https://duck.ai"
+"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් පිටුවක් සමගින් "
+"අන්තර්ජාලයේ: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6604,8 +6688,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s "
-"නිර්නාමික කේතය %2$s වෙත ඊමේල් කරන්න"
+"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s නිර්නාමික "
+"කේතය %2$s වෙත ඊමේල් කරන්න"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6626,9 +6710,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. "
-"එය අක්‍රිය කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව "
-"ම %1$sduck.ai%2$s වෙත පිවිසිය හැකි ය."
+"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. එය අක්‍රිය "
+"කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව ම %1$sduck.ai%2$s වෙත "
+"පිවිසිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6639,11 +6723,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI "
-"චැට් ආකෘති සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය "
-"කිරීමෙන් DuckDuckGo Search හි Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, "
-"මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට %1$shttps://duck.ai%2$s වෙත "
-"පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
+"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI චැට් ආකෘති "
+"සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි "
+"Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට "
+"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6658,8 +6741,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai "
-"භාවිතා කරන්න පුළුවන්."
+"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai භාවිතා "
+"කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6673,8 +6756,13 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා "
-"පරීක්ෂා කර නැත."
+"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා පරීක්ෂා කර නැත."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6702,10 +6790,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI "
-"කතාබහ, ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, "
-"විවෘත මූලාශ්‍ර AI ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI "
-"කතාබස්"
+"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI කතාබහ, "
+"ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, විවෘත මූලාශ්‍ර AI "
+"ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI කතාබස්"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6733,13 +6820,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා "
-"සාරාංශගත කළ හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා "
-"ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම "
-"ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට "
-"(ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
-"නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ "
-"පමණි."
+"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ "
+"හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් "
+"(සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම "
+"ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට (ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත නිතර නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද "
+"(ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6748,10 +6834,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
-"%1$sDuckDuckGo AI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
-"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
-"සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි %1$sDuckDuckGo AI "
+"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
+"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6760,10 +6845,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
-"DuckDuckGo %1$sAI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
-"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
-"සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි DuckDuckGo %1$sAI "
+"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
+"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6775,12 +6859,11 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
-"එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම "
-"තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් ක්‍රියාත්මක වන ස්වාභාවික භාෂා "
-"තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ අන්තර්ගතයන් මත "
-"පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
+"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව "
+"සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් "
+"ක්‍රියාත්මක වන ස්වාභාවික භාෂා තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ "
+"අන්තර්ගතයන් මත පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6794,15 +6877,13 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
-"එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත "
-"පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත "
-"කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට සෘජුවම සම්බන්ධ වන "
-"අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
-"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් "
-"ස්වයංක්රීයව ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම "
-"වැදගත්ය."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
+"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් "
+"කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති "
+"ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට "
+"සෘජුවම සම්බන්ධ වන අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
+"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
+"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6810,8 +6891,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර "
-"නිරවද්‍යතාව සඳහා පරීක්‍ෂා කර නොමැත."
+"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර නිරවද්‍යතාව සඳහා "
+"පරීක්‍ෂා කර නොමැත."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6820,8 +6901,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට "
-"මෙම කතාබස් දිගටම කරගෙන යන්න."
+"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට මෙම "
+"කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6830,8 +6911,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
-"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
+"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6840,8 +6921,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
-"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
+"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6867,9 +6948,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ "
-"කරන්න."
+msgstr "DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6994,8 +7073,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත "
-"වැනි PII ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
+"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත වැනි PII "
+"ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7003,8 +7082,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai "
-"%2$s වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai %2$s වෙත එකඟ "
+"වෙයි."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7013,8 +7092,7 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s "
-"වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7023,9 +7101,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල "
-"DuckDuckGo ට්‍රැකර් අවහිර කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය "
-"කිරීමට උත්සාහ කරයි."
+"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල DuckDuckGo ට්‍රැකර් අවහිර "
+"කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය කිරීමට උත්සාහ කරයි."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7037,11 +7114,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය "
-"උපාංගයේ පමණක් ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ "
-"ප්‍රතිඵල වැඩි දියුණු කිරීම සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන "
-"පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම "
-"තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය උපාංගයේ පමණක් "
+"ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ ප්‍රතිඵල වැඩි දියුණු කිරීම "
+"සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ "
+"පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන "
+"ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7061,8 +7138,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල "
-"ලබා දීමට අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල ලබා දීමට "
+"අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7148,9 +7225,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු "
-"අහඹු වචන ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 "
-"ක් තෝරා ගනිමු, මුරපදය අවම වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
+"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු අහඹු වචන "
+"ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 ක් තෝරා ගනිමු, මුරපදය අවම "
+"වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7220,9 +7297,7 @@ msgstr "රූපය සංස්කරණය කෙරේ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය "
-"කරයි."
+msgstr "ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7319,6 +7394,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "වැඩිපුරම නැරඹූ අඩවි සක්‍රීය කරන්න"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7354,8 +7435,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම "
-"විටම ඔබේ අදහස වෙනස් කළ හැකිය."
+"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම විටම ඔබේ අදහස වෙනස් "
+"කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7366,9 +7447,7 @@ msgstr "Duck.ai මත අසා ලිවීම සක් රීය කරන�
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය "
-"කරන්න"
+msgstr "නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7400,8 +7479,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් "
-"තවමත් ඔබේ සෙවුම් සහ නිශ්චිත ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
+"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් තවමත් ඔබේ සෙවුම් සහ නිශ්චිත "
+"ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7563,8 +7642,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ "
-"නව මුරදය යටතේ ඔබගේ දත්ත සුරකිනු ඇත."
+"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ නව මුරදය යටතේ "
+"ඔබගේ දත්ත සුරකිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7616,6 +7695,12 @@ msgstr "ඔබගේ සැකසුම් පූරණය කිරීමට �
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "විනෝදාශ්වාද උපදේශක"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7685,9 +7770,7 @@ msgstr "සිතියම පුළුල් කරන්න"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද "
-"නිෂ්පාදන."
+msgstr "පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද නිෂ්පාදන."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7760,9 +7843,7 @@ msgstr "මෙය සරලව පැහැදිලි කරන්න"
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
-"මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි "
-"කරන්න."
+msgstr "මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි කරන්න."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7781,6 +7862,18 @@ msgstr "විවෘත දත්ත"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "පැහැදිලි ගී පද"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7884,6 +7977,12 @@ msgid "FREE"
 msgstr "නොමිලේ"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7939,9 +8038,7 @@ msgstr "ප්‍රතිපෝෂණය සාර්ථකව යවන ලද
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු "
-"කිරීම් බලපායි."
+msgstr "ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් බලපායි."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -7950,18 +8047,15 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් "
-"සෘජුවම බලපායි. ඔබ බෙදාගත් ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම "
-"බලාපොරොත්තු වෙමි."
+"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් සෘජුවම බලපායි. ඔබ බෙදාගත් "
+"ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම බලාපොරොත්තු වෙමි."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් "
-"කරන්න."
+msgstr "පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් කරන්න."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8051,8 +8145,7 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. "
-"%1$sවැඩිදුර දැනගන්න%2$s"
+"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. %1$sවැඩිදුර දැනගන්න%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8130,9 +8223,7 @@ msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගන්�
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව "
-"පවතී."
+msgstr "ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව පවතී."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8196,8 +8287,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට "
-"මෙනු විකල්පයක් තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
+"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට මෙනු විකල්පයක් "
+"තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8297,6 +8388,12 @@ msgstr "නොමිලේ සැලැසුම"
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
 msgstr "ගබඩාවේ ඉඩ නිදහස් කරගන්න"
+
+# smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8420,8 +8517,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac හි යෙදුම් මෙනු තීරුවෙන්, <strong>DuckDuckGo</strong> තෝරන්න &gt; "
-"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන "
-"ස්ථාපනය කරන්න</strong> තෝරන්න."
+"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන ස්ථාපනය "
+"කරන්න</strong> තෝරන්න."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8772,8 +8869,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත "
-"දායක වීමෙන් Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත දායක වීමෙන් Duck."
+"ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8784,8 +8881,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo "
-"දායකත්වයක් සමඟ Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo දායකත්වයක් සමඟ "
+"Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8809,6 +8906,12 @@ msgstr "DuckDuckGo Help වෙතින් පිළිතුරු ලබා �
 msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr "පරිගණක සහාය ලබා ගන්න"
+
+# smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8846,6 +8949,18 @@ msgid "Get the Latest Version"
 msgstr "නවතම අනුවාදය ලබා ගන්න"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8866,6 +8981,12 @@ msgstr "මෙම ගීය ලබා ගන්න මෙයින්:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "ඔබගේ යහළුවන්ව වෙනස් වීමට යොමු කරවා අපට වර්ධනය වීමට උදවු කරන්න!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8896,9 +9017,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
-"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න › පාඨමය කේතය පිටපත් කරන්න%4$sවෙත යන්න"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න › පාඨමය කේතය "
+"පිටපත් කරන්න%4$sවෙත යන්න"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8907,9 +9028,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත "
-"යන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත ගොස් "
+"%3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8919,9 +9039,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
-"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න%4$s වෙත ගොස් මෙම කේතය ස්කෑන් කරන්න:"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත ගොස් මෙම "
+"කේතය ස්කෑන් කරන්න:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8931,10 +9051,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
-"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් "
-"කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. "
+"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8949,8 +9068,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන "
-"සේවා\" සක්‍රිය කර ඇති බවට වග බලා ගන්න."
+"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන සේවා\" සක්‍රිය කර "
+"ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8959,8 +9078,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් "
-"%3$sDuckDuckGo%4$s වෙත පහළට අනුචලනය කරන්න."
+"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් %3$sDuckDuckGo%4$s "
+"වෙත පහළට අනුචලනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9553,6 +9672,12 @@ msgid "Hide Tips"
 msgstr "ඉඟි සඟවන්න"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9637,8 +9762,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist "
-"පිළිතුරුවල ප්‍රධාන කරුණු ඉස්මතු කරයි."
+"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist පිළිතුරුවල ප්‍රධාන "
+"කරුණු ඉස්මතු කරයි."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9665,8 +9790,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ "
-"සුරකින්න.%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
+"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ සුරකින්න."
+"%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9680,8 +9805,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ "
-"රහස්‍යතා ආරක්ෂාව අහිමි වේ."
+"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ රහස්‍යතා ආරක්ෂාව "
+"අහිමි වේ."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9731,8 +9856,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය "
-"කරනු ලබන අතර ඔබව පැතිකඩ කිරීමට භාවිත නොකෙරේ."
+"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය කරනු ලබන අතර ඔබව "
+"පැතිකඩ කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9874,8 +9999,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ "
-"කෙසේද සහ මා කුමක් කිව යුතුද?"
+"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ කෙසේද සහ මා කුමක් "
+"කිව යුතුද?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -9997,8 +10122,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම "
-"කැමති මොනවාද සහ ඇයි?"
+"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම කැමති මොනවාද "
+"සහ ඇයි?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10033,8 +10158,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > "
-"'පිහිටීම හා රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > 'පිහිටීම හා "
+"රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10044,9 +10169,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > "
-"සැකසුම් > අඩවි සැකසුම් > පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා "
-"අවසර දී ඇති ද යන්න දැනගන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > සැකසුම් > අඩවි සැකසුම් > "
+"පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා අවසර දී ඇති ද යන්න දැනගන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10061,8 +10185,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther "
-"Search Engines%4$s ලැයිස්තුවට එකතු කරන්න"
+"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther Search "
+"Engines%4$s ලැයිස්තුවට එකතු කරන්න"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10071,8 +10195,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් "
-"ඇත්නම්, ඔබට කෙලින්ම %1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
+"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් ඇත්නම්, ඔබට කෙලින්ම "
+"%1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10081,17 +10205,14 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා "
-"ගැනීමට මෙම කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස "
-"සුරැකිය හැකි ය."
+"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා ගැනීමට මෙම "
+"කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස සුරැකිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු "
-"කරන්න%2$s"
+msgstr "ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු කරන්න%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10101,17 +10222,15 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ "
-"%1$s හෝ %2$s යන පිටපත් භාවිතා කරන්න."
+"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ %1$s හෝ %2$s "
+"යන පිටපත් භාවිතා කරන්න."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත "
-"කරන්න)."
+msgstr "ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත කරන්න)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10240,8 +10359,7 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය "
-"වැඩි දියුණු කරයි"
+"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය වැඩි දියුණු කරයි"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10254,8 +10372,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් "
-"කිරීම් අපගේ සර්වරය හරහා හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
+"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් කිරීම් අපගේ සර්වරය හරහා "
+"හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10266,8 +10384,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න” වෙත යන්න."
+"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් උපාංගයක් සමග "
+"සමමුහුර්ත කරන්න” වෙත යන්න."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10282,8 +10400,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන "
-"ගැනීමට හැකියි අප ගබඩා කරන්නේ කුමන දත්තද කියා."
+"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන ගැනීමට හැකියි අප "
+"ගබඩා කරන්නේ කුමන දත්තද කියා."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10294,8 +10412,8 @@ msgstr "ඉහළ ඇති මෙනුවෙන් %1$sTools%2$s > %3$sSetting
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
 msgstr ""
-"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි "
-"සලකුණ යොදන්න"
+"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි සලකුණ "
+"යොදන්න"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10622,8 +10740,7 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය "
-"සාරාංශගත කරන්න."
+"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10692,10 +10809,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි "
-"දැන්වීම් ජාලය හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ "
-"පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු "
-"නොකෙරේ."
+"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි දැන්වීම් ජාලය "
+"හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් "
+"නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10704,8 +10820,7 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත "
-"වේ."
+"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත වේ."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11172,6 +11287,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "දැන් DuckDuckGo වලින් නිර්නමිකව සොයන්න"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "ලයිබීරියාව"
 
@@ -11240,6 +11362,12 @@ msgstr "රේඛා චිත්‍ර"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "ප්‍රතිවාදී සීමාවෙන් පන්දු ලබාගැනීම් (Lineouts) දිනාගැනීම්"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11366,9 +11494,7 @@ msgstr "අනුචලනය කරන විට තවත් පින්ත�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය "
-"කරයි"
+msgstr "අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය කරයි"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11548,7 +11674,8 @@ msgstr "සියළුම වචන වල අක්ෂර වින්‍ය�
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
+msgstr ""
+"%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -11894,9 +12021,7 @@ msgstr "මයික්රොනීසියාව"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත "
-"උත්සාහ කරන්න."
+msgstr "මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12127,9 +12252,7 @@ msgstr "මාසික සීමාවට ළඟා විය"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
-"හැක."
+msgstr "මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12336,6 +12459,12 @@ msgstr "%1$sහි තවත් සංඛ්යාලේඛන"
 msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "මිනිත්තු 20කට වැඩියි"
+
+# smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12658,10 +12787,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම "
-"සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo "
-"සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් "
-"මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව "
+"විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු "
+"ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර "
+"තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12823,6 +12952,12 @@ msgstr "එපා ස්තුතියි"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "එපා ස්තුතියි"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13477,14 +13612,20 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the "
-"%4$s icon > Settings%5$s"
+"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the %4$s "
+"icon > Settings%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "විවෘත නමුත් අංක නැති"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13500,8 +13641,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. "
-"පිටු %1$s ක් හෝ ඊට අඩු පිටු ඇති ගොනු උඩුගත කරන්න."
+"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. පිටු %1$s ක් හෝ ඊට අඩු "
+"පිටු ඇති ගොනු උඩුගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13527,9 +13668,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව "
-"දක්වා ඇත."
+msgstr "ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව දක්වා ඇත."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13544,8 +13683,7 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත "
-"උත්සාහ කරන්න."
+"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13697,6 +13835,12 @@ msgstr "කතාබස් යෝජනා විවෘත කරන්න"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "රූප නිර්මාණය සහ සංස්කරණය කිරීමේ යෝජනා විවෘත කරන්න"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -13862,8 +14006,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් "
-"නිරීක්ෂණය කරයි. අපි ඔබව කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
+"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් නිරීක්ෂණය කරයි. අපි ඔබව "
+"කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13876,8 +14020,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු "
-"කරන්නේ හෝ බෙදා හරින්නේ නැත."
+"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු කරන්නේ හෝ බෙදා "
+"හරින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13885,9 +14029,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරකාරකය, ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & "
-"Android%2$sහි ලද හැක."
+"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය, "
+"ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & Android%2$sහි ලද හැක."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14140,8 +14283,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ "
-"සම්බන්ධ නොකරන බැවින් මුරපද යථාවත් කර ගත නොහැක."
+"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ සම්බන්ධ නොකරන බැවින් මුරපද "
+"යථාවත් කර ගත නොහැක."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14341,10 +14484,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත "
-"පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. "
-"ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s "
-"වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ "
+"ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම "
+"සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14353,10 +14495,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
-"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. "
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය ක්‍රියා විරහිත "
-"කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
+"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් "
+"කිරීමට හෝ එය ක්‍රියා විරහිත කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14366,10 +14507,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
-"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය "
-"නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට %1$sDuckAssist සැකසුම්%2$s වෙත "
-"පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
+"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට "
+"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14402,8 +14542,7 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් "
-"කිරීමට තෝරන්න."
+"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් කිරීමට තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14412,8 +14551,7 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI "
-"එකක් තෝරන්න."
+"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් තෝරන්න."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14434,8 +14572,8 @@ msgstr "විශේෂ වූ ප්‍රශ්නයක් තෝරා ග�
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් "
-"අනුගමනය කරන්න."
+"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් අනුගමනය "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14444,10 +14582,22 @@ msgid "Pin"
 msgstr "පිංච"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "%1$s %2$s වෙතින් කතාබස් මෙතැනට පින් කරන්න"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14465,6 +14615,12 @@ msgstr "රෝස"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "පින් කළ"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14505,9 +14661,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
-"සම්පූර්ණ කරන්න."
+msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14515,25 +14669,19 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
-"සම්පූර්ණ කරන්න."
+msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
-"(විකල්ප)"
+msgstr "කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
-"(විකල්ප)"
+msgstr "කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14554,8 +14702,7 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය "
-"මකා දමනු ඇත."
+"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14564,8 +14711,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
-"අලවා අන්තර්ගතය හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
+"හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14574,8 +14721,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
-"අලවා අන්තර්ගතය නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
+"නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14786,6 +14933,12 @@ msgid "Poor formatting"
 msgstr "දුර්වල ආකෘතිකරණය"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14992,6 +15145,12 @@ msgstr "පෙර රූපය"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "පෙර ටැබ්"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15329,8 +15488,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම "
-"පෙළ මෙහි ඇතුලත් කරන්න.]"
+"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම පෙළ මෙහි "
+"ඇතුලත් කරන්න.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15532,6 +15691,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "මධ්‍යම බිල්ට්-ඉන් මධ්‍යස්ථභාවයක් සහිත AI තර්කණය"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15567,14 +15738,20 @@ msgid "Recent chat storage can be adjusted in %s."
 msgstr "මෑත කාලීන කතාබස් ආචයනය %1$s තුළ සකස් කළ හැක."
 
 # smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
 msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
-"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
+"උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15583,8 +15760,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
-"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
+"උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15594,9 +15771,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
-"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
-"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
+"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් "
+"කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
+"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15721,13 +15898,17 @@ msgid "Reduce Usage"
 msgstr "භාවිතය අඩු කරන්න"
 
 # smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr ""
-"ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු "
-"කරයි"
+msgstr "ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු කරයි"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -15868,8 +16049,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ "
-"&quot;Reload&quot; බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
+"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ &quot;Reload&quot; "
+"බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15959,8 +16140,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" "
-"බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" බොත්තම ඉවත් කරයි. "
+"හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15968,9 +16149,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි "
-"\"Generate\" බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව "
-"දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Generate\" බොත්තම ඉවත් "
+"කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16028,9 +16208,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට "
-"DuckDuckGo වෙත යවනු ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු "
-"කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු ලැබේ."
+"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට DuckDuckGo වෙත යවනු "
+"ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු "
+"ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16038,8 +16218,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු "
-"පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත "
+"හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16048,9 +16228,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට "
-"ඉල්ලා ඇති සියලු පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ "
-"කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට ඉල්ලා ඇති සියලු "
+"පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි "
+"තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16097,6 +16277,12 @@ msgid "Reset All Settings"
 msgstr "සියලු සැකසුම් නැවත සකසන්න"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16107,6 +16293,12 @@ msgstr "%1$sකින් යළි සැකසේ"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "විභේදනය"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16130,9 +16322,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා "
-"කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16141,9 +16332,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා "
-"කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16153,10 +16343,9 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය "
-"කර ඇති අතර සාවද්‍යතා අඩංගු විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s "
-"යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය කර ඇති අතර සාවද්‍යතා අඩංගු "
+"විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16581,8 +16770,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ "
-"මෑත කාලීන කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
+"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ මෑත කාලීන "
+"කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16743,8 +16932,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු "
-"%3$sChange%4$s ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
+"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු %3$sChange%4$s "
+"ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16753,8 +16942,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත "
-"ක්ලික් කරන්න (හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
+"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත ක්ලික් කරන්න "
+"(හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16803,6 +16992,12 @@ msgid "Search %s to find results closer to you?"
 msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගැනීමට %1$s සොයන්න ද?"
 
 # smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Search Anonymously"
 msgstr "නිර්නාමිකව සොයන්න"
 
@@ -16826,13 +17021,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන "
-"විශේෂාංගයකි. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන "
-"අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි. ඔබට එය කොපමණ වාර "
-"ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, ඉල්ලූ-විට (Assist "
-"ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන "
-"කලාපවල උප කණ්ඩායමක පමණි."
+"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන විශේෂාංගයකි. මෙය සිදු කිරීම "
+"සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI "
+"භාවිත කරයි. ඔබට එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, "
+"ඉල්ලූ-විට (Assist ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන කලාපවල උප "
+"කණ්ඩායමක පමණි."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16840,8 +17034,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක "
-"තොරතුරු සොයාගැනීමට Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
+"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක තොරතුරු සොයාගැනීමට "
+"Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16850,10 +17044,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප "
-"විශේෂාංගයකි. %1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් "
-"කර පසුව සොයාගත් තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත "
-"කරයි."
+"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප විශේෂාංගයකි. "
+"%1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් කර පසුව සොයාගත් තොරතුරු "
+"මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16974,8 +17167,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ "
-"“ducks” සෘජුවම සොයාගත හැක."
+"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ “ducks” සෘජුවම "
+"සොයාගත හැක."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16994,8 +17187,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් "
-"සෙවුම එක් කරන්න, නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
+"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් සෙවුම එක් කරන්න, "
+"නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17003,8 +17196,7 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් "
-"භාවිතා කරනු ඇත)"
+"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් භාවිතා කරනු ඇත)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17016,11 +17208,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර "
-"ගබඩා තුළ ගබඩා කර ඇත, නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ "
-"සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු "
-"ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් ඔබේ බ්‍රව්සරයෙන් ඉවත් "
-"නොවේ."
+"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර ගබඩා තුළ ගබඩා කර ඇත, "
+"නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත "
+"කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් "
+"ඔබේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17123,8 +17314,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17133,8 +17324,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17143,8 +17334,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17153,8 +17344,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා කර, "
+"ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17169,8 +17360,14 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
-"හැර වෙන කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
+"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට හැර වෙන "
+"කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17388,8 +17585,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් "
-"වල) තෝරන්න"
+"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් වල) "
+"තෝරන්න"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17454,8 +17651,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් "
-"අනෙකුත් විකල්ප වලින් එකක් තෝරන්න)"
+"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් අනෙකුත් "
+"විකල්ප වලින් එකක් තෝරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17577,8 +17774,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත "
-"විමසුමක් යවයි. මෙම උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
+"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත විමසුමක් යවයි. මෙම "
+"උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17676,6 +17873,12 @@ msgid "Set as Homepage"
 msgstr "මුල් පිටුව ලෙස සකසන්න"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17688,8 +17891,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක "
-"කිරීමෙන් පසු Sync & Backup පිහිටුුවන්න."
+"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක කිරීමෙන් පසු Sync & "
+"Backup පිහිටුුවන්න."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17741,6 +17944,18 @@ msgid "Seychelles"
 msgstr "සීෂෙල්ස්"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17776,8 +17991,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. "
-"Duck.ai කිසි විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
+"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. Duck.ai කිසි "
+"විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17838,6 +18060,12 @@ msgid "Share positive feedback"
 msgstr "ධනාත්මක ප්‍රතිපෝෂණ බෙදා ගන්න"
 
 # smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17860,8 +18088,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ "
-"හානිකර වාර්තා සඳහා අවශ්‍ය වේ)"
+"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ හානිකර වාර්තා "
+"සඳහා අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17973,6 +18201,12 @@ msgid "Show Detail"
 msgstr "විස්තර පෙන්වන්න"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "DuckAssist <sup>BETA</sup> පෙන්වන්න"
@@ -17982,8 +18216,7 @@ msgstr "DuckAssist <sup>BETA</sup> පෙන්වන්න"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත "
-"කිරීමටද%2$s හැකිය.)"
+"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත කිරීමටද%2$s හැකිය.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18122,6 +18355,12 @@ msgid "Show more"
 msgstr "දිග හරින්න"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18155,6 +18394,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "පැතිතීරුව පෙන්වන්න"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18209,8 +18454,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
-"කිරීම මතක් කිරීම සඟවයි සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවයි "
+"සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18218,8 +18463,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
-"කිරීම මතක් කිරීම සඟවන අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවන "
+"අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18257,8 +18502,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන "
-"පණිවුඩ පෙන්වන්න"
+"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන පණිවුඩ පෙන්වන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18525,6 +18769,12 @@ msgid "Something went wrong, please try again later."
 msgstr "යමක් වැරදී ඇත, කරුණාකර පසුව නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18579,8 +18829,7 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් "
-"උත්සාහ කරන්න."
+"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18589,16 +18838,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර "
-"ඇති බවට වග බලා ගන්න."
+"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර ඇති බවට වග "
+"බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට "
-"Duck.ai එකෙන් අහන්න උත්සාහ කළ හැක."
+"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට Duck.ai එකෙන් අහන්න "
+"උත්සාහ කළ හැක."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18607,16 +18856,15 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ "
-"කිරීමට%1$sමෙහි ක්ලික් කරන්න%2$s ."
+"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ කිරීමට%1$sමෙහි ක්ලික් "
+"කරන්න%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත "
-"උත්සාහ කරන්න."
+"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18819,6 +19067,12 @@ msgid "Start Using Weekly Limit"
 msgstr "සතිපතා සීමාව භාවිතය අරඹන්න"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "සෙවීම පටන් ගන්න!"
@@ -19014,8 +19268,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය "
-"ලබාගන්න, නැතහොත් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය ලබාගන්න, නැතහොත් "
+"තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19083,9 +19337,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා "
-"කරනවාද?"
+msgstr "සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා කරනවාද?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19397,6 +19649,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "ඔබ ගැන අනවසරයෙන් පරික්ෂා නොකරන සෙවුම් යන්ත්‍රයට මාරු වෙන්න. හැමදාටම."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19407,9 +19667,7 @@ msgstr "%1$sවෙත මාරු විය"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට "
-"යවනු ඇත"
+msgstr "ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට යවනු ඇත"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19464,8 +19722,7 @@ msgstr "Sync & Backup සක්‍රිය කරන ලදී!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය "
-"කළ නොහැක."
+"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19514,9 +19771,9 @@ msgid ""
 msgstr ""
 "ප්‍රතිසාධන කේතය සමමුහුර්ත කරන්න\n"
 "\n"
-"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් "
-"උපාංග කිහිපයක් අතර සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි "
-"වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය කර ගනී.\n"
+"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් උපාංග කිහිපයක් අතර "
+"සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
+"කර ගනී.\n"
 "\n"
 "මෙම තොරතුරු ආරක්ෂිතව තබා ගන්න.\n"
 "මෙම කේතයට ප්‍රවේශය ඇති ඕනෑම අයෙකුට ඔබේ සමමුහුර්ත දත්ත වෙත ප්‍රවේශ විය හැක.\n"
@@ -19525,14 +19782,12 @@ msgstr ""
 "\n"
 "මෙම කේතය ක්‍රියා කරන්නේ කෙසේ ද?\n"
 "1. ඔබේ බ්‍රවුසරයෙන් Duck.ai වෙත ගොස් Duck.ai සැකසුම් විවෘත කරන්න.\n"
-"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
-"කරන්න\" තෝරන්න\n"
-"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන "
-"ස්ථානයේ අලවන්න\n"
+"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය කරන්න\" තෝරන්න\n"
+"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන ස්ථානයේ "
+"අලවන්න\n"
 "\n"
-"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි "
-"කාලයක් භාවිතා නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය "
-"කළ නොහැක."
+"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි කාලයක් භාවිතා "
+"නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19551,6 +19806,12 @@ msgstr "වෙනත් උපාංගයක් සමඟ සමමුහුර
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "සමමුහුර්ත කිරීම සහ උපස්ථ කිරීම තාවකාලිකව ලබා ගත නොහැකිය"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19640,6 +19901,22 @@ msgid "Take Back Your Privacy!"
 msgstr "නැවතත් ඔබගේ පෞද්ගලිකත්වය ලබා ගන්න!"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19661,8 +19938,7 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික "
-"සමීක්ෂණයට සහභාගි වන්න."
+"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික සමීක්ෂණයට සහභාගි වන්න."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19877,9 +20153,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද "
-"තොරතුරු තෙවන පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ "
-"අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට ඇතුළත් වේ."
+"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද තොරතුරු තෙවන "
+"පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට "
+"ඇතුළත් වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19888,8 +20164,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් "
-"Cloud Save කුඩා පිටු සලකුණු මඟින් ඉඩ දෙයි."
+"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් Cloud Save කුඩා පිටු "
+"සලකුණු මඟින් ඉඩ දෙයි."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -19919,8 +20195,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය "
-"හැක්කේ ඔබට පමණි."
+"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය හැක්කේ ඔබට "
+"පමණි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -19941,9 +20217,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල "
-"සුරකින්නේ නැත."
+msgstr "ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල සුරකින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20002,8 +20276,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය "
-"කර ඇති බවට වග බලා ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
+"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය කර ඇති බවට වග බලා "
+"ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20018,8 +20292,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර "
-"කරුණාකර මිනිත්තු කිහිපයක් රැඳී සිටින්න."
+"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර කරුණාකර මිනිත්තු කිහිපයක් "
+"රැඳී සිටින්න."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20038,9 +20312,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් "
-"සහ DuckDuckGo ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් "
-"අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම බ්‍රව්සර් අවසර භාවිතා කරයි."
+"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් සහ DuckDuckGo "
+"ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම "
+"බ්‍රව්සර් අවසර භාවිතා කරයි."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20078,8 +20352,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ "
-"කිරීමට උත්සාහ කරන්න."
+"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ කිරීමට උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20088,8 +20362,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව "
-"කතාබහක් ආරම්භ කරන්න."
+"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව කතාබහක් "
+"ආරම්භ කරන්න."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20104,10 +20378,22 @@ msgid "This Month"
 msgstr "මේ මාසයේ"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "මේ සතියේ"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20116,9 +20402,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත "
-"කරමිනි. AI කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි "
-"විස්තර සඳහා %4$s බලන්න)."
+"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත කරමිනි. AI "
+"කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20128,8 +20413,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI "
-"කතාබස් සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
+"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI කතාබස් "
+"සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20138,8 +20423,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ "
-"අහිතකර තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
+"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ අහිතකර "
+"තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20150,8 +20435,8 @@ msgid ""
 "more info)."
 msgstr ""
 "මෙම සංවාදය DuckDuckGo AI Chat (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sහි %3$s ආකෘතිය "
-"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය "
-"(වැඩි විස්තර සඳහා %4$s බලන්න)."
+"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා "
+"%4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20237,6 +20522,22 @@ msgid "This information isn’t useful"
 msgstr "මෙම තොරතුරු ප්‍රයෝජනවත් නොවේ"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20255,8 +20556,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. "
-"අනෙකුත් ආකෘති සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. අනෙකුත් ආකෘති "
+"සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20265,8 +20566,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. "
-"අනෙකුත් ආකෘති සපයන්නන් සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. අනෙකුත් ආකෘති සපයන්නන් "
+"සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20303,8 +20604,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය "
-"සමඟ සුරකින අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
+"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ සුරකින "
+"අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20313,8 +20614,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
-"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
+"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20324,9 +20625,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
-"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ "
-"වෙතත්, අපට %1$s හි AI-සහය සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
+"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ වෙතත්, අපට %1$s හි AI-සහය "
+"සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20365,9 +20666,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup "
-"විසන්ධි කරයි. Sync & Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට "
-"තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට හැකි වනු ඇත."
+"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup විසන්ධි කරයි. Sync "
+"& Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට "
+"හැකි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20376,8 +20677,7 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු "
-"හැරවිය නොහැක."
+"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු හැරවිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20515,8 +20815,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට "
-"අවශ්‍ය මාර්ගය තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
+"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට අවශ්‍ය මාර්ගය "
+"තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20526,9 +20826,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත "
-"කිරීම සැකසීමේ දී සුරකින ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් "
-"වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
+"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත කිරීම සැකසීමේ දී සුරකින "
+"ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ "
+"PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20537,8 +20837,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය "
-"නවතම අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
+"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය නවතම "
+"අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20546,8 +20846,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ "
-"වීමට ඔබේ බ්‍රවුසරයට ඉඩ දෙන්න."
+"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ වීමට ඔබේ බ්‍රවුසරයට ඉඩ "
+"දෙන්න."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20564,6 +20864,12 @@ msgstr "අද"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "අද"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20737,8 +21043,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ "
-"ප්‍රමාණයක් අවහිර කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
+"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ ප්‍රමාණයක් අවහිර "
+"කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20786,8 +21092,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
-"ශාලාවට යන්නේ කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
+"කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20796,8 +21102,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
-"ශාලාවට යන්නේ කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
+"කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20977,9 +21283,21 @@ msgid "Try Them Out"
 msgstr "ඒවා උත්සාහ කරන්න"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "සෙවුමකට උත්සාහ කරන්න!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21014,9 +21332,7 @@ msgstr "වෙනත් වචන සමග උත්සාහ කරන්න."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ "
-"කරන්න."
+msgstr "තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21029,9 +21345,7 @@ msgstr "වඩාත් නිවැරදි ප්‍රතිඵල සඳහ
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා "
-"දෙනු ඇත."
+msgstr "එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා දෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21048,6 +21362,12 @@ msgid "Try for free"
 msgstr "නොමිලේ අත්හදා බලන්න"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21060,6 +21380,12 @@ msgstr "නොමිලේ අත්හදා බලන්න"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "නොමිලේ උත්සාහ කරන්න! ආරක්ෂිත VPN, පුද්ගලික සහ උසස් AI, සහ තවත් දේ."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21087,6 +21413,12 @@ msgstr "අපගේ බ්‍රවුසරය අත්හදා බලන්
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "අපගේ මුල් පිටුවට ගොස් බලන්න කවදාවත් එවැනි පනිවිඩ පෙන්වන්නේ නැහැ:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21201,8 +21533,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
+"No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21211,8 +21543,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
+"No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21334,6 +21666,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "ඉලක්කගත දැන්වීම් නොමැතිව YouTube නැරඹීම සඳහා Duck Player ආරම්භ කරන්න"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21395,8 +21733,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත "
-"කිරීමෙන් සෙවීමක් සහ ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
+"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත කිරීමෙන් සෙවීමක් සහ "
+"ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21526,8 +21864,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර "
-"%5$sSet Pages%6$s මත ක්ලික් කරන්න."
+"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර %5$sSet "
+"Pages%6$s මත ක්ලික් කරන්න."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -21535,8 +21873,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: "
-"https://duckduckgo.com"
+"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21652,8 +21990,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා "
-"2 ගුණයක් ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
+"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා 2 ගුණයක් "
+"ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21694,6 +22032,12 @@ msgstr "DuckDuckGo දායකත්වයක් සමඟ උසස් AI ම�
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "ඔබේ දායකත්වය සමඟ උසස් AI අගුළු විවෘත කරන්න!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -21787,8 +22131,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට "
-"DuckDuckGo බ්‍රවුසරය යාවත්කාලීන කරන්න"
+"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට DuckDuckGo බ්‍රවුසරය "
+"යාවත්කාලීන කරන්න"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21913,16 +22257,15 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත "
-"කරන්න, නැත්නම් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න, නැත්නම් තවත් "
+"රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත "
-"උත්ශ්‍රේණිගත කරන්න"
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22018,9 +22361,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, "
-"වංචාකරුවන් සහ සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා "
-"ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය නොවේ."
+"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, වංචාකරුවන් සහ "
+"සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22057,14 +22400,20 @@ msgid "Use in Safari"
 msgstr "Safari වල භාවිතා කරන්න"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය "
-"භාවිතා කරන්න. එය ආරක්ෂිතව තබා ගන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා කරන්න. එය "
+"ආරක්ෂිතව තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22072,8 +22421,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට "
-"මේ කේතය භාවිතා කරන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -22223,8 +22572,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
-"කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු "
+"ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22233,8 +22582,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
-"කිරීම් TripAdvisor හි දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් TripAdvisor හි "
+"දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22246,8 +22595,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist "
-"සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist සැකසුම්%2$s "
+"වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22256,8 +22605,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට "
-"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sDuckAssist "
+"සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22266,8 +22615,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති "
-"උපදෙස් පිළිපදින්න."
+"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති උපදෙස් "
+"පිළිපදින්න."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22282,9 +22631,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync "
-"& Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ "
-"සමමුහුර්ත කරන්න%8$s තෝරන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync & "
+"Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ සමමුහුර්ත "
+"කරන්න%8$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22294,9 +22643,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn "
-"On” තෝරන්න Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. "
-"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF එකේ QR ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn On” තෝරන්න "
+"Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන "
+"PDF එකේ QR ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22318,10 +22667,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai "
-"සැකසුම් විවෘත කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR "
-"කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත "
+"කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් උපාංගයක් සමග සමමුහුර්ත කරන්න” "
+"තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22374,8 +22722,7 @@ msgstr "හඬ කතාබහ අවසන්"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් "
-"භාවිතා කරන්නේ නැහැ."
+"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් භාවිතා කරන්නේ නැහැ."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22519,8 +22866,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට "
-"බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
+"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ "
+"ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22540,10 +22887,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට "
-"ඔබව නිරීක්ෂණය කළ හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ "
-"යුතු වීමයි. DuckDuckGo යනු ස්වාධීන සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන "
-"සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
+"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට ඔබව නිරීක්ෂණය කළ "
+"හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ යුතු වීමයි. DuckDuckGo යනු ස්වාධීන "
+"සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22555,9 +22901,7 @@ msgstr "අපි නිර්නාමික කරමු"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ "
-"හැකිය."
+msgstr "ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22569,9 +22913,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
-"වාර්තා කිරීමට, කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව "
-"විමර්ශනය කර විසඳා ගත හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
+"කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22583,17 +22927,15 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
-"වාර්තා කිරීමට, කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට "
-"ගැටලුව විමර්ශනය කර විසඳා ගත හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
+"කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ "
-"හැකිය."
+msgstr "ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -22601,8 +22943,7 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා "
-"කියවිය නොහැක."
+"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා කියවිය නොහැක."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22618,9 +22959,7 @@ msgstr "අපි පරිශීලක නාම හෝ පුද්ගලි�
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද "
-"නැත."
+msgstr "කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද නැත."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22632,8 +22971,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට "
-"පත් නොකරන්නෙමු. අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
+"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට පත් නොකරන්නෙමු. "
+"අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22647,8 +22986,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි "
-"පැවසුවහොත් එය අපට උපකාරී වීමට හැක:"
+"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි පැවසුවහොත් එය "
+"අපට උපකාරී වීමට හැක:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22657,8 +22996,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ "
-"අපට පැවසීමට ඔබගේ උදව් භාවිතා කළ හැකිය:"
+"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ අපට පැවසීමට "
+"ඔබගේ උදව් භාවිතා කළ හැකිය:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22698,8 +23037,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම "
-"වලට විකිණීමට කිසිවක් නැත."
+"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම වලට විකිණීමට "
+"කිසිවක් නැත."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22725,8 +23064,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ "
-"ගිවිසුම් ඇති කරගෙන ඇත්තෙමු."
+"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ ගිවිසුම් ඇති කරගෙන "
+"ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22751,8 +23090,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ "
-"දත්ත සූරාකෑමෙන් නොවේ."
+"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ දත්ත සූරාකෑමෙන් "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -22761,16 +23100,15 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික "
-"පිහිටීම භාවිතා කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
+"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික පිහිටීම භාවිතා "
+"කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත "
-"රඳා සිටිමු."
+"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත රඳා සිටිමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22791,15 +23129,13 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි "
-"අභිමතය පරිදි යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
+"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි අභිමතය පරිදි "
+"යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර "
-"කරන්නෙමු."
+msgstr "ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22808,8 +23144,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට "
-"මෙම දෝෂය දිගටම පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට මෙම දෝෂය දිගටම "
+"පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22818,8 +23154,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර "
-"විට ඔබගේ බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර විට ඔබගේ "
+"බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22834,8 +23170,7 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි "
-"මහන්සි වෙමින් සිටිමු."
+"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි මහන්සි වෙමින් සිටිමු."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -22844,8 +23179,7 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත "
-"පූරණය කළ යුතුය."
+"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත පූරණය කළ යුතුය."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22954,8 +23288,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම "
-"කතාබහේ යෙදිය හැකි ය."
+"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම කතාබහේ යෙදිය "
+"හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22969,8 +23303,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප "
-"විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර "
+"ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22979,9 +23313,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් "
-"පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් "
+"නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22991,17 +23324,15 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ "
-"%1$sගේ %2$s විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් "
-"DuckDuckGo විසින් ගබඩා කර හෝ AI ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ %1$sගේ %2$s "
+"විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් DuckDuckGo විසින් ගබඩා කර හෝ AI "
+"ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න "
-"පුළුවන්."
+msgstr "නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23069,8 +23400,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. "
-"පිටුව නැවත ප්‍රවේශනය කර උත්සාහ කරන්න."
+"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. පිටුව නැවත "
+"ප්‍රවේශනය කර උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23085,8 +23416,7 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ "
-"ප්‍රතිවිරෝධතා මොනවාද?"
+"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ ප්‍රතිවිරෝධතා මොනවාද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -23107,8 +23437,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර "
-"විකල්ප මොනවාද."
+"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර විකල්ප "
+"මොනවාද."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23127,11 +23457,10 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ "
-"ප්‍රතිලාභ මොනවා ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ "
-"කිරීම් සහ රහස්‍යතා ආරක්ෂණ කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත "
-"පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් "
-"කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
+"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ ප්‍රතිලාභ මොනවා "
+"ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ කිරීම් සහ රහස්‍යතා ආරක්ෂණ "
+"කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික "
+"අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23241,6 +23570,12 @@ msgstr "ඔබට වැඩි ම අපහසුතාවක් ඇති ක�
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "අද ඔබව නැවත ගෙන ආ දේ කුමක්ද?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23361,8 +23696,7 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් "
-"වන්නේ කෙසේද?"
+"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් වන්නේ කෙසේද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23463,8 +23797,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම "
-"නිෂ්පාදන වෙළඳ නාම මොනවාද?"
+"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම නිෂ්පාදන වෙළඳ නාම "
+"මොනවාද?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23657,6 +23991,14 @@ msgstr "ජයග්‍රහණ"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "ශීත සුළං මිශ්‍රිත"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -23929,9 +24271,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
-"හැකිය."
+msgstr "ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -23940,8 +24280,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර "
-"මත කඍජුව %1$s හෝ සෙවිය හැකිය."
+"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර මත කඍජුව %1$s හෝ "
+"සෙවිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23955,8 +24295,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s "
-"තුළ එය අක්‍රිය කළ හැකිය."
+"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s තුළ එය "
+"අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23965,22 +24305,21 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් "
-"කිරීමට හෝ එය අක්‍රිය කිරීමට හැකිය."
+"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය "
+"අක්‍රිය කිරීමට හැකිය."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ "
-"හැකිය."
+"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ හැකිය."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s "
-"ද භාාවිත කළ හැකිය."
+"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s ද භාාවිත "
+"කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -23994,8 +24333,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, "
-"එය සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
+"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, එය "
+"සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24016,8 +24355,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස "
-"පළමු සමූහය මකනවා."
+"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස පළමු සමූහය "
+"මකනවා."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24085,6 +24424,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "එක් සංවාදයකට ඇමිණිය හැක්කේ රූප %1$sක් පමණි."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24103,8 +24449,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම "
-"වෙනත් වෙබ් අඩවියක් අහිතකර කිරීමට අවශ්ය වේ."
+"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම වෙනත් වෙබ් අඩවියක් "
+"අහිතකර කිරීමට අවශ්ය වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24161,8 +24507,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් "
-"පුළුල් පරිශීලන සීමාවන් ඇත."
+"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් පුළුල් පරිශීලන "
+"සීමාවන් ඇත."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24171,8 +24517,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ "
-"අනෙකුත් DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
+"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ අනෙකුත් "
+"DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24194,9 +24540,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
-"වනු ඇත. අවසාන කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
-"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
+"කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24206,9 +24552,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
-"වනු ඇත. අවසාන කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
-"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
+"කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24221,9 +24567,13 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
+msgstr "ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන ලැබෙනු ඇත."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
 msgstr ""
-"ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන "
-"ලැබෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24232,8 +24582,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome "
-"වෙනුවට අපගේ යෙදුම භාවිතා කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome වෙනුවට අපගේ යෙදුම භාවිතා "
+"කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24246,8 +24596,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර "
-"ගැනීමට ඉඟි ලබා ගන්න."
+"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර ගැනීමට ඉඟි ලබා "
+"ගන්න."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24271,6 +24621,12 @@ msgstr "ඔයා %1$s අඩවි අවහිර කරලා තියෙන
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "ඔයා 1 වෙබ් අඩවියක් අවහිර කරලා තියෙන්නෙ"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24317,9 +24673,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත "
-"කිරීම නැවත ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
-"නොලැබේ."
+"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
+"ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24329,9 +24684,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
-"ආරම්භ කිරීමට ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
-"නොලැබේ."
+"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත ආරම්භ කිරීමට "
+"ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24345,9 +24699,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. "
-"ඒ වගේම, Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා "
-"කිරීමකට ලක් වෙන්න පුළුවන්."
+"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. ඒ වගේම, "
+"Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා කිරීමකට ලක් වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24391,9 +24744,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
-"විසන්ධි වනු ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා "
-"ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
+"ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24403,9 +24755,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
-"විසන්ධි වනු ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත "
-"හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
+"ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24430,8 +24781,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත "
-"කිසිවිටෙක මෙම දත්ත වෙත ප්‍රවේශය නොමැත."
+"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත කිසිවිටෙක මෙම දත්ත "
+"වෙත ප්‍රවේශය නොමැත."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -24439,8 +24790,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට "
-"කවදාවත් අවසරයක් නැහැ ඒ දත්ත වලට."
+"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට කවදාවත් අවසරයක් "
+"නැහැ ඒ දත්ත වලට."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24448,9 +24799,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
-"හැකිය."
+msgstr "%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24463,8 +24812,7 @@ msgstr "ඔබගේ කතාබස් දැන් සුරැකෙමින
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ "
-"භාවිත නොකෙරේ"
+"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ භාවිත නොකෙරේ"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24478,8 +24826,7 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
-"කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24487,8 +24834,7 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
-"කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24496,8 +24842,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
-"පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24505,8 +24851,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
-"පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24521,9 +24867,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා "
-"කෘත්‍රිම බුද්ධි ආකෘති පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා "
-"ගැනීමට මේ පියවර අනුගමනය කරන්න."
+"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා කෘත්‍රිම බුද්ධි ආකෘති "
+"පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා ගැනීමට මේ පියවර අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24563,8 +24908,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ "
-"සම්බන්ධ කිරීමක් සිදු නොවේ. [%2$sඋදාහරණ පණිවිඩය%3$s]"
+"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ සම්බන්ධ කිරීමක් සිදු නොවේ. "
+"[%2$sඋදාහරණ පණිවිඩය%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24607,10 +24952,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ "
-"මුරපදය 512-bit යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත "
-"සැකසුම් ගොනුව පමණි. යතුර නම ලෙස භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. "
-"DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
+"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ මුරපදය 512-bit "
+"යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත සැකසුම් ගොනුව පමණි. යතුර නම ලෙස "
+"භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24625,9 +24969,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත "
-"හැකි පාර-දත්ත ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත "
-"සම්බන්ධ කළ නොහැක."
+"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත හැකි පාර-දත්ත "
+"ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත සම්බන්ධ කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24641,8 +24984,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම "
-"වේලාවක ඒවා ඉවත් කළ හැකි ය."
+"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම වේලාවක "
+"ඒවා ඉවත් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -24668,15 +25011,22 @@ msgid "Your searches can’t be tied back to you"
 msgstr "ඔබේ සෙවීම් ඔබව නැවත සම්බන්ධ කළ නොහැක"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
-"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර "
-"දැනගන්න%4$s"
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -24696,8 +25046,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට "
-"අපේ බ්‍රවුසරය භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට අපේ බ්‍රවුසරය "
+"භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24706,8 +25056,7 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ "
-"කරන්න."
+"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24716,8 +25065,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button "
-"සමඟ මෙම සංවාදය ඉවත් කරන්න."
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button සමඟ "
+"මෙම සංවාදය ඉවත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24725,9 +25074,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ "
-"ගන්න."
+msgstr "ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ ගන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -24742,8 +25089,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් "
-"දිගටම කරගෙන යන්න."
+"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම කරගෙන "
+"යන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25256,3 +25603,9 @@ msgstr "අවුරුදු"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "වර්ෂ"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s අනාවරණය විය"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "ගොනු %1$sක් භාවිත කර ඇත"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -183,8 +183,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
-"වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
+"ප්‍රකාරයකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -195,8 +195,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
-"වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
+"ප්‍රකාරයකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -213,7 +213,8 @@ msgid ""
 "model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ DuckDuckGo දායකත්වයක් සමඟ පමණි. චැට් දිගටම කරගෙන යාමට මෙම "
-"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු වන්න."
+"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -222,8 +223,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව නැවත උත්සාහ "
-"කරන්න."
+"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව "
+"නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -314,9 +315,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් අදහස් කරන්නේ ආකෘති "
-"සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට "
-"නොහැකි බවයි."
+"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් "
+"අදහස් කරන්නේ ආකෘති සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ "
+"මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට නොහැකි බවයි."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -363,7 +364,7 @@ msgstr "%1$sක් භාවිතා කර ඇත"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s මූලික ආකෘතිවලට වඩා 2-5 ගුණයක් දක්වා වේගයෙන් සීමාවන් භාවිත කරයි %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -402,8 +403,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
-"යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම "
+"කරගෙන යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -414,8 +415,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන යාමට "
-"ආකෘති මාරු කළ හැකි ය."
+"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
+"යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -428,8 +429,8 @@ msgstr "%1$s වචන"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව %6$sහරි%7$sක්ලික් "
-"කරන්න"
+"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව "
+"%6$sහරි%7$sක්ලික් කරන්න"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -437,8 +438,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි ලකුණ "
-"දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
+"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි "
+"ලකුණ දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -458,7 +459,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට %1$sමෙතන ක්ලික් කරන්න%2$s."
+"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට "
+"%1$sමෙතන ක්ලික් කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -484,7 +486,8 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර ඉගෙන ගන්න."
+"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර "
+"ඉගෙන ගන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -503,8 +506,8 @@ msgstr "මුල් තිරයේ ඇති DuckDuckGo යෙදුම් න
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s සහ නැවත "
-"උත්සාහ කරන්න."
+"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s "
+"සහ නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -616,7 +619,7 @@ msgstr "1 දවසකට පෙර"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "ගොනු 1ක් භාවිත කර ඇත"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -838,7 +841,8 @@ msgstr "පැය 6ක පරිශීලන සීමාවට ළඟා වී
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
+"හැක."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -846,8 +850,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට ම කතාබස් කළ "
-"හැකි ය."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට "
+"ම කතාබස් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -901,8 +905,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. කරුණාකර ඔබේ "
-"සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
+"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. "
+"කරුණාකර ඔබේ සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -910,8 +914,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
 msgstr ""
-"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
-"කරන්න."
+"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
+"නැවත නැවුම් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -919,8 +923,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
 msgstr ""
-"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
-"කරන්න."
+"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
+"නැවත නැවුම් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -964,9 +968,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. මෙය "
-"ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. මෙම සැකසුම ක්‍රියා "
-"විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI Chat වෙත ප්‍රවේශ විය හැකිය."
+"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. "
+"මෙය ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. "
+"මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI "
+"Chat වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1027,10 +1032,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ වෙතත්, අපි පසු විපරම් "
-"ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය වෙත සබැඳෙමු, එය OpenAI සහ "
-"Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය දක්වන අපගේ පෞද්ගලික AI බලයෙන් "
-"ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ "
+"වෙතත්, අපි පසු විපරම් ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය "
+"වෙත සබැඳෙමු, එය OpenAI සහ Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය "
+"දක්වන අපගේ පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1215,8 +1220,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට "
-"මාරු වන්න."
+"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් "
+"නොමිලේ ආකෘතියකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1252,8 +1257,8 @@ msgstr "දැන්වීම"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය මගින් වන අතර ඒවා "
-"ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
+"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය "
+"මගින් වන අතර ඒවා ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1261,8 +1266,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය විසිනි, ඒවා ඔබව පැතිකඩ "
-"කිරීමට භාවිතා නොකෙරේ."
+"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය "
+"විසිනි, ඒවා ඔබව පැතිකඩ කිරීමට භාවිතා නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1313,7 +1318,8 @@ msgstr "DuckDuckGo දිගුව එක් කරන්න"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් කරන්න:"
+"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් "
+"කරන්න:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1534,6 +1540,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1711,8 +1719,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo හෝ ආකෘති "
-"සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
+"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo "
+"හෝ ආකෘති සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1759,8 +1767,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, ඔබගේ IP ලිපිනය) "
-"ඉවත් කරනු ලැබේ."
+"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, "
+"ඔබගේ IP ලිපිනය) ඉවත් කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1792,7 +1800,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය ලබා දෙන්න."
+"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය "
+"ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1824,9 +1833,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ දෙයි. සීමිත දත්ත "
-"රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් පමණක් යවයි. %2$s සහිත විමසීම් සහ "
-"ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
+"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ "
+"දෙයි. සීමිත දත්ත රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් "
+"පමණක් යවයි. %2$s සහිත විමසීම් සහ ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ "
+"දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1834,7 +1844,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට අවශ්‍ය වේ)"
+"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට "
+"අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -1972,7 +1983,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
+"නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1981,7 +1993,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
+"නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1995,8 +2008,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. එය කොපමණ වාර ගණනක් "
-"පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම අක්‍රිය කරන්න."
+"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. "
+"එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම "
+"අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2043,8 +2057,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම විටම කරුණු "
-"මට කියන්න"
+"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම "
+"විටම කරුණු මට කියන්න"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2164,7 +2178,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, සියලුම කතා මකා දමනු ඇත."
+"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, "
+"සියලුම කතා මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2173,8 +2188,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද ඕනෑම මෑත "
-"කාලීන කතාබස් ද මකා දමනු ඇත."
+"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද "
+"ඕනෑම මෑත කාලීන කතාබස් ද මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2212,8 +2227,9 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම රැස්කර හෝ හුවමාරුකර "
-"නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු වේ."
+"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම "
+"රැස්කර හෝ හුවමාරුකර නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු "
+"වේ."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2314,7 +2330,7 @@ msgstr "පෞද්ගලිකව අසන්න"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "පෞද්ගලිකව අසන්න"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2349,12 +2365,14 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා AI-සහය සහිත "
-"පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් Assist පෙනී සිටීමට අවශ්‍ය දැ යි "
-"ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම "
-"මත (ඔබ Assist බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
-"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
-"පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
+"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා "
+"AI-සහය සහිත පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් "
+"Assist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් "
+"ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම මත (ඔබ Assist "
+"බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
+"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක "
+"සෙවුම් මත නිතර පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් "
+"ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2366,11 +2384,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් විමසුම් "
-"සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා "
-"වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-"
-"බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව "
-"ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු "
+"කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ "
+"තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා "
+"තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
+"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2508,7 +2527,9 @@ msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදන
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් තිබිය හැක."
+msgstr ""
+"ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් "
+"තිබිය හැක."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2533,9 +2554,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර "
-"වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල "
-"පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර "
+"සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist "
+"ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2544,15 +2565,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව සමහර සෙවීම් "
-"වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, DuckAssist ලබා ගත "
-"හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව "
+"සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, "
+"DuckAssist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව ධාවනය කරන්න."
+msgstr ""
+"ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව "
+"ධාවනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2752,8 +2775,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත හැකි පාරදත්ත "
-"වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
+"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත "
+"හැකි පාරදත්ත වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3134,16 +3157,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
+"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ "
+"සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s "
+"දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් "
+"යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s "
+"දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3151,8 +3176,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන බ්‍රවුසර්%2$s සඳහා පුද්ගලික "
-"සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන "
+"බ්‍රවුසර්%2$s සඳහා පුද්ගලික සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය "
+"යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3259,10 +3285,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ බ්‍රව්සරයේ). ඔබේ සැකසීම් "
-"වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති "
-"දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි "
-"විටෙකත් ඔබගේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ "
+"බ්‍රව්සරයේ). ඔබේ සැකසීම් වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික "
+"Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත "
+"හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි විටෙකත් ඔබගේ "
+"බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3270,8 +3297,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ දත්ත OpenAI වෙත "
-"යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ "
+"දත්ත OpenAI වෙත යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3280,8 +3307,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත OpenAI වෙත "
-"යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත "
+"OpenAI වෙත යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3316,7 +3343,9 @@ msgstr "කැමරූන්"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ හැකිද?"
+msgstr ""
+"කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ "
+"හැකිද?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3765,11 +3794,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික සංවාද "
-"කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. මෙම සැකසුම අක්‍රිය "
-"කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම "
-"ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත "
-"ප්‍රවේශ විය හැකිය."
+"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික "
+"සංවාද කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. "
+"මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු "
+"ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් "
+"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3825,7 +3854,8 @@ msgstr "පෞද්ගලිකව චැට් කරන්න"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ "
+"යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -3833,8 +3863,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක පුද්ගලිකව කතාබහේ "
-"යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක "
+"පුද්ගලිකව කතාබහේ යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -3852,7 +3882,7 @@ msgstr "AI සමඟ පෞද්ගලිකව චැට් කරන්න"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "ජනප්‍රිය AI සමඟ පෞද්ගලිකව කතාබහේ යෙදෙන්න"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3903,8 +3933,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් ගබඩා කර ඇත. "
-"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
+"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් "
+"ගබඩා කර ඇත. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3916,10 +3946,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් "
-"නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
-"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ "
-"කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
+"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
+"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. "
+"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ "
+"ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3942,8 +3973,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන සියලුම ගොනු "
-"%2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව සමාලෝචනය කරනු ලැබේ."
+"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන "
+"සියලුම ගොනු %2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව "
+"සමාලෝචනය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -3951,8 +3983,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට ගබඩාවේ ඉඩ නිදහස් "
-"කරගන්න."
+"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට "
+"ගබඩාවේ ඉඩ නිදහස් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4116,7 +4148,9 @@ msgstr "සේවාවක් තෝරන්න"
 msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
-msgstr "ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම තෝරන්න"
+msgstr ""
+"ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම "
+"තෝරන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4297,9 +4331,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන කතාබස් කාලය "
-"නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා ස්වයංක්‍රීයව මකා දැමිය හැකි "
-"ය."
+"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන "
+"කතාබස් කාලය නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා "
+"ස්වයංක්‍රීයව මකා දැමිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4309,8 +4343,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, ඔබේ "
-"බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ ස්වයංක්‍රීයව මකා දැමිය හැකිය."
+"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, "
+"ඔබේ බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ "
+"ස්වයංක්‍රීයව මකා දැමිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4319,8 +4354,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ අවහිර ලැයිස්තුව අපගේ "
-"ගාස්තු රහිත බ්‍රවුසරයේ"
+"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ "
+"අවහිර ලැයිස්තුව අපගේ ගාස්තු රහිත බ්‍රවුසරයේ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4329,9 +4364,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ %1$sDuck.ai%2$s "
-"හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ ආයතනවලින් චැට් ආකෘතිවලට සහය "
-"දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
+"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ "
+"%1$sDuck.ai%2$s හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ "
+"ආයතනවලින් චැට් ආකෘතිවලට සහය දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4405,8 +4440,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ දකුණු පස "
-"%3$sgears icon%4$s මත ක්ලික් කරන්න)"
+"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ "
+"දකුණු පස %3$sgears icon%4$s මත ක්ලික් කරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4436,7 +4471,8 @@ msgstr "%1$sYes%2$s කලික් කරන්න"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් කරන්න."
+"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් "
+"කරන්න."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4498,8 +4534,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
-"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
+"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
+"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4510,8 +4547,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
-"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
+"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
+"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4580,8 +4618,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් මෙනුව ක්ලික් කර "
-"%3$sDuckDuckGo%4$s තෝරන්න."
+"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් "
+"මෙනුව ක්ලික් කර %3$sDuckDuckGo%4$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4589,8 +4627,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ ඉහළ දකුණු කෙළවරේ "
-"තියෙනවා."
+"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ "
+"ඉහළ දකුණු කෙළවරේ තියෙනවා."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4636,7 +4674,7 @@ msgstr "වසන්න"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "වසන්න"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4686,7 +4724,7 @@ msgstr "සෙවුම වසන්න"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "දෙවන මතය වසා දමන්න"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4791,8 +4829,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු කිරීමට හැකියාව Cloud "
-"Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
+"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු "
+"කිරීමට හැකියාව Cloud Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5064,6 +5102,8 @@ msgstr "දැන්වීම් අවහිර කිරීම දිගටම
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
+"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් "
+"ඒවා මකා දමන්න."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5134,7 +5174,7 @@ msgstr "කුකී දත්ත:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "පිටපත් කර ඇත"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5187,7 +5227,7 @@ msgstr "කේතය පිටපත් කරන්න"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "සබැඳිය පිටපත් කරන්න"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5258,7 +5298,8 @@ msgstr "කොස්ටාරිකාව"
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
 msgstr ""
-"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ කරන්න."
+"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5307,7 +5348,7 @@ msgstr "රූපය සාදන්න"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "බෙදාගැනීමේ සබැඳිය තනන්න"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5359,6 +5400,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය "
+"බැලිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5517,7 +5560,7 @@ msgstr "ප්‍රතිචාර අභිරුචි කරන්න"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "ප්‍රතිචාර සිතැඟි පරිදි සකසන්න"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5592,7 +5635,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් කරගෙන යා හැකිය."
+"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් "
+"කරගෙන යා හැකිය."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -5806,7 +5850,7 @@ msgstr "සර්වර දත්ත මකා දමන්න ද?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "බෙදාගත් සබැඳිය මකන්න"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5818,7 +5862,7 @@ msgstr "පිටපත මකන්න"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "කතාබසක් මකන්න"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5856,7 +5900,7 @@ msgstr "රූපය මකා දමන්න ද?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "මාව මකන්න"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5983,8 +6027,8 @@ msgstr "Duck.ai අසා ලිවීම"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට කිසිවිටෙකත් භාවිතා කරනු "
-"නොලැබේ."
+"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට "
+"කිසිවිටෙකත් භාවිතා කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6002,8 +6046,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා කරන බැවින්, "
-"ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
+"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා "
+"කරන බැවින්, ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6170,7 +6214,7 @@ msgstr "ප්‍රවර්ධනය ඉවත ලන්න"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "සංචාරය ඉවත ලන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6315,8 +6359,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන අතර AI-"
-"ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන "
+"අතර AI-ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6325,8 +6369,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ AI රූප "
-"පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ "
+"AI රූප පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6386,7 +6430,7 @@ msgstr "DuckDuckGo බාගත කරන්න"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "DuckDuckGo බාගන්න"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6442,8 +6486,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
-"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින "
+"විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6452,8 +6496,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
-"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට "
+"සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6474,8 +6518,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප කිහිපයක් කෙටුම්පත් "
-"කරන්න."
+"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප "
+"කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6484,8 +6528,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් සඳහා විකල්ප "
-"කිහිපයක් කෙටුම්පත් කරන්න."
+"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් "
+"සඳහා විකල්ප කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6607,7 +6651,7 @@ msgstr "DuckDuckGo වෙතින් Duck.ai. පුද්ගලික AI ක�
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai හට දැන් PDF විශ්ලේෂණය කළ හැකි ය. අත්හදා බලන්න!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6617,8 +6661,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. සැකසුම් තුළ පිටු "
-"ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
+"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. "
+"සැකසුම් තුළ පිටු ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය "
+"ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6628,8 +6673,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ බ්‍රවුසර "
-"සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය කර නැවත උත්සාහ කරන්න."
+"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ "
+"බ්‍රවුසර සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය "
+"කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6638,8 +6684,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම "
-"කරගෙන යන්න."
+"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම "
+"කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -6655,9 +6701,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය නැවතත් සියතට "
-"ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන ස්වාධීන සමාගමක් ලෙස අපි "
-"කටයුතු කරමු."
+"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය "
+"නැවතත් සියතට ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන "
+"ස්වාධීන සමාගමක් ලෙස අපි කටයුතු කරමු."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6672,8 +6718,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් පිටුවක් සමගින් "
-"අන්තර්ජාලයේ: https://duck.ai"
+"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් "
+"පිටුවක් සමගින් අන්තර්ජාලයේ: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6688,8 +6734,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s නිර්නාමික "
-"කේතය %2$s වෙත ඊමේල් කරන්න"
+"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s "
+"නිර්නාමික කේතය %2$s වෙත ඊමේල් කරන්න"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6710,9 +6756,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. එය අක්‍රිය "
-"කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව ම %1$sduck.ai%2$s වෙත "
-"පිවිසිය හැකි ය."
+"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. "
+"එය අක්‍රිය කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව "
+"ම %1$sduck.ai%2$s වෙත පිවිසිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6723,10 +6769,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI චැට් ආකෘති "
-"සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි "
-"Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට "
-"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
+"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI "
+"චැට් ආකෘති සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය "
+"කිරීමෙන් DuckDuckGo Search හි Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, "
+"මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට %1$shttps://duck.ai%2$s වෙත "
+"පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6741,8 +6788,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai භාවිතා "
-"කරන්න පුළුවන්."
+"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai "
+"භාවිතා කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6756,13 +6803,14 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා පරීක්ෂා කර නැත."
+"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා "
+"පරීක්ෂා කර නැත."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai, Anthropic, OpenAI සහ අනෙකුත් ආයතනවලින් ආකෘති සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6790,9 +6838,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI කතාබහ, "
-"ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, විවෘත මූලාශ්‍ර AI "
-"ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI කතාබස්"
+"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI "
+"කතාබහ, ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, "
+"විවෘත මූලාශ්‍ර AI ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI "
+"කතාබස්"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6820,12 +6869,13 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ "
-"හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් "
-"(සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම "
-"ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට (ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත නිතර නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද "
-"(ඉංග්‍රීසි) කලාපයේ පමණි."
+"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා "
+"සාරාංශගත කළ හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා "
+"ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම "
+"ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට "
+"(ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
+"නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ "
+"පමණි."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6834,9 +6884,10 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි %1$sDuckDuckGo AI "
-"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
-"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
+"%1$sDuckDuckGo AI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
+"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
+"සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6845,9 +6896,10 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි DuckDuckGo %1$sAI "
-"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
-"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
+"DuckDuckGo %1$sAI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
+"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
+"සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6859,11 +6911,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
-"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව "
-"සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් "
-"ක්‍රියාත්මක වන ස්වාභාවික භාෂා තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ "
-"අන්තර්ගතයන් මත පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
+"එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම "
+"තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් ක්‍රියාත්මක වන ස්වාභාවික භාෂා "
+"තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ අන්තර්ගතයන් මත "
+"පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6877,13 +6930,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
-"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් "
-"කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති "
-"ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට "
-"සෘජුවම සම්බන්ධ වන අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
-"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
-"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
+"එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත "
+"පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත "
+"කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට සෘජුවම සම්බන්ධ වන "
+"අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
+"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් "
+"ස්වයංක්රීයව ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම "
+"වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6891,8 +6946,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර නිරවද්‍යතාව සඳහා "
-"පරීක්‍ෂා කර නොමැත."
+"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර "
+"නිරවද්‍යතාව සඳහා පරීක්‍ෂා කර නොමැත."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6901,8 +6956,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට මෙම "
-"කතාබස් දිගටම කරගෙන යන්න."
+"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට "
+"මෙම කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6911,8 +6966,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
-"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
+"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6921,8 +6976,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
-"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
+"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6948,7 +7003,9 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ කරන්න."
+msgstr ""
+"DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7073,8 +7130,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත වැනි PII "
-"ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
+"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත "
+"වැනි PII ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7082,8 +7139,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai %2$s වෙත එකඟ "
-"වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai "
+"%2$s වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7092,7 +7149,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s "
+"වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7101,8 +7159,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල DuckDuckGo ට්‍රැකර් අවහිර "
-"කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය කිරීමට උත්සාහ කරයි."
+"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල "
+"DuckDuckGo ට්‍රැකර් අවහිර කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය "
+"කිරීමට උත්සාහ කරයි."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7114,11 +7173,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය උපාංගයේ පමණක් "
-"ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ ප්‍රතිඵල වැඩි දියුණු කිරීම "
-"සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ "
-"පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන "
-"ගන්න%2$s."
+"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය "
+"උපාංගයේ පමණක් ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ "
+"ප්‍රතිඵල වැඩි දියුණු කිරීම සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන "
+"පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම "
+"තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7138,8 +7197,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල ලබා දීමට "
-"අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල "
+"ලබා දීමට අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7225,9 +7284,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු අහඹු වචන "
-"ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 ක් තෝරා ගනිමු, මුරපදය අවම "
-"වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
+"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු "
+"අහඹු වචන ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 "
+"ක් තෝරා ගනිමු, මුරපදය අවම වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7297,7 +7356,9 @@ msgstr "රූපය සංස්කරණය කෙරේ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය කරයි."
+msgstr ""
+"ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය "
+"කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7397,7 +7458,7 @@ msgstr "වැඩිපුරම නැරඹූ අඩවි සක්‍රී
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "දැන් සක්‍රීය කරන්න"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7435,8 +7496,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම විටම ඔබේ අදහස වෙනස් "
-"කළ හැකිය."
+"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම "
+"විටම ඔබේ අදහස වෙනස් කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7447,7 +7508,9 @@ msgstr "Duck.ai මත අසා ලිවීම සක් රීය කරන�
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය කරන්න"
+msgstr ""
+"නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය "
+"කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7479,8 +7542,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් තවමත් ඔබේ සෙවුම් සහ නිශ්චිත "
-"ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
+"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් "
+"තවමත් ඔබේ සෙවුම් සහ නිශ්චිත ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7642,8 +7705,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ නව මුරදය යටතේ "
-"ඔබගේ දත්ත සුරකිනු ඇත."
+"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ "
+"නව මුරදය යටතේ ඔබගේ දත්ත සුරකිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7700,7 +7763,7 @@ msgstr "විනෝදාශ්වාද උපදේශක"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "සම්පූර්ණ කතාබහ"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7770,7 +7833,9 @@ msgstr "සිතියම පුළුල් කරන්න"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද නිෂ්පාදන."
+msgstr ""
+"පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද "
+"නිෂ්පාදන."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an expired DuckDuckGo subscription.
@@ -7843,7 +7908,9 @@ msgstr "මෙය සරලව පැහැදිලි කරන්න"
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr "මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි කරන්න."
+msgstr ""
+"මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -7867,13 +7934,13 @@ msgstr "පැහැදිලි ගී පද"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai ගවේෂණය කරන්න"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai ගවේෂණය කරන්න"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7980,7 +8047,7 @@ msgstr "නොමිලේ"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "නොමිලේ & වෛකල්පිත"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8038,7 +8105,9 @@ msgstr "ප්‍රතිපෝෂණය සාර්ථකව යවන ලද
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් බලපායි."
+msgstr ""
+"ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු "
+"කිරීම් බලපායි."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8047,15 +8116,18 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් සෘජුවම බලපායි. ඔබ බෙදාගත් "
-"ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම බලාපොරොත්තු වෙමි."
+"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් "
+"සෘජුවම බලපායි. ඔබ බෙදාගත් ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම "
+"බලාපොරොත්තු වෙමි."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් කරන්න."
+msgstr ""
+"පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8145,7 +8217,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. %1$sවැඩිදුර දැනගන්න%2$s"
+"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. "
+"%1$sවැඩිදුර දැනගන්න%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8223,7 +8296,9 @@ msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගන්�
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව පවතී."
+msgstr ""
+"ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව "
+"පවතී."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8287,8 +8362,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට මෙනු විකල්පයක් "
-"තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
+"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට "
+"මෙනු විකල්පයක් තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8393,7 +8468,7 @@ msgstr "ගබඩාවේ ඉඩ නිදහස් කරගන්න"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "නොමිලේ සහ සැමවිටම පුද්ගලිකයි"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8517,8 +8592,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac හි යෙදුම් මෙනු තීරුවෙන්, <strong>DuckDuckGo</strong> තෝරන්න &gt; "
-"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන ස්ථාපනය "
-"කරන්න</strong> තෝරන්න."
+"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන "
+"ස්ථාපනය කරන්න</strong> තෝරන්න."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8869,8 +8944,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත දායක වීමෙන් Duck."
-"ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත "
+"දායක වීමෙන් Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8881,8 +8956,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo දායකත්වයක් සමඟ "
-"Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo "
+"දායකත්වයක් සමඟ Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8911,7 +8986,7 @@ msgstr "පරිගණක සහාය ලබා ගන්න"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "DuckDuckGo ග්‍රාහකත්වය සමඟ වඩා ඉහළ පරිශීලන සීමාවන් ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8952,13 +9027,15 @@ msgstr "නවතම අනුවාදය ලබා ගන්න"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "යෙදුම ලබා ගන්න"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා "
+"ගන්න.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -8986,7 +9063,7 @@ msgstr "ඔබගේ යහළුවන්ව වෙනස් වීමට ය�
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "ආරම්භ කිරීමේ පිරික්සුම් ලැයිස්තුව"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9017,9 +9094,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න › පාඨමය කේතය "
-"පිටපත් කරන්න%4$sවෙත යන්න"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න › පාඨමය කේතය පිටපත් කරන්න%4$sවෙත යන්න"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9028,8 +9105,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත ගොස් "
-"%3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත යන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත "
+"යන්න."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9039,9 +9117,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත ගොස් මෙම "
-"කේතය ස්කෑන් කරන්න:"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න%4$s වෙත ගොස් මෙම කේතය ස්කෑන් කරන්න:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9051,9 +9129,10 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. "
-"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9068,8 +9147,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන සේවා\" සක්‍රිය කර "
-"ඇති බවට වග බලා ගන්න."
+"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන "
+"සේවා\" සක්‍රිය කර ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9078,8 +9157,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් %3$sDuckDuckGo%4$s "
-"වෙත පහළට අනුචලනය කරන්න."
+"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් "
+"%3$sDuckDuckGo%4$s වෙත පහළට අනුචලනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9675,7 +9754,7 @@ msgstr "ඉඟි සඟවන්න"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "නිබන්ධනය සඟවන්න"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9762,8 +9841,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist පිළිතුරුවල ප්‍රධාන "
-"කරුණු ඉස්මතු කරයි."
+"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist "
+"පිළිතුරුවල ප්‍රධාන කරුණු ඉස්මතු කරයි."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9790,8 +9869,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ සුරකින්න."
-"%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
+"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ "
+"සුරකින්න.%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9805,8 +9884,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ රහස්‍යතා ආරක්ෂාව "
-"අහිමි වේ."
+"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ "
+"රහස්‍යතා ආරක්ෂාව අහිමි වේ."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9856,8 +9935,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය කරනු ලබන අතර ඔබව "
-"පැතිකඩ කිරීමට භාවිත නොකෙරේ."
+"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය "
+"කරනු ලබන අතර ඔබව පැතිකඩ කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9999,8 +10078,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ කෙසේද සහ මා කුමක් "
-"කිව යුතුද?"
+"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ "
+"කෙසේද සහ මා කුමක් කිව යුතුද?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10122,8 +10201,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම කැමති මොනවාද "
-"සහ ඇයි?"
+"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම "
+"කැමති මොනවාද සහ ඇයි?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10158,8 +10237,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > 'පිහිටීම හා "
-"රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > "
+"'පිහිටීම හා රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10169,8 +10248,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > සැකසුම් > අඩවි සැකසුම් > "
-"පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා අවසර දී ඇති ද යන්න දැනගන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > "
+"සැකසුම් > අඩවි සැකසුම් > පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා "
+"අවසර දී ඇති ද යන්න දැනගන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10185,8 +10265,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther Search "
-"Engines%4$s ලැයිස්තුවට එකතු කරන්න"
+"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther "
+"Search Engines%4$s ලැයිස්තුවට එකතු කරන්න"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10195,8 +10275,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් ඇත්නම්, ඔබට කෙලින්ම "
-"%1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
+"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් "
+"ඇත්නම්, ඔබට කෙලින්ම %1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10205,14 +10285,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා ගැනීමට මෙම "
-"කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස සුරැකිය හැකි ය."
+"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා "
+"ගැනීමට මෙම කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස "
+"සුරැකිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු කරන්න%2$s"
+msgstr ""
+"ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු "
+"කරන්න%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10222,15 +10305,17 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ %1$s හෝ %2$s "
-"යන පිටපත් භාවිතා කරන්න."
+"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ "
+"%1$s හෝ %2$s යන පිටපත් භාවිතා කරන්න."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත කරන්න)."
+msgstr ""
+"ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත "
+"කරන්න)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10359,7 +10444,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය වැඩි දියුණු කරයි"
+"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය "
+"වැඩි දියුණු කරයි"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10372,8 +10458,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් කිරීම් අපගේ සර්වරය හරහා "
-"හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
+"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් "
+"කිරීම් අපගේ සර්වරය හරහා හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10384,8 +10470,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් උපාංගයක් සමග "
-"සමමුහුර්ත කරන්න” වෙත යන්න."
+"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න” වෙත යන්න."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10400,8 +10486,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන ගැනීමට හැකියි අප "
-"ගබඩා කරන්නේ කුමන දත්තද කියා."
+"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන "
+"ගැනීමට හැකියි අප ගබඩා කරන්නේ කුමන දත්තද කියා."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10412,8 +10498,8 @@ msgstr "ඉහළ ඇති මෙනුවෙන් %1$sTools%2$s > %3$sSetting
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
 msgstr ""
-"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි සලකුණ "
-"යොදන්න"
+"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි "
+"සලකුණ යොදන්න"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10740,7 +10826,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය සාරාංශගත කරන්න."
+"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය "
+"සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10809,9 +10896,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි දැන්වීම් ජාලය "
-"හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් "
-"නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු නොකෙරේ."
+"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි "
+"දැන්වීම් ජාලය හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ "
+"පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10820,7 +10908,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත වේ."
+"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත "
+"වේ."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11291,7 +11380,7 @@ msgstr "දැන් DuckDuckGo වලින් නිර්නමිකව ස�
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "සෙවුම් විමසුම් සහ Duck.ai වෙත විමසුම් යැවීම අතර මාරු වීමට ඉඩ දෙයි"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11367,7 +11456,7 @@ msgstr "ප්‍රතිවාදී සීමාවෙන් පන්දු 
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "සබැඳිය දින 7කින් කල් ඉකුත් වේ."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11494,7 +11583,9 @@ msgstr "අනුචලනය කරන විට තවත් පින්ත�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය කරයි"
+msgstr ""
+"අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය "
+"කරයි"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -11674,8 +11765,7 @@ msgstr "සියළුම වචන වල අක්ෂර වින්‍ය�
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
+msgstr "%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12021,7 +12111,9 @@ msgstr "මයික්රොනීසියාව"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත උත්සාහ කරන්න."
+msgstr ""
+"මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12252,7 +12344,9 @@ msgstr "මාසික සීමාවට ළඟා විය"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
+msgstr ""
+"මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
+"හැක."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12464,7 +12558,7 @@ msgstr "මිනිත්තු 20කට වැඩියි"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "තවත් ප්‍රයෝජනවත් තතු"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12787,10 +12881,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව "
-"විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු "
-"ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර "
-"තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම "
+"සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo "
+"සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් "
+"මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12957,7 +13051,7 @@ msgstr "එපා ස්තුතියි"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "එපා ස්තුතියි"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13612,8 +13706,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the %4$s "
-"icon > Settings%5$s"
+"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the "
+"%4$s icon > Settings%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13625,7 +13719,7 @@ msgstr "විවෘත නමුත් අංක නැති"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "එක්කර ගැනීම සම්පූර්ණයි"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13641,8 +13735,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. පිටු %1$s ක් හෝ ඊට අඩු "
-"පිටු ඇති ගොනු උඩුගත කරන්න."
+"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. "
+"පිටු %1$s ක් හෝ ඊට අඩු පිටු ඇති ගොනු උඩුගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13668,7 +13762,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව දක්වා ඇත."
+msgstr ""
+"ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව "
+"දක්වා ඇත."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13683,7 +13779,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
+"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13840,7 +13937,7 @@ msgstr "රූප නිර්මාණය සහ සංස්කරණය ක�
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "ආරම්භක පිරික්සුම් ලැයිස්තුව විවෘත කරන්න"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14006,8 +14103,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් නිරීක්ෂණය කරයි. අපි ඔබව "
-"කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
+"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් "
+"නිරීක්ෂණය කරයි. අපි ඔබව කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14020,8 +14117,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු කරන්නේ හෝ බෙදා "
-"හරින්නේ නැත."
+"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු "
+"කරන්නේ හෝ බෙදා හරින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14029,8 +14126,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය, "
-"ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & Android%2$sහි ලද හැක."
+"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරකාරකය, ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & "
+"Android%2$sහි ලද හැක."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14283,8 +14381,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ සම්බන්ධ නොකරන බැවින් මුරපද "
-"යථාවත් කර ගත නොහැක."
+"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ "
+"සම්බන්ධ නොකරන බැවින් මුරපද යථාවත් කර ගත නොහැක."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14484,9 +14582,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ "
-"ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම "
-"සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත "
+"පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. "
+"ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s "
+"වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14495,9 +14594,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
-"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් "
-"කිරීමට හෝ එය ක්‍රියා විරහිත කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
+"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. "
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය ක්‍රියා විරහිත "
+"කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14507,9 +14607,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
-"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට "
-"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
+"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය "
+"නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට %1$sDuckAssist සැකසුම්%2$s වෙත "
+"පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14542,7 +14643,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් කිරීමට තෝරන්න."
+"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් "
+"කිරීමට තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14551,7 +14653,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් තෝරන්න."
+"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI "
+"එකක් තෝරන්න."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14572,8 +14675,8 @@ msgstr "විශේෂ වූ ප්‍රශ්නයක් තෝරා ග�
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් අනුගමනය "
-"කරන්න."
+"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් "
+"අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -14585,7 +14688,7 @@ msgstr "පිංච"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "කතාබහක් පින් කරන්න"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14597,7 +14700,7 @@ msgstr "%1$s %2$s වෙතින් කතාබස් මෙතැනට ප�
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "මාව පින් කරන්න"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14620,7 +14723,7 @@ msgstr "පින් කළ"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "ඇමුණූ කතාබස් ඔබේ මෑත කාලීන කතාබස්වල ඉහළින් ම දිස් වනු ඇත."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14661,7 +14764,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+msgstr ""
+"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
+"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14669,19 +14774,25 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+msgstr ""
+"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
+"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
+msgstr ""
+"කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
+"(විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
+msgstr ""
+"කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
+"(විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14702,7 +14813,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය මකා දමනු ඇත."
+"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය "
+"මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14711,8 +14823,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
-"හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
+"අලවා අන්තර්ගතය හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14721,8 +14833,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
-"නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
+"අලවා අන්තර්ගතය නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14937,6 +15049,8 @@ msgstr "දුර්වල ආකෘතිකරණය"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් "
+"නිර්නාමික කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15150,7 +15264,7 @@ msgstr "පෙර ටැබ්"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "පෙර ප්‍රයෝජනවත් තතු"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15488,8 +15602,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම පෙළ මෙහි "
-"ඇතුලත් කරන්න.]"
+"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම "
+"පෙළ මෙහි ඇතුලත් කරන්න.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15694,13 +15808,13 @@ msgstr "මධ්‍යම බිල්ට්-ඉන් මධ්‍යස්ථ
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "තර්කනය මඟින් සංකීර්ණ ප්‍රශ්න සඳහා වඩා හොඳ පිළිතුරු ලබා දිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් සීමාවන් 2-5 ගුණයක වේගයෙන් භාවිත කරයි. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15741,7 +15855,7 @@ msgstr "මෑත කාලීන කතාබස් ආචයනය %1$s තු
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "මෑත කාලීන කතාබස්"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15750,8 +15864,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
-"උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
+"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15760,8 +15874,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
-"උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
+"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15771,9 +15885,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් "
-"කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
-"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
+"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
+"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
+"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15901,14 +16015,16 @@ msgstr "භාවිතය අඩු කරන්න"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "වඩාත් කාර්යක්ෂම ආකෘතියක් භාවිතයෙන් පරිශීලනය අඩු කරන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr "ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු කරයි"
+msgstr ""
+"ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු "
+"කරයි"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16049,8 +16165,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ &quot;Reload&quot; "
-"බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
+"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ "
+"&quot;Reload&quot; බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16140,8 +16256,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" බොත්තම ඉවත් කරයි. "
-"හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" "
+"බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16149,8 +16265,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Generate\" බොත්තම ඉවත් "
-"කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි "
+"\"Generate\" බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව "
+"දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16208,9 +16325,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට DuckDuckGo වෙත යවනු "
-"ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු "
-"ලැබේ."
+"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට "
+"DuckDuckGo වෙත යවනු ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු "
+"කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16218,8 +16335,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත "
-"හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු "
+"පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16228,9 +16345,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට ඉල්ලා ඇති සියලු "
-"පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි "
-"තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට "
+"ඉල්ලා ඇති සියලු පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ "
+"කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16280,7 +16397,7 @@ msgstr "සියලු සැකසුම් නැවත සකසන්න"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "නිබන්ධනය නැවත සකසන්න"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16298,7 +16415,7 @@ msgstr "විභේදනය"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "ප්‍රතිචාරය"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16322,8 +16439,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා "
+"කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16332,8 +16450,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා "
+"කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16343,9 +16462,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය කර ඇති අතර සාවද්‍යතා අඩංගු "
-"විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය "
+"කර ඇති අතර සාවද්‍යතා අඩංගු විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s "
+"යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16770,8 +16890,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ මෑත කාලීන "
-"කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
+"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ "
+"මෑත කාලීන කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16932,8 +17052,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු %3$sChange%4$s "
-"ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
+"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු "
+"%3$sChange%4$s ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16942,8 +17062,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත ක්ලික් කරන්න "
-"(හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
+"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත "
+"ක්ලික් කරන්න (හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16995,7 +17115,7 @@ msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගැන�
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "සෙවීම සහ Duck.ai ටොගලය"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17021,12 +17141,13 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන විශේෂාංගයකි. මෙය සිදු කිරීම "
-"සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI "
-"භාවිත කරයි. ඔබට එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, "
-"ඉල්ලූ-විට (Assist ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන කලාපවල උප "
-"කණ්ඩායමක පමණි."
+"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන "
+"විශේෂාංගයකි. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන "
+"අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි. ඔබට එය කොපමණ වාර "
+"ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, ඉල්ලූ-විට (Assist "
+"ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන "
+"කලාපවල උප කණ්ඩායමක පමණි."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17034,8 +17155,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක තොරතුරු සොයාගැනීමට "
-"Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
+"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක "
+"තොරතුරු සොයාගැනීමට Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17044,9 +17165,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප විශේෂාංගයකි. "
-"%1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් කර පසුව සොයාගත් තොරතුරු "
-"මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි."
+"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප "
+"විශේෂාංගයකි. %1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් "
+"කර පසුව සොයාගත් තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත "
+"කරයි."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17167,8 +17289,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ “ducks” සෘජුවම "
-"සොයාගත හැක."
+"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ "
+"“ducks” සෘජුවම සොයාගත හැක."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17187,8 +17309,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් සෙවුම එක් කරන්න, "
-"නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
+"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් "
+"සෙවුම එක් කරන්න, නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17196,7 +17318,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් භාවිතා කරනු ඇත)"
+"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් "
+"භාවිතා කරනු ඇත)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17208,10 +17331,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර ගබඩා තුළ ගබඩා කර ඇත, "
-"නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත "
-"කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් "
-"ඔබේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර "
+"ගබඩා තුළ ගබඩා කර ඇත, නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ "
+"සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු "
+"ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් ඔබේ බ්‍රව්සරයෙන් ඉවත් "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17314,8 +17438,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17324,8 +17448,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17334,8 +17458,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17344,8 +17468,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා කර, "
-"ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17360,14 +17484,14 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට හැර වෙන "
-"කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
+"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
+"හැර වෙන කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "අපගේ ගුප්ත කේතනය කළ සර්වරයේ ආරක්ෂිතව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17585,8 +17709,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් වල) "
-"තෝරන්න"
+"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් "
+"වල) තෝරන්න"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17651,8 +17775,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් අනෙකුත් "
-"විකල්ප වලින් එකක් තෝරන්න)"
+"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් "
+"අනෙකුත් විකල්ප වලින් එකක් තෝරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17774,8 +17898,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත විමසුමක් යවයි. මෙම "
-"උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
+"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත "
+"විමසුමක් යවයි. මෙම උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17876,7 +18000,7 @@ msgstr "මුල් පිටුව ලෙස සකසන්න"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Duck.ai ප්‍රතිචාරවල ස්වරය සහ ශෛලිය සකසන්න."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -17891,8 +18015,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක කිරීමෙන් පසු Sync & "
-"Backup පිහිටුුවන්න."
+"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක "
+"කිරීමෙන් පසු Sync & Backup පිහිටුුවන්න."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17947,13 +18071,13 @@ msgstr "සීෂෙල්ස්"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "බෙදා ගන්න"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "බෙදා ගන්න"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -17991,15 +18115,15 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. Duck.ai කිසි "
-"විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
+"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. "
+"Duck.ai කිසි විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "කතාබස බෙදා ගන්න"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18063,7 +18187,7 @@ msgstr "ධනාත්මක ප්‍රතිපෝෂණ බෙදා ගන
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "පරාසය බෙදාගන්න"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18088,8 +18212,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ හානිකර වාර්තා "
-"සඳහා අවශ්‍ය වේ)"
+"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ "
+"හානිකර වාර්තා සඳහා අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18204,7 +18328,7 @@ msgstr "විස්තර පෙන්වන්න"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Duck.ai නිබන්ධනය පෙන්වන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18216,7 +18340,8 @@ msgstr "DuckAssist <sup>BETA</sup> පෙන්වන්න"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත කිරීමටද%2$s හැකිය.)"
+"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත "
+"කිරීමටද%2$s හැකිය.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18358,7 +18483,7 @@ msgstr "දිග හරින්න"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "තව මාදිලි පෙන්වන්න"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18399,7 +18524,7 @@ msgstr "පැතිතීරුව පෙන්වන්න"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Duck.ai වෙතින් උපරිම ප්‍රයෝජන ලබා ගැනීමට පියවරානුකූල උපදෙස් පෙන්වන්න."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18454,8 +18579,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවයි "
-"සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
+"කිරීම මතක් කිරීම සඟවයි සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18463,8 +18588,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවන "
-"අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
+"කිරීම මතක් කිරීම සඟවන අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18502,7 +18627,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන පණිවුඩ පෙන්වන්න"
+"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන "
+"පණිවුඩ පෙන්වන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18772,7 +18898,7 @@ msgstr "යමක් වැරදී ඇත, කරුණාකර පසුව 
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "කුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර නැවත වරක් උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18829,7 +18955,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් උත්සාහ කරන්න."
+"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18838,16 +18965,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර ඇති බවට වග "
-"බලා ගන්න."
+"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර "
+"ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට Duck.ai එකෙන් අහන්න "
-"උත්සාහ කළ හැක."
+"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට "
+"Duck.ai එකෙන් අහන්න උත්සාහ කළ හැක."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -18856,15 +18983,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ කිරීමට%1$sමෙහි ක්ලික් "
-"කරන්න%2$s ."
+"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ "
+"කිරීමට%1$sමෙහි ක්ලික් කරන්න%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
+"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19070,7 +19198,7 @@ msgstr "සතිපතා සීමාව භාවිතය අරඹන්න
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "නව කතාබහක් ආරම්භ කරන්න"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19268,8 +19396,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය ලබාගන්න, නැතහොත් "
-"තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය "
+"ලබාගන්න, නැතහොත් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19337,7 +19465,9 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා කරනවාද?"
+msgstr ""
+"සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා "
+"කරනවාද?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19654,7 +19784,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "මෙම දෙවන මතය වෙතට මාරු වන්න"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19667,7 +19797,9 @@ msgstr "%1$sවෙත මාරු විය"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට යවනු ඇත"
+msgstr ""
+"ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට "
+"යවනු ඇත"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19722,7 +19854,8 @@ msgstr "Sync & Backup සක්‍රිය කරන ලදී!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
+"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය "
+"කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -19771,9 +19904,9 @@ msgid ""
 msgstr ""
 "ප්‍රතිසාධන කේතය සමමුහුර්ත කරන්න\n"
 "\n"
-"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් උපාංග කිහිපයක් අතර "
-"සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
-"කර ගනී.\n"
+"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් "
+"උපාංග කිහිපයක් අතර සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි "
+"වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය කර ගනී.\n"
 "\n"
 "මෙම තොරතුරු ආරක්ෂිතව තබා ගන්න.\n"
 "මෙම කේතයට ප්‍රවේශය ඇති ඕනෑම අයෙකුට ඔබේ සමමුහුර්ත දත්ත වෙත ප්‍රවේශ විය හැක.\n"
@@ -19782,12 +19915,14 @@ msgstr ""
 "\n"
 "මෙම කේතය ක්‍රියා කරන්නේ කෙසේ ද?\n"
 "1. ඔබේ බ්‍රවුසරයෙන් Duck.ai වෙත ගොස් Duck.ai සැකසුම් විවෘත කරන්න.\n"
-"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය කරන්න\" තෝරන්න\n"
-"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන ස්ථානයේ "
-"අලවන්න\n"
+"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
+"කරන්න\" තෝරන්න\n"
+"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන "
+"ස්ථානයේ අලවන්න\n"
 "\n"
-"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි කාලයක් භාවිතා "
-"නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය කළ නොහැක."
+"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි "
+"කාලයක් භාවිතා නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය "
+"කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19811,7 +19946,7 @@ msgstr "සමමුහුර්ත කිරීම සහ උපස්ථ ක�
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "උපාංග අතර කතාබස් සමමුහුර්ත කරන්න"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19907,6 +20042,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් "
+"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -19915,6 +20052,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් "
+"වේගවත් ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19938,7 +20077,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික සමීක්ෂණයට සහභාගි වන්න."
+"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික "
+"සමීක්ෂණයට සහභාගි වන්න."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20153,9 +20293,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද තොරතුරු තෙවන "
-"පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට "
-"ඇතුළත් වේ."
+"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද "
+"තොරතුරු තෙවන පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ "
+"අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට ඇතුළත් වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20164,8 +20304,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් Cloud Save කුඩා පිටු "
-"සලකුණු මඟින් ඉඩ දෙයි."
+"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් "
+"Cloud Save කුඩා පිටු සලකුණු මඟින් ඉඩ දෙයි."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20195,8 +20335,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය හැක්කේ ඔබට "
-"පමණි."
+"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය "
+"හැක්කේ ඔබට පමණි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20217,7 +20357,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල සුරකින්නේ නැත."
+msgstr ""
+"ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල "
+"සුරකින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20276,8 +20418,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය කර ඇති බවට වග බලා "
-"ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
+"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය "
+"කර ඇති බවට වග බලා ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20292,8 +20434,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර කරුණාකර මිනිත්තු කිහිපයක් "
-"රැඳී සිටින්න."
+"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර "
+"කරුණාකර මිනිත්තු කිහිපයක් රැඳී සිටින්න."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20312,9 +20454,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් සහ DuckDuckGo "
-"ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම "
-"බ්‍රව්සර් අවසර භාවිතා කරයි."
+"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් "
+"සහ DuckDuckGo ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් "
+"අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම බ්‍රව්සර් අවසර භාවිතා කරයි."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20352,8 +20494,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ කිරීමට උත්සාහ "
-"කරන්න."
+"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ "
+"කිරීමට උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20362,8 +20504,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව කතාබහක් "
-"ආරම්භ කරන්න."
+"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව "
+"කතාබහක් ආරම්භ කරන්න."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20381,7 +20523,7 @@ msgstr "මේ මාසයේ"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "මෙම ප්‍රතිචාරය"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20393,7 +20535,7 @@ msgstr "මේ සතියේ"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "මෙම කතාබහ Duck.ai මත රැඳී තිබෙන අතර ඔබට පෞද්ගලිකව පවතී."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20402,8 +20544,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත කරමිනි. AI "
-"කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා %4$s බලන්න)."
+"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත "
+"කරමිනි. AI කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි "
+"විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20413,8 +20556,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI කතාබස් "
-"සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
+"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI "
+"කතාබස් සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20423,8 +20566,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ අහිතකර "
-"තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
+"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ "
+"අහිතකර තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20435,8 +20578,8 @@ msgid ""
 "more info)."
 msgstr ""
 "මෙම සංවාදය DuckDuckGo AI Chat (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sහි %3$s ආකෘතිය "
-"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා "
-"%4$s බලන්න)."
+"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය "
+"(වැඩි විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20528,6 +20671,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ "
+"කතාබස්වල ඉහළින්ම තබා ගැනීමට පින් කරන්න තෝරන්න!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20536,6 +20681,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button "
+"භාවිතා කරන්න!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20556,8 +20703,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. අනෙකුත් ආකෘති "
-"සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. "
+"අනෙකුත් ආකෘති සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20566,8 +20713,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. අනෙකුත් ආකෘති සපයන්නන් "
-"සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. "
+"අනෙකුත් ආකෘති සපයන්නන් සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20604,8 +20751,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ සුරකින "
-"අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
+"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය "
+"සමඟ සුරකින අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20614,8 +20761,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
-"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
+"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20625,9 +20772,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
-"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ වෙතත්, අපට %1$s හි AI-සහය "
-"සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
+"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ "
+"වෙතත්, අපට %1$s හි AI-සහය සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20666,9 +20813,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup විසන්ධි කරයි. Sync "
-"& Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට "
-"හැකි වනු ඇත."
+"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup "
+"විසන්ධි කරයි. Sync & Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට "
+"තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට හැකි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20677,7 +20824,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු හැරවිය නොහැක."
+"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු "
+"හැරවිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20815,8 +20963,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට අවශ්‍ය මාර්ගය "
-"තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
+"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට "
+"අවශ්‍ය මාර්ගය තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20826,9 +20974,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත කිරීම සැකසීමේ දී සුරකින "
-"ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ "
-"PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
+"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත "
+"කිරීම සැකසීමේ දී සුරකින ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් "
+"වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20837,8 +20985,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය නවතම "
-"අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
+"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය "
+"නවතම අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20846,8 +20994,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ වීමට ඔබේ බ්‍රවුසරයට ඉඩ "
-"දෙන්න."
+"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ "
+"වීමට ඔබේ බ්‍රවුසරයට ඉඩ දෙන්න."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -20870,6 +21018,8 @@ msgstr "අද"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් "
+"එය අක්‍රිය කරන්න.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21043,8 +21193,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ ප්‍රමාණයක් අවහිර "
-"කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
+"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ "
+"ප්‍රමාණයක් අවහිර කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21092,8 +21242,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
-"කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
+"ශාලාවට යන්නේ කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21102,8 +21252,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
-"කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
+"ශාලාවට යන්නේ කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21286,7 +21436,7 @@ msgstr "ඒවා උත්සාහ කරන්න"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "වෙනස් ආකෘතියක් අත්හදා බලන්න"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21297,7 +21447,7 @@ msgstr "සෙවුමකට උත්සාහ කරන්න!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "යෝජනාවක් අත්හදා බලන්න"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21332,7 +21482,9 @@ msgstr "වෙනත් වචන සමග උත්සාහ කරන්න."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ කරන්න."
+msgstr ""
+"තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -21345,7 +21497,9 @@ msgstr "වඩාත් නිවැරදි ප්‍රතිඵල සඳහ
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා දෙනු ඇත."
+msgstr ""
+"එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා "
+"දෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21365,7 +21519,7 @@ msgstr "නොමිලේ අත්හදා බලන්න"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "නොමිලේ අත්හදා බලන්න"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21385,7 +21539,7 @@ msgstr "නොමිලේ උත්සාහ කරන්න! ආරක්ෂ�
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "දින 7කට නොමිලේ අත්හදා බලන්න"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21418,7 +21572,7 @@ msgstr "අපගේ මුල් පිටුවට ගොස් බලන්�
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "තර්කනය අත්හදා බලන්න"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21533,8 +21687,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
-"No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21543,8 +21697,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
-"No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21669,7 +21823,7 @@ msgstr "ඉලක්කගත දැන්වීම් නොමැතිව You
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Duck.ai ටොගලය ක්‍රියාත්මක කරන්න"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21733,8 +21887,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත කිරීමෙන් සෙවීමක් සහ "
-"ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
+"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත "
+"කිරීමෙන් සෙවීමක් සහ ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21864,8 +22018,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර %5$sSet "
-"Pages%6$s මත ක්ලික් කරන්න."
+"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර "
+"%5$sSet Pages%6$s මත ක්ලික් කරන්න."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -21873,8 +22027,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: https://"
-"duckduckgo.com"
+"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21990,8 +22144,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා 2 ගුණයක් "
-"ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
+"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා "
+"2 ගුණයක් ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22037,7 +22191,7 @@ msgstr "ඔබේ දායකත්වය සමඟ උසස් AI අගු�
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "උසස් මාදිලි අගුළු හරින්න"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22131,8 +22285,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට DuckDuckGo බ්‍රවුසරය "
-"යාවත්කාලීන කරන්න"
+"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට "
+"DuckDuckGo බ්‍රවුසරය යාවත්කාලීන කරන්න"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22257,15 +22411,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න, නැත්නම් තවත් "
-"රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත "
+"කරන්න, නැත්නම් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න"
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත "
+"උත්ශ්‍රේණිගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22361,9 +22516,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, වංචාකරුවන් සහ "
-"සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය "
-"නොවේ."
+"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, "
+"වංචාකරුවන් සහ සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා "
+"ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය නොවේ."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22403,7 +22558,7 @@ msgstr "Safari වල භාවිතා කරන්න"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "ඉතිහාසයෙන් කතාබහක් මකා දැමීමට Fire Button භාවිත කරන්න."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22412,8 +22567,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා කරන්න. එය "
-"ආරක්ෂිතව තබා ගන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය "
+"භාවිතා කරන්න. එය ආරක්ෂිතව තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22421,8 +22576,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා "
-"කරන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට "
+"මේ කේතය භාවිතා කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -22572,8 +22727,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු "
-"ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
+"කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22582,8 +22737,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් TripAdvisor හි "
-"දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
+"කිරීම් TripAdvisor හි දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22595,8 +22750,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist සැකසුම්%2$s "
-"වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist "
+"සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22605,8 +22760,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sDuckAssist "
-"සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට "
+"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22615,8 +22770,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති උපදෙස් "
-"පිළිපදින්න."
+"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති "
+"උපදෙස් පිළිපදින්න."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -22631,9 +22786,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync & "
-"Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ සමමුහුර්ත "
-"කරන්න%8$s තෝරන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync "
+"& Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ "
+"සමමුහුර්ත කරන්න%8$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22643,9 +22798,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn On” තෝරන්න "
-"Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන "
-"PDF එකේ QR ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn "
+"On” තෝරන්න Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. "
+"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF එකේ QR ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22667,9 +22822,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත "
-"කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් උපාංගයක් සමග සමමුහුර්ත කරන්න” "
-"තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai "
+"සැකසුම් විවෘත කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR "
+"කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22722,7 +22878,8 @@ msgstr "හඬ කතාබහ අවසන්"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් භාවිතා කරන්නේ නැහැ."
+"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් "
+"භාවිතා කරන්නේ නැහැ."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22866,8 +23023,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ "
-"ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
+"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට "
+"බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22887,9 +23044,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට ඔබව නිරීක්ෂණය කළ "
-"හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ යුතු වීමයි. DuckDuckGo යනු ස්වාධීන "
-"සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
+"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට "
+"ඔබව නිරීක්ෂණය කළ හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ "
+"යුතු වීමයි. DuckDuckGo යනු ස්වාධීන සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන "
+"සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22901,7 +23059,9 @@ msgstr "අපි නිර්නාමික කරමු"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ හැකිය."
+msgstr ""
+"ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22913,9 +23073,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
-"කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
-"හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
+"වාර්තා කිරීමට, කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව "
+"විමර්ශනය කර විසඳා ගත හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22927,15 +23087,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
-"කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
-"හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
+"වාර්තා කිරීමට, කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට "
+"ගැටලුව විමර්ශනය කර විසඳා ගත හැකිය."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ හැකිය."
+msgstr ""
+"ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -22943,7 +23105,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා කියවිය නොහැක."
+"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා "
+"කියවිය නොහැක."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22959,7 +23122,9 @@ msgstr "අපි පරිශීලක නාම හෝ පුද්ගලි�
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද නැත."
+msgstr ""
+"කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද "
+"නැත."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22971,8 +23136,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට පත් නොකරන්නෙමු. "
-"අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
+"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට "
+"පත් නොකරන්නෙමු. අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22986,8 +23151,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි පැවසුවහොත් එය "
-"අපට උපකාරී වීමට හැක:"
+"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි "
+"පැවසුවහොත් එය අපට උපකාරී වීමට හැක:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22996,8 +23161,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ අපට පැවසීමට "
-"ඔබගේ උදව් භාවිතා කළ හැකිය:"
+"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ "
+"අපට පැවසීමට ඔබගේ උදව් භාවිතා කළ හැකිය:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23037,8 +23202,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම වලට විකිණීමට "
-"කිසිවක් නැත."
+"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම "
+"වලට විකිණීමට කිසිවක් නැත."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23064,8 +23229,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ ගිවිසුම් ඇති කරගෙන "
-"ඇත්තෙමු."
+"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ "
+"ගිවිසුම් ඇති කරගෙන ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23090,8 +23255,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ දත්ත සූරාකෑමෙන් "
-"නොවේ."
+"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ "
+"දත්ත සූරාකෑමෙන් නොවේ."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23100,15 +23265,16 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික පිහිටීම භාවිතා "
-"කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
+"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික "
+"පිහිටීම භාවිතා කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත රඳා සිටිමු."
+"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත "
+"රඳා සිටිමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23129,13 +23295,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි අභිමතය පරිදි "
-"යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
+"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි "
+"අභිමතය පරිදි යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර කරන්නෙමු."
+msgstr ""
+"ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර "
+"කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23144,8 +23312,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට මෙම දෝෂය දිගටම "
-"පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට "
+"මෙම දෝෂය දිගටම පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23154,8 +23322,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර විට ඔබගේ "
-"බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර "
+"විට ඔබගේ බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23170,7 +23338,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි මහන්සි වෙමින් සිටිමු."
+"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි "
+"මහන්සි වෙමින් සිටිමු."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23179,7 +23348,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත පූරණය කළ යුතුය."
+"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත "
+"පූරණය කළ යුතුය."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23288,8 +23458,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම කතාබහේ යෙදිය "
-"හැකි ය."
+"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම "
+"කතාබහේ යෙදිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23303,8 +23473,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර "
-"ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප "
+"විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23313,8 +23483,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් "
-"නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් "
+"පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23324,15 +23495,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ %1$sගේ %2$s "
-"විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් DuckDuckGo විසින් ගබඩා කර හෝ AI "
-"ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ "
+"%1$sගේ %2$s විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් "
+"DuckDuckGo විසින් ගබඩා කර හෝ AI ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න පුළුවන්."
+msgstr ""
+"නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න "
+"පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23400,8 +23573,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. පිටුව නැවත "
-"ප්‍රවේශනය කර උත්සාහ කරන්න."
+"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. "
+"පිටුව නැවත ප්‍රවේශනය කර උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23416,7 +23589,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ ප්‍රතිවිරෝධතා මොනවාද?"
+"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ "
+"ප්‍රතිවිරෝධතා මොනවාද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -23437,8 +23611,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර විකල්ප "
-"මොනවාද."
+"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර "
+"විකල්ප මොනවාද."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23457,10 +23631,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ ප්‍රතිලාභ මොනවා "
-"ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ කිරීම් සහ රහස්‍යතා ආරක්ෂණ "
-"කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික "
-"අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
+"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ "
+"ප්‍රතිලාභ මොනවා ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ "
+"කිරීම් සහ රහස්‍යතා ආරක්ෂණ කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත "
+"පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් "
+"කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23575,7 +23750,7 @@ msgstr "අද ඔබව නැවත ගෙන ආ දේ කුමක්ද?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "ඔබට කළ හැක්කේ කුමක් ද?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23696,7 +23871,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් වන්නේ කෙසේද?"
+"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් "
+"වන්නේ කෙසේද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23797,8 +23973,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම නිෂ්පාදන වෙළඳ නාම "
-"මොනවාද?"
+"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම "
+"නිෂ්පාදන වෙළඳ නාම මොනවාද?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23999,6 +24175,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු "
+"කිරීමට භාවිත නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24271,7 +24450,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
+msgstr ""
+"ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24280,8 +24461,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර මත කඍජුව %1$s හෝ "
-"සෙවිය හැකිය."
+"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර "
+"මත කඍජුව %1$s හෝ සෙවිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24295,8 +24476,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s තුළ එය "
-"අක්‍රිය කළ හැකිය."
+"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s "
+"තුළ එය අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24305,21 +24486,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය "
-"අක්‍රිය කිරීමට හැකිය."
+"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් "
+"කිරීමට හෝ එය අක්‍රිය කිරීමට හැකිය."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ හැකිය."
+"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s ද භාාවිත "
-"කළ හැකිය."
+"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s "
+"ද භාාවිත කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24333,8 +24515,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, එය "
-"සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
+"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, "
+"එය සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24355,8 +24537,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස පළමු සමූහය "
-"මකනවා."
+"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස "
+"පළමු සමූහය මකනවා."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24428,7 +24610,7 @@ msgstr "එක් සංවාදයකට ඇමිණිය හැක්කේ
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "එකවර ඇමිණිය හැක්කේ ටැබ් %1$sක් පමණි."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24449,8 +24631,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම වෙනත් වෙබ් අඩවියක් "
-"අහිතකර කිරීමට අවශ්ය වේ."
+"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම "
+"වෙනත් වෙබ් අඩවියක් අහිතකර කිරීමට අවශ්ය වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24507,8 +24689,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් පුළුල් පරිශීලන "
-"සීමාවන් ඇත."
+"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් "
+"පුළුල් පරිශීලන සීමාවන් ඇත."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24517,8 +24699,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ අනෙකුත් "
-"DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
+"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ "
+"අනෙකුත් DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24540,9 +24722,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
-"කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
-"නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
+"වනු ඇත. අවසාන කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
+"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24552,9 +24734,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
-"කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
-"නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
+"වනු ඇත. අවසාන කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
+"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24567,13 +24749,15 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr "ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන ලැබෙනු ඇත."
+msgstr ""
+"ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන "
+"ලැබෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "සියල්ල සූදානම්!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24582,8 +24766,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome වෙනුවට අපගේ යෙදුම භාවිතා "
-"කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome "
+"වෙනුවට අපගේ යෙදුම භාවිතා කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24596,8 +24780,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර ගැනීමට ඉඟි ලබා "
-"ගන්න."
+"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර "
+"ගැනීමට ඉඟි ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24626,7 +24810,7 @@ msgstr "ඔයා 1 වෙබ් අඩවියක් අවහිර කරල
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "ඔබ Duck.ai සම්බන්ධ මූලික කරුණු ප්‍රගුණ කර ඇත"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24673,8 +24857,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
-"ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
+"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත "
+"කිරීම නැවත ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24684,8 +24869,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත ආරම්භ කිරීමට "
-"ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
+"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
+"ආරම්භ කිරීමට ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24699,8 +24885,9 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. ඒ වගේම, "
-"Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා කිරීමකට ලක් වෙන්න පුළුවන්."
+"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. "
+"ඒ වගේම, Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා "
+"කිරීමකට ලක් වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24744,8 +24931,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා "
+"ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24755,8 +24943,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත "
+"හැකිය:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24781,8 +24970,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත කිසිවිටෙක මෙම දත්ත "
-"වෙත ප්‍රවේශය නොමැත."
+"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත "
+"කිසිවිටෙක මෙම දත්ත වෙත ප්‍රවේශය නොමැත."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -24790,8 +24979,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට කවදාවත් අවසරයක් "
-"නැහැ ඒ දත්ත වලට."
+"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට "
+"කවදාවත් අවසරයක් නැහැ ඒ දත්ත වලට."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24799,7 +24988,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
+msgstr ""
+"%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24812,7 +25003,8 @@ msgstr "ඔබගේ කතාබස් දැන් සුරැකෙමින
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ භාවිත නොකෙරේ"
+"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ "
+"භාවිත නොකෙරේ"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24826,7 +25018,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
+"කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -24834,7 +25027,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
+"කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24842,8 +25036,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
+"පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24851,8 +25045,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
+"පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24867,8 +25061,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා කෘත්‍රිම බුද්ධි ආකෘති "
-"පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා ගැනීමට මේ පියවර අනුගමනය කරන්න."
+"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා "
+"කෘත්‍රිම බුද්ධි ආකෘති පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා "
+"ගැනීමට මේ පියවර අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24908,8 +25103,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ සම්බන්ධ කිරීමක් සිදු නොවේ. "
-"[%2$sඋදාහරණ පණිවිඩය%3$s]"
+"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ "
+"සම්බන්ධ කිරීමක් සිදු නොවේ. [%2$sඋදාහරණ පණිවිඩය%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24952,9 +25147,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ මුරපදය 512-bit "
-"යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත සැකසුම් ගොනුව පමණි. යතුර නම ලෙස "
-"භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
+"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ "
+"මුරපදය 512-bit යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත "
+"සැකසුම් ගොනුව පමණි. යතුර නම ලෙස භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. "
+"DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24969,8 +25165,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත හැකි පාර-දත්ත "
-"ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත සම්බන්ධ කළ නොහැක."
+"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත "
+"හැකි පාර-දත්ත ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත "
+"සම්බන්ධ කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24984,8 +25181,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම වේලාවක "
-"ඒවා ඉවත් කළ හැකි ය."
+"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම "
+"වේලාවක ඒවා ඉවත් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25017,6 +25214,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
+"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25025,8 +25224,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
+"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර "
+"දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25046,8 +25246,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට අපේ බ්‍රවුසරය "
-"භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට "
+"අපේ බ්‍රවුසරය භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25056,7 +25256,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ කරන්න."
+"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25065,8 +25266,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button සමඟ "
-"මෙම සංවාදය ඉවත් කරන්න."
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button "
+"සමඟ මෙම සංවාදය ඉවත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25074,7 +25275,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ ගන්න."
+msgstr ""
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ "
+"ගන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25089,8 +25292,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම කරගෙන "
-"යන්න."
+"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් "
+"දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -25608,4 +25811,4 @@ msgstr "වර්ෂ"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,7 +87,8 @@ msgstr "%1$s a %2$s Modely umelej inteligencie"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
+msgstr ""
+"%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -98,7 +99,8 @@ msgstr "Pokusy: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
+msgstr ""
+"DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -122,6 +124,12 @@ msgstr "pred %1$s dňami"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Bol rozpoznaný jazyk %1$s"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -216,7 +224,8 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
+msgstr ""
+"%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -353,6 +362,12 @@ msgid "%s used"
 msgstr "Použitých %1$s"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s zobrazenie"
@@ -444,7 +459,8 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
+msgstr ""
+"%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -469,13 +485,15 @@ msgstr "%1$sZistite, ako chránime informácie o vašej polohe%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
+msgstr ""
+"%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
+msgstr ""
+"%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -487,7 +505,8 @@ msgstr "%1$sDlho stlačte%2$s ikonu aplikácie DuckDuckGo na úvodnej obrazovke"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
+msgstr ""
+"%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -594,6 +613,12 @@ msgstr "DuckDuckGo zablokoval 1 pokus za posledných 24 hodín"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "pred 1 dňom"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -887,14 +912,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
+msgstr ""
+"K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
+msgstr ""
+"Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1506,6 +1533,14 @@ msgid "Advanced Models"
 msgstr "Pokročilé modely"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Inzerovať vo vyhľadávaní"
@@ -1842,7 +1877,8 @@ msgstr "Už je to synchronizované."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
+msgstr ""
+"Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2291,6 +2327,12 @@ msgstr "Spýtaj sa súkromne"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask privately"
 msgstr "Spýtaj sa súkromne"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2885,7 +2927,8 @@ msgstr "Zablokovať túto stránku vo všetkých výsledkoch"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
+msgstr ""
+"Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3851,6 +3894,12 @@ msgid "Chat privately with AI"
 msgstr "Súkromný chat s AI"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4640,6 +4689,12 @@ msgid "Close"
 msgstr "Zatvoriť"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4682,6 +4737,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Zatvoriť vyhľadávanie"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5055,6 +5116,12 @@ msgid "Continue Blocking Ads"
 msgstr "Pokračuj v blokovaní reklám"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5120,6 +5187,12 @@ msgid "Cookie data:"
 msgstr "Údaje súborov cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5158,13 +5231,20 @@ msgstr "Kopírovať"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
+msgstr ""
+"Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopírovať kód"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5280,6 +5360,12 @@ msgid "Create Image"
 msgstr "Vytvoriť obrázok"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5321,6 +5407,14 @@ msgstr "Vytvoril/-a"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Vytvorené %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5474,6 +5568,12 @@ msgstr "Prispôsobiť odpovede"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Prispôsobiť odpovede"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5762,10 +5862,22 @@ msgid "Delete Server Data?"
 msgstr "Chceš zmazať údaje servera?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Vymazať prepis"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5798,6 +5910,12 @@ msgstr "Odstrániť obrázok"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Vymazať obrázok?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6108,6 +6226,12 @@ msgid "Dismiss promotion"
 msgstr "Zrušiť propagáciu"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6218,7 +6342,8 @@ msgstr "Nevidíte súbor? %1$s%2$s%3$sKliknite sem a stiahnite si ho znova.%4$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr "Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
+msgstr ""
+"Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6316,6 +6441,12 @@ msgstr "Sťahovanie je dokončené"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Stiahni si DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6533,6 +6664,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai od DuckDuckGo. Súkromný AI chat. Zadarmo."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6570,7 +6707,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
+msgstr ""
+"Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6684,6 +6822,12 @@ msgid ""
 msgstr ""
 "Odpovede Duck.ai nie sú založené na konkrétnych zdrojoch a nie sú "
 "kontrolované z hľadiska presnosti."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6871,8 +7015,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite "
-"e-mailom tento anonymný kód %1$s na adresu %2$s"
+"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite e-"
+"mailom tento anonymný kód %1$s na adresu %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6880,13 +7024,15 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
+msgstr ""
+"DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
+msgstr ""
+"DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7024,7 +7170,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
+msgstr ""
+"DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7231,7 +7378,8 @@ msgstr "Upravujem obrázok..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
+msgstr ""
+"Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7326,6 +7474,12 @@ msgstr "Povoliť najviac navštevované weby"
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Povoliť najnavštevovanejšie weby"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7627,6 +7781,12 @@ msgid "Entertainment guide"
 msgstr "Sprievodca zábavou"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Rovníková Guinea"
 
@@ -7790,6 +7950,18 @@ msgid "Explicit lyrics"
 msgstr "Explicitné texty"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7889,6 +8061,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Bezplatne"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8092,7 +8270,8 @@ msgstr "Finančný poradca"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
+msgstr ""
+"Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8104,7 +8283,8 @@ msgstr "Nájdi <b>%1$s</b> v&nbsp;tvojom priečinku so&nbsp;stiahnutými súborm
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
+msgstr ""
+"Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8310,6 +8490,12 @@ msgstr "Bezplatný plán"
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
 msgstr "Uvoľniť miesto"
+
+# smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8573,7 +8759,8 @@ msgstr "Všeobecná umelá inteligencia s vysokou mierou moderovania"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
+msgstr ""
+"Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -8826,6 +9013,12 @@ msgid "Get computer help"
 msgstr "Získať pomoc s počítačom"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8863,6 +9056,18 @@ msgid "Get the Latest Version"
 msgstr "Získajte najnovšiu verziu"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8883,6 +9088,12 @@ msgstr "Túto skladbu si môžete vypočuť na:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Prehovorte svojich priateľov a pomôžte nám rásť!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8956,7 +9167,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
+msgstr ""
+"Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9569,6 +9781,12 @@ msgid "Hide Tips"
 msgstr "Skryť tipy"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9772,7 +9990,8 @@ msgstr "Otvárací čas chýba"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
+msgstr ""
+"Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10638,7 +10857,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
+msgstr ""
+"Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10688,7 +10908,8 @@ msgstr "Je to rýchly, bezplatný a poskytuje ti ešte väčšiu ochranu online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
+msgstr ""
+"Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11131,7 +11352,8 @@ msgstr "Viac informácií o tom, ako to funguje"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
+msgstr ""
+"Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11187,6 +11409,13 @@ msgstr "Vráť sa k nám."
 msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Umožňuje vám anonymne vyhľadávať cez DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11257,6 +11486,12 @@ msgstr "Jednoduchá kresba"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Vyhrané auty"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12355,6 +12590,12 @@ msgid "More than 20 minutes"
 msgstr "Viac ako 20 minút"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12840,6 +13081,12 @@ msgstr "Nie, ďakujem"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Nie, ďakujem"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13504,6 +13751,12 @@ msgid "On but no numbers"
 msgstr "Zapnuté, bez čísel"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13560,7 +13813,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
+msgstr ""
+"Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13639,7 +13893,8 @@ msgstr "Otvorte položku Poloha a uistite sa, že je poloha %1$szapnutá%2$s."
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Privacy', then 'Location Services'."
-msgstr "Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
+msgstr ""
+"Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
 
 # smartling.placeholder_format=C
 #. Indicates a business is open 24 hours a day.
@@ -13714,6 +13969,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Otvoriť návrhy na vytváranie a úpravu obrázkov"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13776,7 +14037,8 @@ msgstr "Otvoriť panel Ako funguje Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
+msgstr ""
+"Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14461,10 +14723,22 @@ msgid "Pin"
 msgstr "Pripnúť"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Pripni sem chaty z %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14482,6 +14756,12 @@ msgstr "Ružová"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Pripnuté"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14546,7 +14826,8 @@ msgstr "Popíš, prečo je odpoveď v chate škodlivá alebo nezákonná. (nepov
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
+msgstr ""
+"Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14801,6 +15082,12 @@ msgid "Poor formatting"
 msgstr "Zlé formátovanie"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15007,6 +15294,12 @@ msgstr "Predchádzajúci obrázok"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Predchádzajúce karty"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15551,6 +15844,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Rozumná AI so strednou zabudovanou moderáciou"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15584,6 +15889,12 @@ msgstr "Nedávne karty"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Úložisko nedávnych chatov je možné upraviť v %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15738,6 +16049,12 @@ msgstr "Skús vyhľadávať znova bez tejto stránky"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Znížiť používanie"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16117,6 +16434,12 @@ msgid "Reset All Settings"
 msgstr "Obnoviť všetky nastavenia"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16127,6 +16450,12 @@ msgstr "Obnoví sa za %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Rozlíšenie"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16617,7 +16946,8 @@ msgstr "Ulož si až 30 svojich najnovších chatov lokálne do svojho zariad
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
+msgstr ""
+"Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16802,7 +17132,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
+msgstr ""
+"Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16825,6 +17156,12 @@ msgstr "Vyhľadávanie"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Chcete vyhľadať %1$s, aby sa našli výsledky vo vašom okolí?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16952,7 +17289,8 @@ msgstr "Viditeľnosť vyhľadávania"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
+msgstr ""
+"Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17088,7 +17426,8 @@ msgstr "Vyhľadávajte cez DuckDuckGo"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
+msgstr ""
+"Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17138,7 +17477,8 @@ msgstr "Druhý názor"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
+msgstr ""
+"Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17167,9 +17507,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou "
-"end-to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných "
-"zariadení."
+"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou end-"
+"to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných zariadení."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17196,6 +17535,12 @@ msgid ""
 msgstr ""
 "Bezpečne uložené na serveri DuckDuckGo s end-to-end šifrovaním. Nikto okrem "
 "teba nemôže vidieť tvoje údaje, dokonca ani my."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17367,13 +17712,15 @@ msgstr "Vyberte %1$sDuckDuckGo%2$s a potom %3$sPridať ako predvolené%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
+msgstr ""
+"V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
+msgstr ""
+"V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17709,6 +18056,12 @@ msgid "Set as Homepage"
 msgstr "Nastaviť ako domovskú stránku"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17776,6 +18129,18 @@ msgid "Seychelles"
 msgstr "Seychely"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17784,7 +18149,8 @@ msgstr "Zdieľať"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
+msgstr ""
+"Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17814,6 +18180,13 @@ msgstr ""
 "Zdieľaj polohu na úrovni mesta s modelmi AI, aby si zvýšil/-a relevantnosť. "
 "Duck.ai nám ani modelom umelej inteligencie nikdy neodhalí vašu presnú "
 "polohu."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17872,6 +18245,12 @@ msgstr "Zdieľaj adresu URL stránky"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Zdieľajte kladnú spätnú väzbu"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18009,6 +18388,12 @@ msgid "Show Detail"
 msgstr "Zobraziť podrobnosti"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "Zobraziť DuckAssist <sup>BETA</sup>"
@@ -18017,7 +18402,8 @@ msgstr "Zobraziť DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
+msgstr ""
+"Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18156,6 +18542,12 @@ msgid "Show more"
 msgstr "Zobraziť viac"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18189,6 +18581,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Zobraziť bočný panel"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18265,7 +18663,8 @@ msgstr "Zobraziť vodorovné čiary medzi stránkami vo výsledkoch vyhľadávan
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
+msgstr ""
+"Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18281,12 +18680,14 @@ msgstr "Zobraziť najnavštevovanejšie odkazy na novej karte"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
+msgstr ""
+"Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
+msgstr ""
+"Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18317,7 +18718,8 @@ msgstr "Zobrazovať návrhy pod vyhľadávacím poľom pri písaní"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
+msgstr ""
+"Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18327,7 +18729,8 @@ msgstr "Zobraziť pozadie tlačidla Hľadať"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
+msgstr ""
+"Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18565,6 +18968,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Vyskytla sa chyba. Skús to neskôr."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18618,7 +19027,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
+msgstr ""
+"Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18652,7 +19062,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
+msgstr ""
+"Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18706,7 +19117,8 @@ msgstr "Zdrojový text bol vymazaný"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
+msgstr ""
+"Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18855,6 +19267,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Začni používať týždenný limit"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Začnite vyhľadávať!"
@@ -18966,7 +19384,8 @@ msgstr "Zablokujte skryté sledovače, ktoré na vás číhajú na iných weboch
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
+msgstr ""
+"Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19439,6 +19858,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Prejdite na vyhľadávač, ktorý vás nesleduje. Nikdy."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19449,7 +19876,8 @@ msgstr "Prepnuté na %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
+msgstr ""
+"Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19594,6 +20022,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Služba Sync & Backup je dočasne nedostupná."
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19681,6 +20115,22 @@ msgid "Take Back Your Privacy!"
 msgstr "Získajte späť svoje súkromie!"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19701,7 +20151,8 @@ msgstr "Získajte späť kontrolu nad svojimi osobnými údajmi!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
+msgstr ""
+"Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20001,7 +20452,8 @@ msgstr "Uplynul časový limit žiadosti. Skús to znova."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
+msgstr ""
+"Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -20120,7 +20572,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
+msgstr ""
+"Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20145,10 +20598,22 @@ msgid "This Month"
 msgstr "Tento mesiac"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Tento týždeň"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20281,6 +20746,22 @@ msgid "This information isn’t useful"
 msgstr "Tieto informácie nie sú užitočné"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20395,7 +20876,8 @@ msgstr "Tento preklad je nesprávny"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
+msgstr ""
+"Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -20518,8 +21000,8 @@ msgstr "Tipy"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme "
-"vám.%2$s"
+"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme vám."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20567,8 +21049,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete "
-"vytlačiť.%3$sKliknite na ikonu tlače.%4$s"
+"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete vytlačiť."
+"%3$sKliknite na ikonu tlače.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20617,6 +21099,12 @@ msgstr "Dnes"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Dnes"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21032,9 +21520,21 @@ msgid "Try Them Out"
 msgstr "Vyskúšaj ich!"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Skúste niečo vyhľadať!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21069,13 +21569,15 @@ msgstr "Skúste iné kľúčové slová."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
+msgstr ""
+"Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
+msgstr ""
+"Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21099,6 +21601,12 @@ msgid "Try for free"
 msgstr "Skús to zadarmo!"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21111,6 +21619,12 @@ msgstr "Skús to zadarmo!"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "Vyskúšaj zadarmo! Bezpečná VPN, pokročilá a súkromná AI a ešte viac."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21140,6 +21654,12 @@ msgid "Try our homepage that never shows these messages:"
 msgstr ""
 "Vyskúšajte našu domovskú stránku, na ktorej sa nikdy nezobrazujú tieto "
 "správy:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21380,12 +21900,19 @@ msgstr "Vypnúť:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
+msgstr ""
+"Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Zapnite Duck Player a sledujte YouTube bez cielených reklám"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21397,7 +21924,8 @@ msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Presná 
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
+msgstr ""
+"Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21603,13 +22131,14 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: "
-"https://duckduckgo.com."
+"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: https://"
+"duckduckgo.com."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr "Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
+msgstr ""
+"Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21622,7 +22151,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
+msgstr ""
+"Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -21636,7 +22166,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
+msgstr ""
+"V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21758,6 +22289,12 @@ msgstr "Odomkni pokročilé modely AI s predplatným DuckDuckGo."
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Odomkni s tvojím predplatným pokročilú AI!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22121,6 +22658,12 @@ msgstr "Používať v prehliadači Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Používať v prehliadači Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23175,7 +23718,8 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
+msgstr ""
+"Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23309,6 +23853,12 @@ msgstr "Čo ťa najviac trápilo?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Čo vás dnes priviedlo späť?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23539,7 +24089,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
+msgstr ""
+"Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23557,7 +24108,8 @@ msgstr "Kde sledovať <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
+msgstr ""
+"Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23597,7 +24149,8 @@ msgstr "Kto sme"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr "Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
+msgstr ""
+"Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23727,6 +24280,14 @@ msgstr "Výhry"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Zimné prehánky"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24157,6 +24718,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Do jednej konverzácie môžeš pripojiť iba %1$s obrázkov."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24298,6 +24866,12 @@ msgstr ""
 "aplikácie DuckDuckGo."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24344,6 +24918,12 @@ msgstr "Zablokoval/-a si %1$s stránok"
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "Zablokoval/-a si 1 stránku"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24495,7 +25075,8 @@ msgstr "Podľa vášho prehliadača ste tento odkaz už otvorili."
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
+msgstr ""
+"Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -24544,7 +25125,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
+msgstr ""
+"Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24605,7 +25187,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
+msgstr ""
+"Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24744,6 +25327,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Tvoje vyhľadávania sa nedajú spojiť s svojou osobou"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24782,7 +25373,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
+msgstr ""
+"Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25120,7 +25712,8 @@ msgstr "oficiálnej webovej stránky"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
+msgstr ""
+"alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25331,3 +25924,9 @@ msgstr "rokov"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "r"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,8 +87,7 @@ msgstr "%1$s a %2$s Modely umelej inteligencie"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
+msgstr "%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -99,8 +98,7 @@ msgstr "Pokusy: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
+msgstr "DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -129,7 +127,7 @@ msgstr "Bol rozpoznaný jazyk %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Použité súbory: %1$s"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -224,8 +222,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
+msgstr "%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -365,7 +362,7 @@ msgstr "Použitých %1$s"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s čerpá limity až 2–5× rýchlejšie ako základné modely %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -459,8 +456,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
+msgstr "%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -485,15 +481,13 @@ msgstr "%1$sZistite, ako chránime informácie o vašej polohe%2$s."
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
+msgstr "%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
+msgstr "%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -505,8 +499,7 @@ msgstr "%1$sDlho stlačte%2$s ikonu aplikácie DuckDuckGo na úvodnej obrazovke"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
+msgstr "%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -618,7 +611,7 @@ msgstr "pred 1 dňom"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 použitý súbor"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -912,16 +905,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
+msgstr "K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
+msgstr "Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1538,7 +1529,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
+msgstr "Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1877,8 +1868,7 @@ msgstr "Už je to synchronizované."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
+msgstr "Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2332,7 +2322,7 @@ msgstr "Spýtaj sa súkromne"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Spýtaj sa súkromne"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2927,8 +2917,7 @@ msgstr "Zablokovať túto stránku vo všetkých výsledkoch"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
+msgstr "Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3897,7 +3886,7 @@ msgstr "Súkromný chat s AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Četuj súkromne s populárnymi AI"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4692,7 +4681,7 @@ msgstr "Zatvoriť"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Zatvoriť"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4742,7 +4731,7 @@ msgstr "Zatvoriť vyhľadávanie"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Zavrieť druhý názor"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5119,7 +5108,7 @@ msgstr "Pokračuj v blokovaní reklám"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5190,7 +5179,7 @@ msgstr "Údaje súborov cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Skopírované"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5231,8 +5220,7 @@ msgstr "Kopírovať"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
+msgstr "Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5244,7 +5232,7 @@ msgstr "Kopírovať kód"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopírovať odkaz"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5363,7 +5351,7 @@ msgstr "Vytvoriť obrázok"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Vytvoriť odkaz na zdieľanie"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5415,6 +5403,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Vytvorením odkazu sa vytvorí kópia četu, ktorú si môže zobraziť každý, kto "
+"ho otvorí."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5573,7 +5563,7 @@ msgstr "Prispôsobiť odpovede"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Prispôsobiť odpovede"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5865,7 +5855,7 @@ msgstr "Chceš zmazať údaje servera?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Odstrániť zdieľaný odkaz"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5877,7 +5867,7 @@ msgstr "Vymazať prepis"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Zmazať čet"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5915,7 +5905,7 @@ msgstr "Vymazať obrázok?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Zmaž ma"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6229,7 +6219,7 @@ msgstr "Zrušiť propagáciu"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Zrušiť prehliadku"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6342,8 +6332,7 @@ msgstr "Nevidíte súbor? %1$s%2$s%3$sKliknite sem a stiahnite si ho znova.%4$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr ""
-"Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
+msgstr "Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6446,7 +6435,7 @@ msgstr "Stiahni si DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Stiahni si DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6667,7 +6656,7 @@ msgstr "Duck.ai od DuckDuckGo. Súkromný AI chat. Zadarmo."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai teraz dokáže analyzovať súbory PDF. Vyskúšaj to!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6707,8 +6696,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
+msgstr "Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6827,7 +6815,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai podporuje modely od Anthropic, OpenAI a ďalších."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7015,8 +7003,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite e-"
-"mailom tento anonymný kód %1$s na adresu %2$s"
+"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite "
+"e-mailom tento anonymný kód %1$s na adresu %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7024,15 +7012,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
+msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
+msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7170,8 +7156,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
+msgstr "DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7378,8 +7363,7 @@ msgstr "Upravujem obrázok..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
+msgstr "Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7479,7 +7463,7 @@ msgstr "Povoliť najnavštevovanejšie weby"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Zapnúť teraz"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7784,7 +7768,7 @@ msgstr "Sprievodca zábavou"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Celý čet"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7953,13 +7937,13 @@ msgstr "Explicitné texty"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Preskúmaj Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Preskúmaj Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8066,7 +8050,7 @@ msgstr "Bezplatne"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "Bezplatné a voliteľné"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8270,8 +8254,7 @@ msgstr "Finančný poradca"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
+msgstr "Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8283,8 +8266,7 @@ msgstr "Nájdi <b>%1$s</b> v&nbsp;tvojom priečinku so&nbsp;stiahnutými súborm
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
+msgstr "Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8495,7 +8477,7 @@ msgstr "Uvoľniť miesto"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Zadarmo a vždy súkromné"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8759,8 +8741,7 @@ msgstr "Všeobecná umelá inteligencia s vysokou mierou moderovania"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
+msgstr "Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9016,7 +8997,7 @@ msgstr "Získať pomoc s počítačom"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Získaj vyššie limity používania s predplatným DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9059,13 +9040,15 @@ msgstr "Získajte najnovšiu verziu"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Získaj aplikáciu"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9093,7 +9076,7 @@ msgstr "Prehovorte svojich priateľov a pomôžte nám rásť!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Kontrolný zoznam na začiatok"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9167,8 +9150,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
+msgstr "Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9784,7 +9766,7 @@ msgstr "Skryť tipy"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Skryť návod"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9990,8 +9972,7 @@ msgstr "Otvárací čas chýba"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
+msgstr "Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10857,8 +10838,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
+msgstr "Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10908,8 +10888,7 @@ msgstr "Je to rýchly, bezplatný a poskytuje ti ešte väčšiu ochranu online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
+msgstr "Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11352,8 +11331,7 @@ msgstr "Viac informácií o tom, ako to funguje"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
+msgstr "Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11416,6 +11394,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11491,7 +11471,7 @@ msgstr "Vyhrané auty"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Platnosť odkazu vyprší o 7 dní."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12593,7 +12573,7 @@ msgstr "Viac ako 20 minút"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Ďalšie tipy"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13086,7 +13066,7 @@ msgstr "Nie, ďakujem"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nie, ďakujem"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13754,7 +13734,7 @@ msgstr "Zapnuté, bez čísel"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Úvodné nastavenie je dokončené"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13813,8 +13793,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
+msgstr "Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -13893,8 +13872,7 @@ msgstr "Otvorte položku Poloha a uistite sa, že je poloha %1$szapnutá%2$s."
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Privacy', then 'Location Services'."
-msgstr ""
-"Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
+msgstr "Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
 
 # smartling.placeholder_format=C
 #. Indicates a business is open 24 hours a day.
@@ -13972,7 +13950,7 @@ msgstr "Otvoriť návrhy na vytváranie a úpravu obrázkov"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Otvor kontrolný zoznam na začiatok"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14037,8 +14015,7 @@ msgstr "Otvoriť panel Ako funguje Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
+msgstr "Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14726,7 +14703,7 @@ msgstr "Pripnúť"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Pripnúť čet"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14738,7 +14715,7 @@ msgstr "Pripni sem chaty z %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Pripni ma"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14761,7 +14738,7 @@ msgstr "Pripnuté"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Pripnuté čety sa zobrazia na vrchu tvojich nedávnych četov."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14826,8 +14803,7 @@ msgstr "Popíš, prečo je odpoveď v chate škodlivá alebo nezákonná. (nepov
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
+msgstr "Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15086,6 +15062,8 @@ msgstr "Zlé formátovanie"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"K dispozícii sú populárne modely AI. Účet nie je potrebný. Čety sú "
+"anonymizované nami."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15299,7 +15277,7 @@ msgstr "Predchádzajúce karty"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Predchádzajúce tipy"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15847,13 +15825,13 @@ msgstr "Rozumná AI so strednou zabudovanou moderáciou"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Uvažovanie môže poskytnúť lepšie odpovede na zložité otázky."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Uvažovanie je dôkladnejšie, ale limity vyčerpáva 2–5× rýchlejšie. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15894,7 +15872,7 @@ msgstr "Úložisko nedávnych chatov je možné upraviť v %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Nedávne čety"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16054,7 +16032,7 @@ msgstr "Znížiť používanie"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Zníž používanie vďaka efektívnejšiemu modelu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16437,7 +16415,7 @@ msgstr "Obnoviť všetky nastavenia"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Reštartovať návod"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16455,7 +16433,7 @@ msgstr "Rozlíšenie"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Odpoveď"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16946,8 +16924,7 @@ msgstr "Ulož si až 30 svojich najnovších chatov lokálne do svojho zariad
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
+msgstr "Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17132,8 +17109,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
+msgstr "Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17161,7 +17137,7 @@ msgstr "Chcete vyhľadať %1$s, aby sa našli výsledky vo vašom okolí?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Prepínač Vyhľadávanie a Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17289,8 +17265,7 @@ msgstr "Viditeľnosť vyhľadávania"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
+msgstr "Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -17426,8 +17401,7 @@ msgstr "Vyhľadávajte cez DuckDuckGo"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
+msgstr "Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17477,8 +17451,7 @@ msgstr "Druhý názor"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
+msgstr "Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17507,8 +17480,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou end-"
-"to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných zariadení."
+"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou "
+"end-to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných "
+"zariadení."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17540,7 +17514,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Bezpečne uložené na našom šifrovanom serveri."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17712,15 +17686,13 @@ msgstr "Vyberte %1$sDuckDuckGo%2$s a potom %3$sPridať ako predvolené%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
+msgstr "V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
+msgstr "V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18059,7 +18031,7 @@ msgstr "Nastaviť ako domovskú stránku"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Nastav tón a štýl odpovedí Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18132,13 +18104,13 @@ msgstr "Seychely"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Zdieľať"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Zdieľať"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18149,8 +18121,7 @@ msgstr "Zdieľať"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
+msgstr "Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18186,7 +18157,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Zdieľať čet"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18250,7 +18221,7 @@ msgstr "Zdieľajte kladnú spätnú väzbu"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Rozsah zdieľania"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18391,7 +18362,7 @@ msgstr "Zobraziť podrobnosti"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Zobraziť návod pre Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18402,8 +18373,7 @@ msgstr "Zobraziť DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
+msgstr "Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18545,7 +18515,7 @@ msgstr "Zobraziť viac"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Zobraziť viac modelov"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18586,7 +18556,7 @@ msgstr "Zobraziť bočný panel"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Zobraziť tipy krok za krokom, ako z Duck.ai vyťažiť čo najviac."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18663,8 +18633,7 @@ msgstr "Zobraziť vodorovné čiary medzi stránkami vo výsledkoch vyhľadávan
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
+msgstr "Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -18680,14 +18649,12 @@ msgstr "Zobraziť najnavštevovanejšie odkazy na novej karte"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
+msgstr "Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
+msgstr "Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18718,8 +18685,7 @@ msgstr "Zobrazovať návrhy pod vyhľadávacím poľom pri písaní"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
+msgstr "Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18729,8 +18695,7 @@ msgstr "Zobraziť pozadie tlačidla Hľadať"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
+msgstr "Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18971,7 +18936,7 @@ msgstr "Vyskytla sa chyba. Skús to neskôr."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Vyskytla sa chyba. Skús to znova."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19027,8 +18992,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
+msgstr "Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19062,8 +19026,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
+msgstr "Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19117,8 +19080,7 @@ msgstr "Zdrojový text bol vymazaný"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
+msgstr "Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19270,7 +19232,7 @@ msgstr "Začni používať týždenný limit"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Začni nový čet"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19384,8 +19346,7 @@ msgstr "Zablokujte skryté sledovače, ktoré na vás číhajú na iných weboch
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
+msgstr "Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19863,7 +19824,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Prepnúť na tento druhý názor"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19876,8 +19837,7 @@ msgstr "Prepnuté na %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
+msgstr "Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20025,7 +19985,7 @@ msgstr "Služba Sync & Backup je dočasne nedostupná."
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Synchronizuj čety medzi zariadeniami"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20121,6 +20081,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Vezmi si Duck.ai všade so sebou. Získaj ju zabudovanú v našej bezplatnej "
+"aplikácii na rýchlejší prístup, nech si kdekoľvek."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20129,6 +20091,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Vezmi si Duck.ai všade so sebou. Získaj ho zabudovaný v našom bezplatnom "
+"prehliadači na rýchlejší prístup, nech prehliadaš kdekoľvek."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20151,8 +20115,7 @@ msgstr "Získajte späť kontrolu nad svojimi osobnými údajmi!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
+msgstr "Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20452,8 +20415,7 @@ msgstr "Uplynul časový limit žiadosti. Skús to znova."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
+msgstr "Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -20572,8 +20534,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
+msgstr "Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20601,7 +20562,7 @@ msgstr "Tento mesiac"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Táto odpoveď"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20613,7 +20574,7 @@ msgstr "Tento týždeň"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Tento čet zostáva v Duck.ai a zostáva pre teba súkromný."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20752,6 +20713,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Toto je len ukážkový čet. Otvor jeho ponuku (tri bodky) a potom vyber "
+"Pripnúť, aby ponuka zostala na vrchu tvojich četov!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20760,6 +20723,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Toto je len ukážkový čet. Vymaž ho pomocou tlačidla Fire Button v bočnej "
+"ponuke!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20876,8 +20841,7 @@ msgstr "Tento preklad je nesprávny"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
+msgstr "Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21000,8 +20964,8 @@ msgstr "Tipy"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme vám."
-"%2$s"
+"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme "
+"vám.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21049,8 +21013,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete vytlačiť."
-"%3$sKliknite na ikonu tlače.%4$s"
+"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete "
+"vytlačiť.%3$sKliknite na ikonu tlače.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21104,7 +21068,7 @@ msgstr "Dnes"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
+msgstr "Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21523,7 +21487,7 @@ msgstr "Vyskúšaj ich!"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Skús iný model"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21534,7 +21498,7 @@ msgstr "Skúste niečo vyhľadať!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Vyskúšaj návrh"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21569,15 +21533,13 @@ msgstr "Skúste iné kľúčové slová."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
+msgstr "Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
+msgstr "Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21604,7 +21566,7 @@ msgstr "Skús to zadarmo!"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Skús to zadarmo!"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21624,7 +21586,7 @@ msgstr "Vyskúšaj zadarmo! Bezpečná VPN, pokročilá a súkromná AI a ešte 
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Vyskúšaj zadarmo na 7 dní"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21659,7 +21621,7 @@ msgstr ""
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Vyskúšaj uvažovanie"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21900,8 +21862,7 @@ msgstr "Vypnúť:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
+msgstr "Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -21912,7 +21873,7 @@ msgstr "Zapnite Duck Player a sledujte YouTube bez cielených reklám"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Zapnúť prepínač Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21924,8 +21885,7 @@ msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Presná 
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
+msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22131,14 +22091,13 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: https://"
-"duckduckgo.com."
+"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: "
+"https://duckduckgo.com."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr ""
-"Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
+msgstr "Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22151,8 +22110,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
+msgstr "Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22166,8 +22124,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
+msgstr "V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22294,7 +22251,7 @@ msgstr "Odomkni s tvojím predplatným pokročilú AI!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Odomkni pokročilé modely"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22663,7 +22620,7 @@ msgstr "Používať v prehliadači Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Čet z histórie môžeš zmazať pomocou tlačidla Fire Button."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23718,8 +23675,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
+msgstr "Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23858,7 +23814,7 @@ msgstr "Čo vás dnes priviedlo späť?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Čo môžeš urobiť?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24089,8 +24045,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
+msgstr "Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24108,8 +24063,7 @@ msgstr "Kde sledovať <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
+msgstr "Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24149,8 +24103,7 @@ msgstr "Kto sme"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
+msgstr "Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24288,6 +24241,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"S Duck.ai sú tvoje čety anonymizované a nikdy sa nepoužívajú na trénovanie "
+"umelej inteligencie. Zapni alebo vypni kedykoľvek v ponuke „%1$s“."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24722,7 +24677,7 @@ msgstr "Do jednej konverzácie môžeš pripojiť iba %1$s obrázkov."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Naraz môžeš priložiť iba %1$s kariet."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24869,7 +24824,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Všetko je pripravené!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24923,7 +24878,7 @@ msgstr "Zablokoval/-a si 1 stránku"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Zvládol/-a si základy Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25075,8 +25030,7 @@ msgstr "Podľa vášho prehliadača ste tento odkaz už otvorili."
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
+msgstr "Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -25125,8 +25079,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
+msgstr "Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25187,8 +25140,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
+msgstr "Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25333,6 +25285,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Tvoje nastavenia sú uložené, ale vymazaním súborov cookie sa obnovia. "
+"Aktivuj si rozšírenie %1$sDuckDuckGo No AI%2$s, aby sa nastavenia uložili "
+"natrvalo."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25373,8 +25328,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
+msgstr "Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25712,8 +25666,7 @@ msgstr "oficiálnej webovej stránky"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
+msgstr "alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25929,4 +25882,4 @@ msgstr "r"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -122,6 +123,12 @@ msgstr "Pred %1$s dnevi"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Zaznanih: %1$s"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +362,12 @@ msgid "%s used"
 msgstr "Uporabljeno: %1$s"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s ogled"
@@ -489,13 +502,15 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
+msgstr ""
+"%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
+msgstr ""
+"%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -602,6 +617,12 @@ msgstr "DuckDuckGo je v zadnjih 24 urah blokiral 1 poskus"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "Pred 1 dnevom"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -822,7 +843,8 @@ msgstr "Dosežena je 6-urna omejitev uporabe."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -902,7 +924,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
+msgstr ""
+"Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1511,6 +1534,14 @@ msgctxt ""
 "app variant)"
 msgid "Advanced Models"
 msgstr "Napredni modeli"
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2144,7 +2175,8 @@ msgstr "Ali ste prepričani, da želite izbrisati ta pogovor in začeti novega?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
+msgstr ""
+"Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2299,6 +2331,12 @@ msgstr "Vprašaj zasebno"
 msgctxt "Placeholder text user’s chat input"
 msgid "Ask privately"
 msgstr "Vprašaj zasebno"
+
+# smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2491,7 +2529,8 @@ msgstr "Samodejno odgovarjanje"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
+msgstr ""
+"Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2889,7 +2928,8 @@ msgstr "Blokiraj to spletno mesto v vseh rezultatih"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
+msgstr ""
+"Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3771,8 +3811,8 @@ msgstr ""
 "klepeta z umetno inteligenco tretjih oseb, ki podpirajo modele OpenAI, "
 "Anthropic in druge. Če to nastavitev izklopiš, bodo gumbi in povezave za "
 "klepet v iskalniku DuckDuckGo skriti. Vendar pa lahko še vedno dostopaš do "
-"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš "
-"%1$shttps://duck.ai%2$s neposredno."
+"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš %1$shttps://duck."
+"ai%2$s neposredno."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3851,6 +3891,12 @@ msgstr "Klepetajte zasebno z modelom %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Klepetajte zasebno z UI"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4394,7 +4440,8 @@ msgstr "Kliknite %1$stukaj%2$s za prenos razširitve DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
+msgstr ""
+"Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4427,7 +4474,8 @@ msgstr "Kliknite %1$sNastavitve%2$s v spustnem meniju."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
+msgstr ""
+"Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4640,6 +4688,12 @@ msgid "Close"
 msgstr "Zapri"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4682,6 +4736,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Zapri iskanje"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5055,6 +5115,12 @@ msgid "Continue Blocking Ads"
 msgstr "Nadaljuj blokiranje oglasov"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5120,6 +5186,12 @@ msgid "Cookie data:"
 msgstr "Podatki v piškotu:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5158,13 +5230,20 @@ msgstr "Kopiraj"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
+msgstr ""
+"Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopiraj kodo"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5280,6 +5359,12 @@ msgid "Create Image"
 msgstr "Ustvari sliko"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5321,6 +5406,14 @@ msgstr "Ustvaril/-a"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Ustvaril model %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5476,6 +5569,12 @@ msgid "Customize responses"
 msgstr "Prilagodi odzive"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "Prilagoditev te strani"
@@ -5540,7 +5639,8 @@ msgstr "Dosežena je dnevna omejitev"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5760,10 +5860,22 @@ msgid "Delete Server Data?"
 msgstr "Želite izbrisati podatke strežnika?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Izbriši prepis"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5796,6 +5908,12 @@ msgstr "Izbriši sliko"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Želite izbrisati sliko?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6112,6 +6230,12 @@ msgid "Dismiss promotion"
 msgstr "Zavrni promocijo"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6323,6 +6447,12 @@ msgid "Download DuckDuckGo"
 msgstr "Prenesi DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo Browser"
@@ -6489,7 +6619,8 @@ msgstr "Spustite svoje fotografije ali datoteke PDF"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
+msgstr ""
+"Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6535,7 +6666,14 @@ msgstr "pogoji storitve Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
+msgstr ""
+"Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
+
+# smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6575,7 +6713,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
+msgstr ""
+"Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6690,6 +6829,12 @@ msgstr ""
 "natančnosti."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6705,7 +6850,8 @@ msgstr "Duck.ai je nadgrajen!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
+msgstr ""
+"Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6882,7 +7028,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
+msgstr ""
+"DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7236,7 +7383,8 @@ msgstr "Urejanje slike ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
+msgstr ""
+"Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7297,7 +7445,8 @@ msgstr "Omogoči funkcije UI"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
+msgstr ""
+"Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7331,6 +7480,12 @@ msgstr "Omogoči najbolj obiskana spletna mesta"
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Omogoči najbolj obiskana spletna mesta"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7503,7 +7658,8 @@ msgstr "Prepričajte se, da so »Lokacijske storitve« %1$somogočene%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
+msgstr ""
+"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7515,7 +7671,8 @@ msgstr "Preverite, ali je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
+msgstr ""
+"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7539,7 +7696,8 @@ msgstr "Prepričajte se, da ima brskalnik omogočen %1$sdostop do lokacije%2$s."
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
+msgstr ""
+"Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7632,6 +7790,12 @@ msgid "Entertainment guide"
 msgstr "Vodič za zabavo"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Ekvatorialna Gvineja"
 
@@ -7639,7 +7803,8 @@ msgstr "Ekvatorialna Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
+msgstr ""
+"V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7793,6 +7958,18 @@ msgid "Explicit lyrics"
 msgstr "Eksplicitna besedila"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7892,6 +8069,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Brezplačno"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8316,6 +8499,12 @@ msgid "Free Up Storage"
 msgstr "Sprostitev prostora za shranjevanje"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8325,7 +8514,8 @@ msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
+msgstr ""
+"Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8830,6 +9020,12 @@ msgid "Get computer help"
 msgstr "Pridobite računalniško pomoč"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8867,6 +9063,18 @@ msgid "Get the Latest Version"
 msgstr "Pridobite najnovejšo različico"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8887,6 +9095,12 @@ msgstr "Pridobi to pesem na:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Povabite prijatelje in nam pomagajte, da zrastemo!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8940,8 +9154,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve "
-"Duck.ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
+"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve Duck."
+"ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
 "napravo%4$s ter optično preberite to kodo:"
 
 # smartling.placeholder_format=C
@@ -9575,6 +9789,12 @@ msgid "Hide Tips"
 msgstr "Nasveti za skrivanje"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9873,7 +10093,8 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
+msgstr ""
+"Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10320,7 +10541,8 @@ msgstr "V zgornjem meniju izberite %1$sOrodja%2$s > %3$sNastavitve%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
+msgstr ""
+"V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10646,7 +10868,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
+msgstr ""
+"Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10696,7 +10919,8 @@ msgstr "Je hiter, brezplačen in zagotavlja še večjo spletno zaščito."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
+msgstr ""
+"Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11195,6 +11419,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Omogoča anonimno iskanje z DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberija"
 
@@ -11263,6 +11494,12 @@ msgstr "Črtna risba"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Osvojeni lineouti"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12152,7 +12389,8 @@ msgstr "Dosežena je mesečna omejitev"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12314,7 +12552,8 @@ msgstr "Več statističnih podatkov o medaljah je na voljo na %1$s"
 msgctxt ""
 "Note on the Olympics module as to where they can find more information"
 msgid "More medal stats on %solympics.com%s"
-msgstr "Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
+msgstr ""
+"Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
 
 # smartling.placeholder_format=C
 #. A link to more information on a topic. The placeholder is the name of a website. For example 'More on Wikipedia'.
@@ -12359,6 +12598,12 @@ msgstr "Več statističnih podatkov je na voljo na %1$s"
 msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Več kot 20 minut"
+
+# smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12846,6 +13091,12 @@ msgstr "Ne, hvala"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Ne, hvala"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13510,6 +13761,12 @@ msgid "On but no numbers"
 msgstr "Vklopljeno, vendar brez številk"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13621,7 +13878,8 @@ msgstr "Odpri spletno mesto %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
+msgstr ""
+"Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13720,6 +13978,12 @@ msgstr "Odpri predloge za klepet"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Odpri predloge za ustvarjanje in urejanje slik"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14471,10 +14735,22 @@ msgid "Pin"
 msgstr "Pripni"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Pripnite klepete sem iz %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14492,6 +14768,12 @@ msgstr "Roza"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Pripeto"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14532,7 +14814,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
+msgstr ""
+"Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14540,7 +14823,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
+msgstr ""
+"Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14807,6 +15091,12 @@ msgid "Poor formatting"
 msgstr "Slabo oblikovanje"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15013,6 +15303,12 @@ msgstr "Prejšnja slika"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Prejšnji zavihki"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15557,6 +15853,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Umetna inteligenca za sklepanje s srednjo vgrajeno moderacijo"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15589,7 +15897,14 @@ msgstr "Nedavni zavihki"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr "Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
+msgstr ""
+"Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15744,6 +16059,12 @@ msgstr "Ponovi iskanje brez tega spletnega mesta"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Zmanjšaj uporabo"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15904,7 +16225,8 @@ msgstr "Zapomni si mojo izbiro"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
+msgstr ""
+"Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16125,6 +16447,12 @@ msgid "Reset All Settings"
 msgstr "Ponastavi vse nastavitve"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16135,6 +16463,12 @@ msgstr "Ponastavi se čez %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Ločljivost"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16261,7 +16595,8 @@ msgstr "Rezultati ne vključujejo informacij z blokiranih spletnih mest."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
+msgstr ""
+"Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16624,7 +16959,8 @@ msgstr "Shrani do 30 vaših najnovejših klepetov lokalno v vaši napravi."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
+msgstr ""
+"Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16764,7 +17100,8 @@ msgstr "Pomaknite navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
+msgstr ""
+"Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -16834,6 +17171,12 @@ msgstr "Iskanje"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Želite iskati »%1$s« za rezultate, ki so vam bližji?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17207,6 +17550,12 @@ msgstr ""
 "vas ne more videti vaših podatkov, niti mi."
 
 # smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "Security issue"
 msgstr "Varnostna vprašanja"
@@ -17349,8 +17698,8 @@ msgstr "V meniju Safari izberite %1$s»Nastavitev za to spletno mesto ...«%2$s.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Izberite %1$sPo meri%2$s in v vnosno polje vnesite "
-"%3$shttps://duckduckgo.com%4$s"
+"Izberite %1$sPo meri%2$s in v vnosno polje vnesite %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17716,6 +18065,12 @@ msgid "Set as Homepage"
 msgstr "Nastavi kot Domačo stran"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17783,6 +18138,18 @@ msgid "Seychelles"
 msgstr "Sejšeli"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17821,6 +18188,13 @@ msgstr ""
 "Delite lokacijo na ravni mesta z modeli umetne inteligence, da izboljšate "
 "ustreznost. Duck.ai nam ali modelom umetne inteligence nikoli ne razkrije "
 "vaše natančne lokacije."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17879,6 +18253,12 @@ msgstr "Deli URL strani"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Delite pozitivne povratne informacije"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18016,6 +18396,12 @@ msgid "Show Detail"
 msgstr "Prikaži podrobnosti"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "Pokaži DuckAssist <sup>BETA</sup>"
@@ -18024,7 +18410,8 @@ msgstr "Pokaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
+msgstr ""
+"Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18163,6 +18550,12 @@ msgid "Show more"
 msgstr "Pokaži več"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18196,6 +18589,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Prikaži stransko vrstico"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18297,7 +18696,8 @@ msgstr "Prikaže občasne opomnike, da dodate DuckDuckGo v svoje naprave"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
+msgstr ""
+"Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18333,7 +18733,8 @@ msgstr "Prikaže pozdravno sporočilo na vrhu strani z rezultati iskanja"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
+msgstr ""
+"Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18564,6 +18965,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Nekaj je šlo narobe, poskusite znova pozneje."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18653,7 +19060,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
+msgstr ""
+"Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18858,6 +19266,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Nadaljuj znotraj tedenske omejitve"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Začnite iskati!"
@@ -18958,7 +19372,8 @@ msgstr "Ustavi ustvarjanje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
+msgstr ""
+"Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19438,6 +19853,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Preklopite na iskalnik, ki vam ne sledi. Nikoli."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19448,7 +19871,8 @@ msgstr "Preklopljeno na model %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
+msgstr ""
+"S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -19591,6 +20015,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sinhronizacija in varnostno kopiranje trenutno nista na voljo"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19678,6 +20108,22 @@ msgid "Take Back Your Privacy!"
 msgstr "Povrnite si zasebnost!"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19699,8 +20145,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo "
-"Duck.ai."
+"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19965,7 +20411,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
+msgstr ""
+"Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20143,10 +20590,22 @@ msgid "This Month"
 msgstr "Ta mesec"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Ta teden"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20277,6 +20736,22 @@ msgstr "Ta vrsta slike ni podprta, priložite JPG, PNG, WebP ali GIF."
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Te informacije niso uporabne"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20518,7 +20993,8 @@ msgstr "Nasveti"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
+msgstr ""
+"Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20620,6 +21096,12 @@ msgstr "Danes"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Danes"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20841,7 +21323,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
+msgstr ""
+"Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20849,7 +21332,8 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
+msgstr ""
+"Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21031,9 +21515,21 @@ msgid "Try Them Out"
 msgstr "Preizkusite jih"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Preizkusi z iskanjem!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21051,7 +21547,8 @@ msgstr "Poskusi dodati mesto, državo ali poštno številko"
 #. Message to display during errors for users who have AI enabled to encourage them to use that feature while the site is having issues. Example: 'Try asking Duck.ai, our private AI chat service:'
 msgctxt "noresults"
 msgid "Try asking %s, our private AI chat service:"
-msgstr "Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
+msgstr ""
+"Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
 
 # smartling.placeholder_format=C
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
@@ -21083,7 +21580,8 @@ msgstr "Preizkusite omogočiti anonimno lokacijo za natančnejše rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
+msgstr ""
+"Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21100,6 +21598,12 @@ msgid "Try for free"
 msgstr "Preizkusite brezplačno"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21114,6 +21618,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Preizkusite brezplačno! Varen VPN, napredna in zasebna umetna inteligenca "
 "ter še več."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21141,6 +21651,12 @@ msgstr "Preizkusite naš brskalnik,"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Preizkusite našo domačo stran, ki nikoli ne prikazuje teh sporočil:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21221,7 +21737,8 @@ msgstr "Preizkusite nedavno dodana odprtokodna modela Llama 3.1 in Mixtral"
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
+msgstr ""
+"Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21385,7 +21902,14 @@ msgstr "Za natančnejše rezultate vklopite %1$sNatančno lokacijo%2$s."
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
+msgstr ""
+"Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21548,7 +22072,8 @@ msgstr "Povratnih informacij ni mogoče poslati"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
+msgstr ""
+"Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -21595,12 +22120,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
+msgstr ""
+"Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
+msgstr ""
+"Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21747,13 +22274,20 @@ msgstr "Odklenite napredne modele umetne inteligence z naročnino %1$s"
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
+msgstr ""
+"Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Odklenite napredno umetno inteligenco z naročnino!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22094,7 +22628,8 @@ msgstr "Uporabite DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
+msgstr ""
+"Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22117,6 +22652,12 @@ msgstr "Uporabi v brskalniku Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Uporabi v brskalniku Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22663,7 +23204,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
+msgstr ""
+"Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22843,7 +23385,8 @@ msgstr ""
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr "Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
+msgstr ""
+"Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -22896,7 +23439,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
+msgstr ""
+"Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23006,7 +23550,8 @@ msgstr "Dosežena je tedenska omejitev uporabe"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23151,7 +23696,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
+msgstr ""
+"Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -23300,6 +23846,12 @@ msgstr "Kaj vas je najbolj motilo?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Kaj vas je danes prineslo nazaj?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23548,7 +24100,8 @@ msgstr "Kje gledati: <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
+msgstr ""
+"Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23718,6 +24271,14 @@ msgstr "Zmage"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Sneg z dežjem"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24146,6 +24707,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "V enem pogovoru lahko priložite največ toliko slik: %1$s."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24274,7 +24842,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
+msgstr ""
+"Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24285,6 +24854,12 @@ msgid ""
 msgstr ""
 "Ko boste imeli nameščeno najnovejšo različico aplikacije DuckDuckGo, boste "
 "prejemali samodejne posodobitve."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24334,6 +24909,12 @@ msgid "You've blocked 1 site"
 msgstr "Blokirali ste 1 spletno mesto"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24366,7 +24947,8 @@ msgstr "Dosegli ste najdaljše trajanje glasovnega klepeta za eno sejo."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
+msgstr ""
+"Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24734,6 +25316,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Vaših iskanj ni mogoče povezati z vami"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24807,13 +25397,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
+msgstr ""
+"Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
+msgstr ""
+"Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24896,7 +25488,8 @@ msgstr "od %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
+msgstr ""
+"omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25109,7 +25702,8 @@ msgstr "uradno spletno stran"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
+msgstr ""
+"ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25320,3 +25914,9 @@ msgstr "let."
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "leto"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -128,7 +127,7 @@ msgstr "Zaznanih: %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Uporabljenih datotek: %1$s"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,7 +364,7 @@ msgstr "Uporabljeno: %1$s"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s porablja omejitve do 2–5-krat hitreje kot osnovni modeli %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -502,15 +501,13 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
+msgstr "%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
+msgstr "%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -622,7 +619,7 @@ msgstr "Pred 1 dnevom"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "Uporabljena 1 datoteka"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -843,8 +840,7 @@ msgstr "Dosežena je 6-urna omejitev uporabe."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -924,8 +920,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
+msgstr "Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1541,7 +1536,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
+msgstr "Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2175,8 +2170,7 @@ msgstr "Ali ste prepričani, da želite izbrisati ta pogovor in začeti novega?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
+msgstr "Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2336,7 +2330,7 @@ msgstr "Vprašaj zasebno"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Vprašajte zasebno"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2529,8 +2523,7 @@ msgstr "Samodejno odgovarjanje"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
+msgstr "Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2928,8 +2921,7 @@ msgstr "Blokiraj to spletno mesto v vseh rezultatih"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
+msgstr "Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3811,8 +3803,8 @@ msgstr ""
 "klepeta z umetno inteligenco tretjih oseb, ki podpirajo modele OpenAI, "
 "Anthropic in druge. Če to nastavitev izklopiš, bodo gumbi in povezave za "
 "klepet v iskalniku DuckDuckGo skriti. Vendar pa lahko še vedno dostopaš do "
-"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš %1$shttps://duck."
-"ai%2$s neposredno."
+"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš "
+"%1$shttps://duck.ai%2$s neposredno."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3896,7 +3888,7 @@ msgstr "Klepetajte zasebno z UI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Klepetajte zasebno s priljubljenimi umetnimi inteligencami"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4440,8 +4432,7 @@ msgstr "Kliknite %1$stukaj%2$s za prenos razširitve DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
+msgstr "Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4474,8 +4465,7 @@ msgstr "Kliknite %1$sNastavitve%2$s v spustnem meniju."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
+msgstr "Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4691,7 +4681,7 @@ msgstr "Zapri"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Zapri"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4741,7 +4731,7 @@ msgstr "Zapri iskanje"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Zapri drugo mnenje"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5118,7 +5108,7 @@ msgstr "Nadaljuj blokiranje oglasov"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5189,7 +5179,7 @@ msgstr "Podatki v piškotu:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Kopirano"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5230,8 +5220,7 @@ msgstr "Kopiraj"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
+msgstr "Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5243,7 +5232,7 @@ msgstr "Kopiraj kodo"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopiraj povezavo"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5362,7 +5351,7 @@ msgstr "Ustvari sliko"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Ustvari povezavo za skupno rabo"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5414,6 +5403,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Ustvarjanje povezave ustvari kopijo klepeta, ki si jo lahko ogleda vsak, ki "
+"jo odpre."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5572,7 +5563,7 @@ msgstr "Prilagodi odzive"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Prilagodi odzive"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5639,8 +5630,7 @@ msgstr "Dosežena je dnevna omejitev"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5863,7 +5853,7 @@ msgstr "Želite izbrisati podatke strežnika?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Izbriši deljeno povezavo"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5875,7 +5865,7 @@ msgstr "Izbriši prepis"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Izbriši klepet"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5913,7 +5903,7 @@ msgstr "Želite izbrisati sliko?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Izbriši me"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6233,7 +6223,7 @@ msgstr "Zavrni promocijo"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Opusti ogled"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6450,7 +6440,7 @@ msgstr "Prenesi DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Prenesi DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6619,8 +6609,7 @@ msgstr "Spustite svoje fotografije ali datoteke PDF"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
+msgstr "Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -6666,14 +6655,13 @@ msgstr "pogoji storitve Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
+msgstr "Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai zdaj lahko analizira datoteke PDF. Preizkusite!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6713,8 +6701,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
+msgstr "Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6832,7 +6819,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai podpira modele ponudnikov Anthropic, OpenAI in drugih."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6850,8 +6837,7 @@ msgstr "Duck.ai je nadgrajen!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
+msgstr "Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7028,8 +7014,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
+msgstr "DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7383,8 +7368,7 @@ msgstr "Urejanje slike ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
+msgstr "Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7445,8 +7429,7 @@ msgstr "Omogoči funkcije UI"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
+msgstr "Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7485,7 +7468,7 @@ msgstr "Omogoči najbolj obiskana spletna mesta"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Omogoči zdaj"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7658,8 +7641,7 @@ msgstr "Prepričajte se, da so »Lokacijske storitve« %1$somogočene%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
+msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7671,8 +7653,7 @@ msgstr "Preverite, ali je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
+msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7696,8 +7677,7 @@ msgstr "Prepričajte se, da ima brskalnik omogočen %1$sdostop do lokacije%2$s."
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
+msgstr "Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7793,7 +7773,7 @@ msgstr "Vodič za zabavo"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Celoten klepet"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7803,8 +7783,7 @@ msgstr "Ekvatorialna Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
+msgstr "V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -7961,13 +7940,13 @@ msgstr "Eksplicitna besedila"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Razišči Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Razišči Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8074,7 +8053,7 @@ msgstr "Brezplačno"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "BREZPLAČNO IN NEOBVEZNO"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8502,7 +8481,7 @@ msgstr "Sprostitev prostora za shranjevanje"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Brezplačno in vedno zasebno"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8514,8 +8493,7 @@ msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
+msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9023,7 +9001,7 @@ msgstr "Pridobite računalniško pomoč"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Pridobite višje omejitve uporabe z naročnino na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9066,13 +9044,15 @@ msgstr "Pridobite najnovejšo različico"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Pridobite aplikacijo"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Prenesite brezplačni brskalnik DuckDuckGo %1$sza blokiranje oglasov na "
+"YouTubu.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9100,7 +9080,7 @@ msgstr "Povabite prijatelje in nam pomagajte, da zrastemo!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Seznam za začetek"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9154,8 +9134,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve Duck."
-"ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
+"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve "
+"Duck.ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
 "napravo%4$s ter optično preberite to kodo:"
 
 # smartling.placeholder_format=C
@@ -9792,7 +9772,7 @@ msgstr "Nasveti za skrivanje"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Skrij vadnico"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10093,8 +10073,7 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
+msgstr "Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10541,8 +10520,7 @@ msgstr "V zgornjem meniju izberite %1$sOrodja%2$s > %3$sNastavitve%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
+msgstr "V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -10868,8 +10846,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
+msgstr "Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -10919,8 +10896,7 @@ msgstr "Je hiter, brezplačen in zagotavlja še večjo spletno zaščito."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
+msgstr "Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11423,7 +11399,7 @@ msgstr "Omogoča anonimno iskanje z DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11499,7 +11475,7 @@ msgstr "Osvojeni lineouti"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Povezava poteče čez 7 dni."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12389,8 +12365,7 @@ msgstr "Dosežena je mesečna omejitev"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12552,8 +12527,7 @@ msgstr "Več statističnih podatkov o medaljah je na voljo na %1$s"
 msgctxt ""
 "Note on the Olympics module as to where they can find more information"
 msgid "More medal stats on %solympics.com%s"
-msgstr ""
-"Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
+msgstr "Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
 
 # smartling.placeholder_format=C
 #. A link to more information on a topic. The placeholder is the name of a website. For example 'More on Wikipedia'.
@@ -12603,7 +12577,7 @@ msgstr "Več kot 20 minut"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Več nasvetov"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13096,7 +13070,7 @@ msgstr "Ne, hvala"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Ne, hvala"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13764,7 +13738,7 @@ msgstr "Vklopljeno, vendar brez številk"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Uvajanje je končano"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13878,8 +13852,7 @@ msgstr "Odpri spletno mesto %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
+msgstr "Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13983,7 +13956,7 @@ msgstr "Odpri predloge za ustvarjanje in urejanje slik"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Odpri seznam za začetek"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14738,7 +14711,7 @@ msgstr "Pripni"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Pripni klepet"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14750,7 +14723,7 @@ msgstr "Pripnite klepete sem iz %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Pripni me"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14773,7 +14746,7 @@ msgstr "Pripeto"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Pripeti klepeti se bodo pojavili na vrhu nedavnih klepetov."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14814,8 +14787,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
+msgstr "Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14823,8 +14795,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
+msgstr "Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15095,6 +15066,8 @@ msgstr "Slabo oblikovanje"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Na voljo so priljubljeni modeli umetne inteligence. Račun ni potreben. "
+"Klepeti, ki jih anonimiziramo."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15308,7 +15281,7 @@ msgstr "Prejšnji zavihki"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Prejšnji nasveti"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15856,13 +15829,13 @@ msgstr "Umetna inteligenca za sklepanje s srednjo vgrajeno moderacijo"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Razmišljanje lahko ponudi boljše odgovore na zapletena vprašanja."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15897,14 +15870,13 @@ msgstr "Nedavni zavihki"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr ""
-"Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
+msgstr "Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Nedavni klepeti"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16064,7 +16036,7 @@ msgstr "Zmanjšaj uporabo"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Zmanjšajte uporabo z učinkovitejšim modelom"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16225,8 +16197,7 @@ msgstr "Zapomni si mojo izbiro"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
+msgstr "Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16450,7 +16421,7 @@ msgstr "Ponastavi vse nastavitve"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Ponastavi vadnico"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16468,7 +16439,7 @@ msgstr "Ločljivost"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Odziv"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16595,8 +16566,7 @@ msgstr "Rezultati ne vključujejo informacij z blokiranih spletnih mest."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
+msgstr "Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16959,8 +16929,7 @@ msgstr "Shrani do 30 vaših najnovejših klepetov lokalno v vaši napravi."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
+msgstr "Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17100,8 +17069,7 @@ msgstr "Pomaknite navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
+msgstr "Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17176,7 +17144,7 @@ msgstr "Želite iskati »%1$s« za rezultate, ki so vam bližji?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Preklop za iskanje in Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17553,7 +17521,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Varno shranjeno na našem šifriranem strežniku."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17698,8 +17666,8 @@ msgstr "V meniju Safari izberite %1$s»Nastavitev za to spletno mesto ...«%2$s.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Izberite %1$sPo meri%2$s in v vnosno polje vnesite %3$shttps://duckduckgo."
-"com%4$s"
+"Izberite %1$sPo meri%2$s in v vnosno polje vnesite "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18068,7 +18036,7 @@ msgstr "Nastavi kot Domačo stran"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Nastavi ton in slog odzivov Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18141,13 +18109,13 @@ msgstr "Sejšeli"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Deli"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Deli"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18194,7 +18162,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Deli klepet"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18258,7 +18226,7 @@ msgstr "Delite pozitivne povratne informacije"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Obseg deljenja"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18399,7 +18367,7 @@ msgstr "Prikaži podrobnosti"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Prikaži vadnico za Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18410,8 +18378,7 @@ msgstr "Pokaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
+msgstr "Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18553,7 +18520,7 @@ msgstr "Pokaži več"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Pokaži več modelov"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18594,7 +18561,7 @@ msgstr "Prikaži stransko vrstico"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18696,8 +18663,7 @@ msgstr "Prikaže občasne opomnike, da dodate DuckDuckGo v svoje naprave"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
+msgstr "Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18733,8 +18699,7 @@ msgstr "Prikaže pozdravno sporočilo na vrhu strani z rezultati iskanja"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
+msgstr "Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18968,7 +18933,7 @@ msgstr "Nekaj je šlo narobe, poskusite znova pozneje."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Nekaj je šlo narobe. Poskusite znova."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19060,8 +19025,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
+msgstr "Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19269,7 +19233,7 @@ msgstr "Nadaljuj znotraj tedenske omejitve"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Začni nov klepet"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19372,8 +19336,7 @@ msgstr "Ustavi ustvarjanje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
+msgstr "Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -19858,7 +19821,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Preklopi na to drugo mnenje"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19871,8 +19834,7 @@ msgstr "Preklopljeno na model %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
+msgstr "S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20018,7 +19980,7 @@ msgstr "Sinhronizacija in varnostno kopiranje trenutno nista na voljo"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sinhronizirajte klepete med napravami"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20114,6 +20076,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Vzemite Duck.ai s seboj povsod. Zagotovite si ga vgrajenega v našo "
+"brezplačno aplikacijo za hitrejši dostop, kjer koli ste."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20122,6 +20086,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Vzemite Duck.ai s seboj povsod. Zagotovite si ga vgrajenega v naš brezplačni "
+"brskalnik za hitrejši dostop, kjer koli brskate."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20145,8 +20111,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo Duck."
-"ai."
+"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20411,8 +20377,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
+msgstr "Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20593,7 +20558,7 @@ msgstr "Ta mesec"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Ta odziv"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20605,7 +20570,7 @@ msgstr "Ta teden"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Ta klepet ostane v Duck.ai in je zaseben za vas."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20744,6 +20709,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"To je le vzorčni klepet. Odprite njegov meni (tri pike) in izberite Pripni, "
+"da bo ostal na vrhu vaših klepetov!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20752,6 +20719,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"To je le vzorčni klepet. Uporabite gumb Fire Button v stranskem meniju, da "
+"ga izbrišete."
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20993,8 +20962,7 @@ msgstr "Nasveti"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
+msgstr "Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21102,6 +21070,8 @@ msgstr "Danes"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Preklopite, da preizkusite zasebni klepet z umetno inteligenco ali pa ga "
+"%1$sonemogočite v meniju %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21323,8 +21293,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
+msgstr "Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21332,8 +21301,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
+msgstr "Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21518,7 +21486,7 @@ msgstr "Preizkusite jih"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Poskusite drug model"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21529,7 +21497,7 @@ msgstr "Preizkusi z iskanjem!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Poskusite predlog"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21547,8 +21515,7 @@ msgstr "Poskusi dodati mesto, državo ali poštno številko"
 #. Message to display during errors for users who have AI enabled to encourage them to use that feature while the site is having issues. Example: 'Try asking Duck.ai, our private AI chat service:'
 msgctxt "noresults"
 msgid "Try asking %s, our private AI chat service:"
-msgstr ""
-"Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
+msgstr "Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
 
 # smartling.placeholder_format=C
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
@@ -21580,8 +21547,7 @@ msgstr "Preizkusite omogočiti anonimno lokacijo za natančnejše rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
+msgstr "Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21601,7 +21567,7 @@ msgstr "Preizkusite brezplačno"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Preizkusite brezplačno"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21623,7 +21589,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Preizkušajte brezplačno 7 dni"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21656,7 +21622,7 @@ msgstr "Preizkusite našo domačo stran, ki nikoli ne prikazuje teh sporočil:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Preizkusite razmišljanje"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21737,8 +21703,7 @@ msgstr "Preizkusite nedavno dodana odprtokodna modela Llama 3.1 in Mixtral"
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
+msgstr "Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -21902,14 +21867,13 @@ msgstr "Za natančnejše rezultate vklopite %1$sNatančno lokacijo%2$s."
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
+msgstr "Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Vklopi preklopnik za Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22072,8 +22036,7 @@ msgstr "Povratnih informacij ni mogoče poslati"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
+msgstr "Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -22120,14 +22083,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
+msgstr "Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
+msgstr "Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22274,8 +22235,7 @@ msgstr "Odklenite napredne modele umetne inteligence z naročnino %1$s"
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
+msgstr "Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -22287,7 +22247,7 @@ msgstr "Odklenite napredno umetno inteligenco z naročnino!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Odklenite napredne modele"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22628,8 +22588,7 @@ msgstr "Uporabite DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
+msgstr "Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22657,7 +22616,7 @@ msgstr "Uporabi v brskalniku Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Uporabite gumb Fire Button za brisanje klepeta iz zgodovine."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23204,8 +23163,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
+msgstr "Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23385,8 +23343,7 @@ msgstr ""
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr ""
-"Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
+msgstr "Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -23439,8 +23396,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
+msgstr "Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23550,8 +23506,7 @@ msgstr "Dosežena je tedenska omejitev uporabe"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -23696,8 +23651,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
+msgstr "Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -23851,7 +23805,7 @@ msgstr "Kaj vas je danes prineslo nazaj?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Kaj znaš?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24100,8 +24054,7 @@ msgstr "Kje gledati: <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
+msgstr "Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24279,6 +24232,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Z Duck.ai so vaši klepeti anonimizirani in se nikoli ne uporabljajo za "
+"učenje UI. Kadar koli ga vklopite ali izklopite v meniju »%1$s«."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24711,7 +24666,7 @@ msgstr "V enem pogovoru lahko priložite največ toliko slik: %1$s."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Naenkrat lahko priložite samo toliko zavihkov: %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24842,8 +24797,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
+msgstr "Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24859,7 +24813,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Vse je pripravljeno!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24912,7 +24866,7 @@ msgstr "Blokirali ste 1 spletno mesto"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Osvojili ste osnove Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24947,8 +24901,7 @@ msgstr "Dosegli ste najdaljše trajanje glasovnega klepeta za eno sejo."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
+msgstr "Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25322,6 +25275,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Vaše nastavitve so shranjene, vendar jih bo brisanje piškotkov ponastavilo. "
+"Omogočite razširitev %1$sDuckDuckGo No AI%2$s, da bo to trajno."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25397,15 +25352,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
+msgstr "Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
+msgstr "Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25488,8 +25441,7 @@ msgstr "od %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
+msgstr "omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25702,8 +25654,7 @@ msgstr "uradno spletno stran"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
+msgstr "ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25919,4 +25870,4 @@ msgstr "leto"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/sq_AL/LC_MESSAGES/duckduckgo.po
+++ b/locales/sq_AL/LC_MESSAGES/duckduckgo.po
@@ -102,6 +102,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "U pikas %s"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -283,6 +288,11 @@ msgstr "%s përpjekje gjurmimi të bllokuara"
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -486,6 +496,11 @@ msgstr "1 përpjekje e bllokuar nga DuckDuckGo gjatë 24 orëve të fundit"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 ditë më parë"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1228,6 +1243,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Reklamoni Te Përfundime Kërkimesh"
@@ -1856,6 +1878,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3110,6 +3137,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3745,6 +3777,11 @@ msgstr "Vizatim"
 msgid "Close"
 msgstr "Mbylle"
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3780,6 +3817,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4088,6 +4130,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4142,6 +4189,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr "Të dhëna cookie-sh:"
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4180,6 +4232,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4276,6 +4333,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4310,6 +4372,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4435,6 +4504,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4671,9 +4745,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4701,6 +4785,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4954,6 +5043,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5122,6 +5216,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5298,6 +5397,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5405,6 +5509,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5909,6 +6018,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Aktivizo Sajtet Më të Vizituar"
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6157,6 +6271,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6291,6 +6410,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6375,6 +6504,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6711,6 +6845,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7133,6 +7272,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7164,6 +7308,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7181,6 +7335,11 @@ msgstr "Merreni këtë këngë prej:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Bëjini shokët tuaj të hidhen te ne dhe ndihmonani të fuqizohemi!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr "Ganë"
@@ -7733,6 +7892,11 @@ msgstr "Fshihi Hapat"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -9070,6 +9234,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Ju lejon të kërkoni në mënyrë anonime me DuckDuckGo-në"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9125,6 +9295,11 @@ msgstr "Vizatim Vijash"
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -10024,6 +10199,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Më tepër se 20 minuta"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10418,6 +10598,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10969,6 +11154,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "On, por pa numra"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11145,6 +11335,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11750,9 +11945,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11767,6 +11972,11 @@ msgstr "Rozë"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12026,6 +12236,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12196,6 +12411,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12640,6 +12860,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12667,6 +12897,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12789,6 +13024,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -13098,6 +13338,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Rikthe te Parazgjedhjet Krejt Rregullimet"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -13106,6 +13351,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13672,6 +13922,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr "Të kërkohet me %s për të gjetur përfundime më afër jush?"
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Kërkoni Në Mënyrë Anonime"
 
@@ -13957,6 +14212,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14382,6 +14642,11 @@ msgstr "Caktojeni si Motorin Parazgjedhje të Kërkimeve"
 msgid "Set as Homepage"
 msgstr "Caktojeni si Faqen hyrëse"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14436,6 +14701,16 @@ msgstr "Rregullimet u përditësuan"
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14465,6 +14740,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14514,6 +14795,11 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Jepni përshtypje pozitive"
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
@@ -14625,6 +14911,11 @@ msgstr "Shfaq Bookmarklet-in dhe të Dhëna Rregullimesh"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Shfaq Hollësi"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14748,6 +15039,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14776,6 +15072,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -15079,6 +15380,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15315,6 +15621,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15794,6 +16105,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Hidhuni te motori i kërkimeve që s’ju gjurmon. Kurrë."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15906,6 +16224,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15976,6 +16299,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Rimerrni Privatësinë Tuaj!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16356,9 +16693,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16460,6 +16807,20 @@ msgstr ""
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Ky informacion s’qe i dobishëm"
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
@@ -16720,6 +17081,11 @@ msgstr "Sot"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -17059,9 +17425,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Provoni një kërkim!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -17116,6 +17492,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -17126,6 +17507,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -17149,6 +17535,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Provoni faqen tonë hyrëse, e cila s’i shfaq kurrë këto mesazhe:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17348,6 +17739,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17651,6 +18047,11 @@ msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr ""
 
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -17947,6 +18348,11 @@ msgstr "Përdoreni në Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Përdoreni në Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18887,6 +19293,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Ç’ju ripruri sot?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19229,6 +19640,13 @@ msgstr "Fitore"
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19577,6 +19995,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19687,6 +20111,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19726,6 +20155,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -20036,6 +20470,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20514,6 +20955,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "vt"
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
 
 #~ msgctxt "SERP footer content"
 #~ msgid "%s Billion Searches"

--- a/locales/sr_RS/LC_MESSAGES/duckduckgo.po
+++ b/locales/sr_RS/LC_MESSAGES/duckduckgo.po
@@ -107,6 +107,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "Откривен је %s"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -288,6 +293,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -487,6 +497,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "пре 1 дана"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1228,6 +1243,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1857,6 +1879,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3104,6 +3131,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3712,6 +3744,11 @@ msgstr "Клипарт"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3747,6 +3784,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4054,6 +4096,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4108,6 +4155,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr "Подаци о колачићима:"
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4145,6 +4197,11 @@ msgstr "Копирај и налепи %sо:подешавањима#претр�
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4241,6 +4298,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4275,6 +4337,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4400,6 +4469,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4636,9 +4710,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4666,6 +4750,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4919,6 +5008,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5085,6 +5179,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5260,6 +5359,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5367,6 +5471,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5866,6 +5975,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6111,6 +6225,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6244,6 +6363,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6325,6 +6454,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6658,6 +6792,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7079,6 +7218,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7110,6 +7254,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7128,6 +7282,11 @@ msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr ""
 "Препоручите пријатељима да промене претраживач и помозите нам да растемо!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7679,6 +7838,11 @@ msgstr "Сакриј кораке"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -9002,6 +9166,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Допушта вам да претражујете анонимно уз DuckDuckGo"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9057,6 +9227,11 @@ msgstr "Цртање линија"
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9957,6 +10132,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Више од 20 минута"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10351,6 +10531,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10901,6 +11086,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Укључи али без бројева"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11073,6 +11263,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11678,9 +11873,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11695,6 +11900,11 @@ msgstr "Розе"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11951,6 +12161,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12120,6 +12335,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12562,6 +12782,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12589,6 +12819,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12711,6 +12946,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -13013,6 +13253,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Ресетуј сва подешавања"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -13021,6 +13266,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13582,6 +13832,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Претражуј анонимно"
 
@@ -13867,6 +14122,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14271,6 +14531,11 @@ msgstr "‎Постави као подразумевани прегледник
 msgid "Set as Homepage"
 msgstr "Постави као почетну страницу"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14324,6 +14589,16 @@ msgstr "Подешавања су ажурирана"
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14353,6 +14628,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14401,6 +14682,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14513,6 +14799,11 @@ msgstr "Приказ забелешки и подешавања"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Прикажи детаље"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14636,6 +14927,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14664,6 +14960,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14967,6 +15268,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15199,6 +15505,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15677,6 +15988,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Пређите на прегледник који вас не прати. Никада."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15789,6 +16107,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15859,6 +16182,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Повратите вашу приватност!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16235,9 +16572,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16338,6 +16685,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16600,6 +16961,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16937,9 +17303,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Пробајте претрагу!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16993,6 +17369,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -17003,6 +17384,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -17026,6 +17412,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Пробајте нашу почетну страницу која никад не приказује ове поруке:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17225,6 +17616,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17513,6 +17909,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17810,6 +18211,11 @@ msgstr "Користи у Фајерфокс претраживачу"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Користи у Сафари претраживачу"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18736,6 +19142,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Шта је утицало да дођете поново код нас данас?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19078,6 +19489,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19425,6 +19843,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19533,6 +19957,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19571,6 +20000,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19879,6 +20313,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20352,6 +20793,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "год"
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
 
 #~ msgctxt "SERP footer content"
 #~ msgid "%s Billion Searches"

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,8 @@ msgstr "!Bang-sökgenvägar"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
+msgstr ""
+"”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -122,6 +123,12 @@ msgstr "%1$s dagar sedan"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s identifierades"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +362,12 @@ msgid "%s used"
 msgstr "%1$s använt"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s visning"
@@ -416,7 +429,8 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
+msgstr ""
+"%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -596,6 +610,12 @@ msgstr "1 försök blockerat av DuckDuckGo under de senaste 24 timmarna"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 dag sedan"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1293,7 +1313,8 @@ msgstr "Installera tillägget DuckDuckGo"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
+msgstr ""
+"Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1508,6 +1529,14 @@ msgid "Advanced Models"
 msgstr "Avancerade modeller"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Annonsera på söksidan"
@@ -1541,7 +1570,8 @@ msgstr "Afrikaans"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
+msgstr ""
+"Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
@@ -1791,7 +1821,8 @@ msgstr "Vill du tillåta anonym filgranskning för den här chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
+msgstr ""
+"Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2124,19 +2155,22 @@ msgstr "Är du fortfarande där?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
+msgstr ""
+"Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Är du säker på att du vill rensa den här konversationen och starta en ny?"
+msgstr ""
+"Är du säker på att du vill rensa den här konversationen och starta en ny?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
+msgstr ""
+"Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2293,6 +2327,12 @@ msgid "Ask privately"
 msgstr "Fråga privat"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2343,11 +2383,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist är en valbar funktion i våra sökresultat som anonymt kan generera "
-"AI-assisterade svar på sökfrågor. För att göra detta skannar den webben "
-"efter relevant innehåll och använder sedan AI-driven naturlig språkteknologi "
-"för att generera ett kort svar baserat på relevant information som hittats. "
-"Det är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
+"Assist är en valbar funktion i våra sökresultat som anonymt kan generera AI-"
+"assisterade svar på sökfrågor. För att göra detta skannar den webben efter "
+"relevant innehåll och använder sedan AI-driven naturlig språkteknologi för "
+"att generera ett kort svar baserat på relevant information som hittats. Det "
+"är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
 "källor och baseras på %1$sgenomsökning av webben%2$s."
 
 # smartling.placeholder_format=C
@@ -2439,7 +2479,8 @@ msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten avslutats."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
+msgstr ""
+"Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2480,7 +2521,8 @@ msgstr "Autosvar"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
+msgstr ""
+"Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3118,8 +3160,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Surfa som vanligt medan vi ger dig integritetsskydd. Vi har förenat vår "
-"sökmotor, spårningsblockerare och tvingande kryptering i ett "
-"%1$s%2$s-tillägg%3$s."
+"sökmotor, spårningsblockerare och tvingande kryptering i ett %1$s%2$s-"
+"tillägg%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3753,12 +3795,12 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med "
-"AI-chattmodeller från tredje part med stöd för modeller från OpenAI, "
-"Anthropic och fler. Om du stänger av den här inställningen döljs "
-"chattknappar och länkar på DuckDuckGo Search. Du kan dock fortfarande komma "
-"åt chatten när den här inställningen är avstängd genom att gå till "
-"%1$shttps://duck.ai%2$s direkt."
+"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med AI-"
+"chattmodeller från tredje part med stöd för modeller från OpenAI, Anthropic "
+"och fler. Om du stänger av den här inställningen döljs chattknappar och "
+"länkar på DuckDuckGo Search. Du kan dock fortfarande komma åt chatten när "
+"den här inställningen är avstängd genom att gå till %1$shttps://duck.ai%2$s "
+"direkt."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3837,6 +3879,12 @@ msgstr "Chatta privat med %1$s"
 msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr "Chatta privat med AI"
+
+# smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3992,7 +4040,8 @@ msgstr "Kontrollera stavningen"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
+msgstr ""
+"Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4415,7 +4464,8 @@ msgstr "Klicka på %1$sInställningar%2$s i rullgardinsmenyn."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
+msgstr ""
+"Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4628,6 +4678,12 @@ msgid "Close"
 msgstr "Stäng"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4670,6 +4726,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Stäng sökning"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5043,6 +5105,12 @@ msgid "Continue Blocking Ads"
 msgstr "Fortsätt blockera annonser"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5108,6 +5176,12 @@ msgid "Cookie data:"
 msgstr "Cookie-uppgifter:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5153,6 +5227,12 @@ msgstr "Kopiera och klistra in %1$sabout:preferences#search%2$s i adressfältet"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kopiera kod"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5270,6 +5350,12 @@ msgid "Create Image"
 msgstr "Skapa bild"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5311,6 +5397,14 @@ msgstr "Skapad av"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Skapad av %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5464,6 +5558,12 @@ msgstr "Anpassa svar"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Anpassa svar"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5752,10 +5852,22 @@ msgid "Delete Server Data?"
 msgstr "Radera serverdata?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Ta bort avskrift"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5788,6 +5900,12 @@ msgstr "Ta bort bilden"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Ta bort bild?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5915,7 +6033,8 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
+msgstr ""
+"Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6098,6 +6217,12 @@ msgid "Dismiss promotion"
 msgstr "Stäng kampanj"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6202,7 +6327,8 @@ msgstr "Ser du inte DuckDuckGo i listan?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
+msgstr ""
+"Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6250,8 +6376,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan "
-"AI-funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
+"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan AI-"
+"funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6306,6 +6432,12 @@ msgstr "Nedladdning klar"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Ladda ner DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6523,6 +6655,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai av DuckDuckGo. Privat AI-chatt. Gratis."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6626,8 +6764,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai låter dig chatta privat med populära AI-modeller. Att inaktivera det "
-"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka "
-"%1$sduck.ai%2$s direkt."
+"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka %1$sduck."
+"ai%2$s direkt."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6676,6 +6814,12 @@ msgstr ""
 "för korrekthet."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6701,9 +6845,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym "
-"AI-chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, "
-"AI-modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
+"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym AI-"
+"chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, AI-"
+"modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6872,7 +7016,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
+msgstr ""
+"DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7318,6 +7463,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "Aktivera de mest besökta webbplatserna"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7615,6 +7766,12 @@ msgid "Entertainment guide"
 msgstr "Guide till underhållning"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Equatorial Guinea"
 msgstr "Ekvatorialguinea"
 
@@ -7713,7 +7870,8 @@ msgstr "Förklara det accepterade svaret med enkla ord."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
+msgstr ""
+"Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7774,6 +7932,18 @@ msgstr "Stötande innehåll"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Stötande låttexter"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7877,6 +8047,12 @@ msgid "FREE"
 msgstr "Gratis"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7932,7 +8108,8 @@ msgstr "Feedback har skickats"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
+msgstr ""
+"Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8086,7 +8263,8 @@ msgstr "Hitta <b>%1$s</b> i din nedladdningsmapp"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
+msgstr ""
+"Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8123,7 +8301,8 @@ msgstr "Hitta sökresultat närmare dig."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
+msgstr ""
+"Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8290,6 +8469,12 @@ msgid "Free Up Storage"
 msgstr "Frigör lagring"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8299,7 +8484,8 @@ msgstr "Kostnadsfria och privata chattar, anonymiserade av oss"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
+msgstr ""
+"Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8778,9 +8964,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Få tillgång till avancerade AI-modeller i Duck.ai med ett "
-"DuckDuckGo-abonnemang, som även inkluderar vårt VPN och andra premiumskydd "
-"för integritet."
+"Få tillgång till avancerade AI-modeller i Duck.ai med ett DuckDuckGo-"
+"abonnemang, som även inkluderar vårt VPN och andra premiumskydd för "
+"integritet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8804,6 +8990,12 @@ msgstr "Hitta svar på DuckDuckGos hjälpsidor."
 msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr "Få hjälp med datorn"
+
+# smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8843,6 +9035,18 @@ msgid "Get the Latest Version"
 msgstr "Hämta den senaste versionen"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8863,6 +9067,12 @@ msgstr "Skaffa den här låten på:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Få dina vänner att byta och hjälp oss växa!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9207,7 +9417,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
+msgstr ""
+"Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9548,6 +9759,12 @@ msgstr "Dölj steg"
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
 msgstr "Dölj tips"
+
+# smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10088,7 +10305,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
+msgstr ""
+"Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10668,7 +10886,8 @@ msgstr "Det är snabbt, gratis och ger dig ännu mer skydd online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
+msgstr ""
+"Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11167,6 +11386,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Låter dig söka anonymt med DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberia"
 
@@ -11237,6 +11463,12 @@ msgid "Lineouts Won"
 msgstr "Vunna lineouts"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Typsnitt för länk:"
@@ -11250,7 +11482,8 @@ msgstr "Länkar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
+msgstr ""
+"Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11361,7 +11594,8 @@ msgstr "Läser in fler sökresultat med bilder när du skrollar"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
+msgstr ""
+"Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12329,6 +12563,12 @@ msgid "More than 20 minutes"
 msgstr "Mer än 20 minuter"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12649,11 +12889,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nya promptar och svar krypteras och lagras tillfälligt på en "
-"DuckDuckGo-server efter att de har skickats, så att du kan återställa "
-"chatten om din internetanslutning bryts. Om du inaktiverar chatthistoriken "
-"raderas fästa chattar och tillfällig lagring av nya promptar och svar "
-"inaktiveras."
+"Nya promptar och svar krypteras och lagras tillfälligt på en DuckDuckGo-"
+"server efter att de har skickats, så att du kan återställa chatten om din "
+"internetanslutning bryts. Om du inaktiverar chatthistoriken raderas fästa "
+"chattar och tillfällig lagring av nya promptar och svar inaktiveras."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12815,6 +13054,12 @@ msgstr "Nej tack"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Nej tack"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13479,6 +13724,12 @@ msgid "On but no numbers"
 msgstr "På men utan nummer"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13689,6 +13940,12 @@ msgstr "Öppna chattförslag"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Öppna förslag på att skapa och redigera bilder"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14437,10 +14694,22 @@ msgid "Pin"
 msgstr "Fäst"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Fäst chattar här från %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14458,6 +14727,12 @@ msgstr "Rosa"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Fäst"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14498,7 +14773,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Lös följande utmaning för att bekräfta att prompten görs av en människa."
+msgstr ""
+"Lös följande utmaning för att bekräfta att prompten görs av en människa."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14506,7 +14782,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Lös följande utmaning för att bekräfta att sökningen görs av en människa."
+msgstr ""
+"Lös följande utmaning för att bekräfta att sökningen görs av en människa."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14775,6 +15052,12 @@ msgid "Poor formatting"
 msgstr "Dålig formatering"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14981,6 +15264,12 @@ msgstr "Föregående bild"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Föregående flikar"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15275,7 +15564,8 @@ msgstr "Fråga mig"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Be mig använda min ungefärliga plats för att få sökresultat i närheten."
+msgstr ""
+"Be mig använda min ungefärliga plats för att få sökresultat i närheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15521,6 +15811,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Resonerande AI med medelhög modereringsnivå"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15556,14 +15858,20 @@ msgid "Recent chat storage can be adjusted in %s."
 msgstr "Lagring av senaste chattar kan justeras i %1$s."
 
 # smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
 msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på "
-"DuckDuckGo-servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
+"servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15572,8 +15880,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på "
-"DuckDuckGo-servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
+"servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15708,6 +16016,12 @@ msgstr "Gör om sökningen utan den här webbplatsen"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Minska användning"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16085,6 +16399,12 @@ msgid "Reset All Settings"
 msgstr "Återställ alla inställningar"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16095,6 +16415,12 @@ msgstr "Återställs om %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Upplösning"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16588,7 +16914,8 @@ msgstr "Spara upp till 30 av dina senaste chattar lokalt på din enhet."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
+msgstr ""
+"Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16765,13 +17092,15 @@ msgstr "Skrolla nedåt och leta reda på %1$sdin webbläsare%2$s i listan."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
+msgstr ""
+"Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
+msgstr ""
+"Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16794,6 +17123,12 @@ msgstr "Sök"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Vill du söka efter %1$s för att hitta resultat närmare dig?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17107,7 +17442,8 @@ msgstr "En andra åsikt"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
+msgstr ""
+"Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17116,8 +17452,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17126,8 +17462,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17146,8 +17482,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Lagra dina chattar på ett säkert sätt på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra dina chattar på ett säkert sätt på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17164,6 +17500,12 @@ msgid ""
 msgstr ""
 "Lagras säkert på DuckDuckGos server med end-to-end-kryptering. Ingen annan "
 "än du kan se dina uppgifter, inte ens vi."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17672,6 +18014,12 @@ msgid "Set as Homepage"
 msgstr "Använd som startsida"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17691,7 +18039,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
+msgstr ""
+"Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17737,6 +18086,18 @@ msgid "Seychelles"
 msgstr "Seychellerna"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17774,6 +18135,13 @@ msgid ""
 msgstr ""
 "Dela en plats på ortnivå med AI-modellerna för att öka relevansen. Duck.ai "
 "avslöjar aldrig din exakta plats för oss själva eller AI-modellerna."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17832,6 +18200,12 @@ msgstr "Dela sidans URL"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Dela positiv feedback"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17967,6 +18341,12 @@ msgstr "Visa bokmärkta data och inställningsdata"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Visa mer info"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18116,6 +18496,12 @@ msgid "Show more"
 msgstr "Visa mer"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18149,6 +18535,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Visa sidofält"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18241,12 +18633,14 @@ msgstr "Visar mest besökta länkar i ny flik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
+msgstr ""
+"Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
+msgstr ""
+"Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18264,7 +18658,8 @@ msgstr "Visar sidnummer där sidan med sökresultat bryts"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
+msgstr ""
+"Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18290,7 +18685,8 @@ msgstr "Visar välkomstmeddelande högst upp på sidan med sökresultat"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
+msgstr ""
+"Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18519,6 +18915,12 @@ msgstr "Något gick fel när Sync & Backup skulle aktiveras. Försök igen."
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Något gick fel. Försök igen senare."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18815,6 +19217,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Börja använda veckogränsen"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Börja söka!"
@@ -19093,7 +19501,8 @@ msgstr "Förslag på rubrik för ett blogginlägg"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
+msgstr ""
+"Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19393,6 +19802,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Byt till en sökmotor som inte spårar dig. Någonsin."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19543,6 +19960,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Sync & Backup är inte tillgängligt just nu"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19628,6 +20051,22 @@ msgstr "Tadzjikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Ta tillbaka din integritet!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20016,7 +20455,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
+msgstr ""
+"Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20096,10 +20536,22 @@ msgid "This Month"
 msgstr "Den här månaden"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Denna vecka"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20230,6 +20682,22 @@ msgid "This information isn’t useful"
 msgstr "Den här informationen är inte användbar"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20276,8 +20744,8 @@ msgstr "Denna sida kräver javascript för att fungera."
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
 msgstr ""
-"Innehållet på den här sidan kommer att skickas med ditt meddelande till "
-"Duck.ai"
+"Innehållet på den här sidan kommer att skickas med ditt meddelande till Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20350,7 +20818,8 @@ msgstr "Denna video kan ännu inte visas här. Du kan titta på den på %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
+msgstr ""
+"Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20535,8 +21004,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"För att överföra din chatthistorik till Duck.ai, uppdatera "
-"DuckDuckGo-webbläsaren till den senaste versionen och försök igen."
+"För att överföra din chatthistorik till Duck.ai, uppdatera DuckDuckGo-"
+"webbläsaren till den senaste versionen och försök igen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20562,6 +21031,12 @@ msgstr "Idag"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Idag"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20975,9 +21450,21 @@ msgid "Try Them Out"
 msgstr "Prova dem"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Testa att söka!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21046,6 +21533,12 @@ msgid "Try for free"
 msgstr "Prova gratis"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21058,6 +21551,12 @@ msgstr "Prova gratis"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "Prova gratis! Säkert VPN, avancerad och privat AI med mera."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21085,6 +21584,12 @@ msgstr "Prova vår webbläsare"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Testa vår hemsida som aldrig visar meddelanden som de här:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21334,6 +21839,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Aktivera Duck Player för att titta på YouTube utan riktade annonser"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -21536,13 +22047,14 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: "
-"https://duckduckgo.com"
+"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
+msgstr ""
+"Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21569,7 +22081,8 @@ msgstr "Under sektionen %1$sSök%2$s, klicka på %3$sHantera sökmotorer...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
+msgstr ""
+"Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -21676,8 +22189,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås upp avancerade AI-modeller och högre gränser med en "
-"DuckDuckGo-prenumeration"
+"Lås upp avancerade AI-modeller och högre gränser med en DuckDuckGo-"
+"prenumeration"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -21697,6 +22210,12 @@ msgstr "Lås upp avancerade AI-modeller med en DuckDuckGo-prenumeration"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Lås upp avancerad AI med din prenumeration!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22035,7 +22554,8 @@ msgstr "Använd DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
+msgstr ""
+"Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22058,6 +22578,12 @@ msgstr "Använd i Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Använd i Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22321,10 +22847,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna "
-"Duck.ai-inställningarna. Välj Aktivera under Sync & Backup och välj "
-"Synkronisera med en annan enhet. Eller skanna QR-koden på din "
-"återställnings-PDF."
+"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna Duck."
+"ai-inställningarna. Välj Aktivera under Sync & Backup och välj Synkronisera "
+"med en annan enhet. Eller skanna QR-koden på din återställnings-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22377,8 +22902,8 @@ msgstr "Röstchatt avslutad"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Röstchatt är anonymiserad av oss och används aldrig för att träna "
-"AI-modeller."
+"Röstchatt är anonymiserad av oss och används aldrig för att träna AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22558,7 +23083,8 @@ msgstr "Vi anonymiserar"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
+msgstr ""
+"Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22592,14 +23118,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
+msgstr ""
+"Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
+msgstr ""
+"Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22610,7 +23138,8 @@ msgstr "Vi förföljer dig inte med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Vi lagrar inte användarnamn eller annan personligt identifierbar information."
+msgstr ""
+"Vi lagrar inte användarnamn eller annan personligt identifierbar information."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22641,7 +23170,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
+msgstr ""
+"Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22793,7 +23323,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
+msgstr ""
+"Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -22994,7 +23525,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
+msgstr ""
+"Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23089,7 +23621,8 @@ msgstr "Kan du ge några faktorer man ska tänka på när man köper en datorsk�
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
+msgstr ""
+"Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23183,7 +23716,8 @@ msgstr "Vilka är de viktigaste lärdomarna?"
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr "Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
+msgstr ""
+"Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
@@ -23208,7 +23742,8 @@ msgstr "Vilka är de mest rekommenderade rätterna här?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
+msgstr ""
+"Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23233,6 +23768,12 @@ msgstr "Vad störde dig mest?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Varför är du tillbaka idag?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23429,7 +23970,8 @@ msgstr "Vad vill du ge feedback om?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
+msgstr ""
+"Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23461,7 +24003,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
+msgstr ""
+"När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -23519,7 +24062,8 @@ msgstr "Vilka är vi"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr "Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
+msgstr ""
+"Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23649,6 +24193,14 @@ msgstr "Vinster"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Snö och snöblandat regn"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -23902,7 +24454,8 @@ msgstr "Ja, ny användare!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, vi slänger data när du är klar med dem och de kan inte återställas."
+msgstr ""
+"Ja, vi slänger data när du är klar med dem och de kan inte återställas."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -23921,7 +24474,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
+msgstr ""
+"Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24075,6 +24629,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Du kan bara bifoga %1$s bilder per konversation."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24100,7 +24661,8 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr "Du kan återställa dina inställningar efter att du har tagit bort kakor."
+msgstr ""
+"Du kan återställa dina inställningar efter att du har tagit bort kakor."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24220,6 +24782,12 @@ msgstr ""
 "uppdateringar av den."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24265,6 +24833,12 @@ msgstr "Du har blockerat %1$s webbplatser"
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "Du har blockerat 1 webbplats"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24341,8 +24915,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. "
-"YouTube-videor som visas här spåras därför av YouTube/Google."
+"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. YouTube-"
+"videor som visas här spåras därför av YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24458,8 +25032,8 @@ msgstr "Dina chattar sparas nu."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Dina chattar är privata, sparas aldrig och används inte för att träna "
-"AI-modeller"
+"Dina chattar är privata, sparas aldrig och används inte för att träna AI-"
+"modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -24602,10 +25176,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure "
-"Hash-algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande "
-"inställningsfil lämnar din webbläsare. Vi sparar inställningsfilen med "
-"nyckeln som namn. DuckDuckGo känner aldrig till ditt lösenord."
+"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure Hash-"
+"algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande inställningsfil "
+"lämnar din webbläsare. Vi sparar inställningsfilen med nyckeln som namn. "
+"DuckDuckGo känner aldrig till ditt lösenord."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24661,6 +25235,14 @@ msgstr "Din roll"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Dina sökningar kan inte kopplas tillbaka till dig"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -24827,7 +25409,8 @@ msgstr "av %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
+msgstr ""
+"av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25041,8 +25624,8 @@ msgstr "den officiella webbplatsen"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat "
-"%3$s-tecken)"
+"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat %3$s-"
+"tecken)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25253,3 +25836,9 @@ msgstr "år"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "år"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,7 @@ msgstr "!Bang-sökgenvägar"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
+msgstr "”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -128,7 +127,7 @@ msgstr "%1$s identifierades"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s filer använda"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -365,7 +364,7 @@ msgstr "%1$s använt"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -429,8 +428,7 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
+msgstr "%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -615,7 +613,7 @@ msgstr "1 dag sedan"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 fil använd"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1313,8 +1311,7 @@ msgstr "Installera tillägget DuckDuckGo"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
+msgstr "Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1535,6 +1532,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Avancerade modeller kan förbruka gränserna 2–5 gånger snabbare än andra "
+"modeller. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1570,8 +1569,7 @@ msgstr "Afrikaans"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
+msgstr "Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
@@ -1821,8 +1819,7 @@ msgstr "Vill du tillåta anonym filgranskning för den här chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
+msgstr "Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2155,22 +2152,19 @@ msgstr "Är du fortfarande där?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
+msgstr "Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Är du säker på att du vill rensa den här konversationen och starta en ny?"
+msgstr "Är du säker på att du vill rensa den här konversationen och starta en ny?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
+msgstr "Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2330,7 +2324,7 @@ msgstr "Fråga privat"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Fråga privat"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2383,11 +2377,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist är en valbar funktion i våra sökresultat som anonymt kan generera AI-"
-"assisterade svar på sökfrågor. För att göra detta skannar den webben efter "
-"relevant innehåll och använder sedan AI-driven naturlig språkteknologi för "
-"att generera ett kort svar baserat på relevant information som hittats. Det "
-"är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
+"Assist är en valbar funktion i våra sökresultat som anonymt kan generera "
+"AI-assisterade svar på sökfrågor. För att göra detta skannar den webben "
+"efter relevant innehåll och använder sedan AI-driven naturlig språkteknologi "
+"för att generera ett kort svar baserat på relevant information som hittats. "
+"Det är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
 "källor och baseras på %1$sgenomsökning av webben%2$s."
 
 # smartling.placeholder_format=C
@@ -2479,8 +2473,7 @@ msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten avslutats."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
+msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2521,8 +2514,7 @@ msgstr "Autosvar"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
+msgstr "Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -3160,8 +3152,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Surfa som vanligt medan vi ger dig integritetsskydd. Vi har förenat vår "
-"sökmotor, spårningsblockerare och tvingande kryptering i ett %1$s%2$s-"
-"tillägg%3$s."
+"sökmotor, spårningsblockerare och tvingande kryptering i ett "
+"%1$s%2$s-tillägg%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3795,12 +3787,12 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med AI-"
-"chattmodeller från tredje part med stöd för modeller från OpenAI, Anthropic "
-"och fler. Om du stänger av den här inställningen döljs chattknappar och "
-"länkar på DuckDuckGo Search. Du kan dock fortfarande komma åt chatten när "
-"den här inställningen är avstängd genom att gå till %1$shttps://duck.ai%2$s "
-"direkt."
+"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med "
+"AI-chattmodeller från tredje part med stöd för modeller från OpenAI, "
+"Anthropic och fler. Om du stänger av den här inställningen döljs "
+"chattknappar och länkar på DuckDuckGo Search. Du kan dock fortfarande komma "
+"åt chatten när den här inställningen är avstängd genom att gå till "
+"%1$shttps://duck.ai%2$s direkt."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3884,7 +3876,7 @@ msgstr "Chatta privat med AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Chatta privat med populära AI:er"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4040,8 +4032,7 @@ msgstr "Kontrollera stavningen"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
+msgstr "Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4464,8 +4455,7 @@ msgstr "Klicka på %1$sInställningar%2$s i rullgardinsmenyn."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
+msgstr "Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4681,7 +4671,7 @@ msgstr "Stäng"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Stäng"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4731,7 +4721,7 @@ msgstr "Stäng sökning"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Stäng andra bedömning"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5108,7 +5098,7 @@ msgstr "Fortsätt blockera annonser"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Fortsätt senaste chattar här. Eller radera dem med Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5179,7 +5169,7 @@ msgstr "Cookie-uppgifter:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Kopierad"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5232,7 +5222,7 @@ msgstr "Kopiera kod"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Kopiera länk"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5353,7 +5343,7 @@ msgstr "Skapa bild"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Skapa dela länk"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5405,6 +5395,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"När du skapar en länk skapas en kopia av chatten som kan visas av alla som "
+"öppnar den."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5563,7 +5555,7 @@ msgstr "Anpassa svar"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Anpassa svar"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5855,7 +5847,7 @@ msgstr "Radera serverdata?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Ta bort delad länk"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5867,7 +5859,7 @@ msgstr "Ta bort avskrift"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Radera en chatt"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5905,7 +5897,7 @@ msgstr "Ta bort bild?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Radera mig"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6033,8 +6025,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
+msgstr "Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6220,7 +6211,7 @@ msgstr "Stäng kampanj"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Avvisa rundtur"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6327,8 +6318,7 @@ msgstr "Ser du inte DuckDuckGo i listan?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
+msgstr "Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6376,8 +6366,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan AI-"
-"funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
+"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan "
+"AI-funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6437,7 +6427,7 @@ msgstr "Ladda ner DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Ladda ner DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6658,7 +6648,7 @@ msgstr "Duck.ai av DuckDuckGo. Privat AI-chatt. Gratis."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai kan nu analysera PDF-filer. Prova det!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6764,8 +6754,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai låter dig chatta privat med populära AI-modeller. Att inaktivera det "
-"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka %1$sduck."
-"ai%2$s direkt."
+"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka "
+"%1$sduck.ai%2$s direkt."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6817,7 +6807,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai stöder modeller från Anthropic, OpenAI med flera."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6845,9 +6835,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym AI-"
-"chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, AI-"
-"modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
+"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym "
+"AI-chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, "
+"AI-modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7016,8 +7006,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
+msgstr "DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7466,7 +7455,7 @@ msgstr "Aktivera de mest besökta webbplatserna"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Aktivera nu"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7769,7 +7758,7 @@ msgstr "Guide till underhållning"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Hela chatten"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7870,8 +7859,7 @@ msgstr "Förklara det accepterade svaret med enkla ord."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
+msgstr "Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7937,13 +7925,13 @@ msgstr "Stötande låttexter"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Utforska Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Utforska Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8050,7 +8038,7 @@ msgstr "Gratis"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "GRATIS OCH VALFRITT"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8108,8 +8096,7 @@ msgstr "Feedback har skickats"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
+msgstr "Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8263,8 +8250,7 @@ msgstr "Hitta <b>%1$s</b> i din nedladdningsmapp"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
+msgstr "Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8301,8 +8287,7 @@ msgstr "Hitta sökresultat närmare dig."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
+msgstr "Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8472,7 +8457,7 @@ msgstr "Frigör lagring"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Gratis och alltid privat"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8484,8 +8469,7 @@ msgstr "Kostnadsfria och privata chattar, anonymiserade av oss"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
+msgstr "Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8964,9 +8948,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Få tillgång till avancerade AI-modeller i Duck.ai med ett DuckDuckGo-"
-"abonnemang, som även inkluderar vårt VPN och andra premiumskydd för "
-"integritet."
+"Få tillgång till avancerade AI-modeller i Duck.ai med ett "
+"DuckDuckGo-abonnemang, som även inkluderar vårt VPN och andra premiumskydd "
+"för integritet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8995,7 +8979,7 @@ msgstr "Få hjälp med datorn"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Få högre användningsgränser med en DuckDuckGo-prenumeration."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9038,13 +9022,15 @@ msgstr "Hämta den senaste versionen"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Hämta appen"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Hämta den kostnadsfria DuckDuckGo-webbläsaren %1$sför att blockera annonser "
+"på YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9072,7 +9058,7 @@ msgstr "Få dina vänner att byta och hjälp oss växa!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Checklista för att komma igång"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9417,8 +9403,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
+msgstr "Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -9764,7 +9749,7 @@ msgstr "Dölj tips"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Dölj handledning"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10305,8 +10290,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
+msgstr "Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10886,8 +10870,7 @@ msgstr "Det är snabbt, gratis och ger dig ännu mer skydd online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
+msgstr "Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11390,7 +11373,7 @@ msgstr "Låter dig söka anonymt med DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "Låter dig växla mellan att skicka sökfrågor och promptar till Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11466,7 +11449,7 @@ msgstr "Vunna lineouts"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Länken går ut om 7 dagar."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11482,8 +11465,7 @@ msgstr "Länkar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
+msgstr "Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -11594,8 +11576,7 @@ msgstr "Läser in fler sökresultat med bilder när du skrollar"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
+msgstr "Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12566,7 +12547,7 @@ msgstr "Mer än 20 minuter"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Fler tips"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12889,10 +12870,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nya promptar och svar krypteras och lagras tillfälligt på en DuckDuckGo-"
-"server efter att de har skickats, så att du kan återställa chatten om din "
-"internetanslutning bryts. Om du inaktiverar chatthistoriken raderas fästa "
-"chattar och tillfällig lagring av nya promptar och svar inaktiveras."
+"Nya promptar och svar krypteras och lagras tillfälligt på en "
+"DuckDuckGo-server efter att de har skickats, så att du kan återställa "
+"chatten om din internetanslutning bryts. Om du inaktiverar chatthistoriken "
+"raderas fästa chattar och tillfällig lagring av nya promptar och svar "
+"inaktiveras."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13059,7 +13041,7 @@ msgstr "Nej tack"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Nej tack"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13727,7 +13709,7 @@ msgstr "På men utan nummer"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Introduktion klar"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13945,7 +13927,7 @@ msgstr "Öppna förslag på att skapa och redigera bilder"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Öppna kom igång-checklistan"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14697,7 +14679,7 @@ msgstr "Fäst"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Fäst en chatt"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14709,7 +14691,7 @@ msgstr "Fäst chattar här från %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Fäst mig"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14732,7 +14714,7 @@ msgstr "Fäst"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14773,8 +14755,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Lös följande utmaning för att bekräfta att prompten görs av en människa."
+msgstr "Lös följande utmaning för att bekräfta att prompten görs av en människa."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14782,8 +14763,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Lös följande utmaning för att bekräfta att sökningen görs av en människa."
+msgstr "Lös följande utmaning för att bekräfta att sökningen görs av en människa."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15056,6 +15036,8 @@ msgstr "Dålig formatering"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Populära AI-modeller tillgängliga. Inget konto behövs. Chattar anonymiserade "
+"av oss."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15269,7 +15251,7 @@ msgstr "Föregående flikar"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Föregående tips"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15564,8 +15546,7 @@ msgstr "Fråga mig"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Be mig använda min ungefärliga plats för att få sökresultat i närheten."
+msgstr "Be mig använda min ungefärliga plats för att få sökresultat i närheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15814,13 +15795,15 @@ msgstr "Resonerande AI med medelhög modereringsnivå"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Resonemang kan ge bättre svar på komplexa frågor."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Resonemanget är mer grundligt, men förbrukar gränserna 2–5 gånger snabbare. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15861,7 +15844,7 @@ msgstr "Lagring av senaste chattar kan justeras i %1$s."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Senaste chattar"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15870,8 +15853,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
-"servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på "
+"DuckDuckGo-servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15880,8 +15863,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
-"servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på "
+"DuckDuckGo-servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16021,7 +16004,7 @@ msgstr "Minska användning"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Minska användningen med en mer effektiv modell"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16402,7 +16385,7 @@ msgstr "Återställ alla inställningar"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Återställ handledning"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16420,7 +16403,7 @@ msgstr "Upplösning"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Svar"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16914,8 +16897,7 @@ msgstr "Spara upp till 30 av dina senaste chattar lokalt på din enhet."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
+msgstr "Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17092,15 +17074,13 @@ msgstr "Skrolla nedåt och leta reda på %1$sdin webbläsare%2$s i listan."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
+msgstr "Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
+msgstr "Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17128,7 +17108,7 @@ msgstr "Vill du söka efter %1$s för att hitta resultat närmare dig?"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Sök & Duck.ai-reglage"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17442,8 +17422,7 @@ msgstr "En andra åsikt"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
+msgstr "Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17452,8 +17431,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17462,8 +17441,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17482,8 +17461,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Lagra dina chattar på ett säkert sätt på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra dina chattar på ett säkert sätt på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17505,7 +17484,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Lagras säkert på vår krypterade server."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -18017,7 +17996,7 @@ msgstr "Använd som startsida"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Ställ in tonen och stilen för Duck.ai:s svar."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18039,8 +18018,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
+msgstr "Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18089,13 +18067,13 @@ msgstr "Seychellerna"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Dela"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Dela"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18141,7 +18119,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Dela chatt"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18205,7 +18183,7 @@ msgstr "Dela positiv feedback"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Delningsomfång"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18346,7 +18324,7 @@ msgstr "Visa mer info"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Visa Duck.ai-handledning"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18499,7 +18477,7 @@ msgstr "Visa mer"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Visa fler modeller"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18540,7 +18518,7 @@ msgstr "Visa sidofält"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Visa steg-för-steg-tips för att få ut det mesta av Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18633,14 +18611,12 @@ msgstr "Visar mest besökta länkar i ny flik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
+msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
+msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18658,8 +18634,7 @@ msgstr "Visar sidnummer där sidan med sökresultat bryts"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
+msgstr "Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -18685,8 +18660,7 @@ msgstr "Visar välkomstmeddelande högst upp på sidan med sökresultat"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
+msgstr "Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18920,7 +18894,7 @@ msgstr "Något gick fel. Försök igen senare."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Något gick fel. Försök igen."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19220,7 +19194,7 @@ msgstr "Börja använda veckogränsen"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Starta en ny chatt"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19501,8 +19475,7 @@ msgstr "Förslag på rubrik för ett blogginlägg"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
+msgstr "Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -19807,7 +19780,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Byt till denna andra bedömning"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19963,7 +19936,7 @@ msgstr "Sync & Backup är inte tillgängligt just nu"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Synkronisera chattar mellan dina enheter"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20059,6 +20032,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Ta med dig Duck.ai överallt. Få det inbyggt i vår kostnadsfria app för "
+"snabbare åtkomst, var du än är."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20067,6 +20042,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Ta med dig Duck.ai överallt. Få den inbyggd i vår kostnadsfria webbläsare "
+"för snabbare åtkomst, var du än surfar."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20455,8 +20432,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
+msgstr "Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -20539,7 +20515,7 @@ msgstr "Den här månaden"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Detta svar"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20551,7 +20527,7 @@ msgstr "Denna vecka"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Den här chatten stannar i Duck.ai och förblir privat för dig."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20688,6 +20664,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Det här är bara en exempelchatt. Öppna dess meny (de tre punkterna) och välj "
+"sedan Fäst för att behålla den längst upp bland dina chattar!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20696,6 +20674,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Det här är bara en exempelchatt. Använd Fire Button i sidomenyn för att "
+"radera den!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20744,8 +20724,8 @@ msgstr "Denna sida kräver javascript för att fungera."
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
 msgstr ""
-"Innehållet på den här sidan kommer att skickas med ditt meddelande till Duck."
-"ai"
+"Innehållet på den här sidan kommer att skickas med ditt meddelande till "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20818,8 +20798,7 @@ msgstr "Denna video kan ännu inte visas här. Du kan titta på den på %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
+msgstr "Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21004,8 +20983,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"För att överföra din chatthistorik till Duck.ai, uppdatera DuckDuckGo-"
-"webbläsaren till den senaste versionen och försök igen."
+"För att överföra din chatthistorik till Duck.ai, uppdatera "
+"DuckDuckGo-webbläsaren till den senaste versionen och försök igen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21037,6 +21016,8 @@ msgstr "Idag"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21453,7 +21434,7 @@ msgstr "Prova dem"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Prova en annan modell"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21464,7 +21445,7 @@ msgstr "Testa att söka!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Prova ett förslag"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21536,7 +21517,7 @@ msgstr "Prova gratis"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Prova gratis"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21556,7 +21537,7 @@ msgstr "Prova gratis! Säkert VPN, avancerad och privat AI med mera."
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Prova gratis i 7 dagar"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21589,7 +21570,7 @@ msgstr "Testa vår hemsida som aldrig visar meddelanden som de här:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Testa resonemang"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21842,7 +21823,7 @@ msgstr "Aktivera Duck Player för att titta på YouTube utan riktade annonser"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Aktivera Duck.ai-växling"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22047,14 +22028,13 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: https://"
-"duckduckgo.com"
+"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
+msgstr "Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22081,8 +22061,7 @@ msgstr "Under sektionen %1$sSök%2$s, klicka på %3$sHantera sökmotorer...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
+msgstr "Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22189,8 +22168,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås upp avancerade AI-modeller och högre gränser med en DuckDuckGo-"
-"prenumeration"
+"Lås upp avancerade AI-modeller och högre gränser med en "
+"DuckDuckGo-prenumeration"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -22215,7 +22194,7 @@ msgstr "Lås upp avancerad AI med din prenumeration!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Lås upp avancerade modeller"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22554,8 +22533,7 @@ msgstr "Använd DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
+msgstr "Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22583,7 +22561,7 @@ msgstr "Använd i Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Använd Fire Button för att radera en chatt från historiken."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22847,9 +22825,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna Duck."
-"ai-inställningarna. Välj Aktivera under Sync & Backup och välj Synkronisera "
-"med en annan enhet. Eller skanna QR-koden på din återställnings-PDF."
+"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna "
+"Duck.ai-inställningarna. Välj Aktivera under Sync & Backup och välj "
+"Synkronisera med en annan enhet. Eller skanna QR-koden på din "
+"återställnings-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22902,8 +22881,8 @@ msgstr "Röstchatt avslutad"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Röstchatt är anonymiserad av oss och används aldrig för att träna AI-"
-"modeller."
+"Röstchatt är anonymiserad av oss och används aldrig för att träna "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23083,8 +23062,7 @@ msgstr "Vi anonymiserar"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
+msgstr "Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23118,16 +23096,14 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
+msgstr "Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
+msgstr "Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23138,8 +23114,7 @@ msgstr "Vi förföljer dig inte med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Vi lagrar inte användarnamn eller annan personligt identifierbar information."
+msgstr "Vi lagrar inte användarnamn eller annan personligt identifierbar information."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23170,8 +23145,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
+msgstr "Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23323,8 +23297,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
+msgstr "Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23525,8 +23498,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
+msgstr "Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23621,8 +23593,7 @@ msgstr "Kan du ge några faktorer man ska tänka på när man köper en datorsk�
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
+msgstr "Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -23716,8 +23687,7 @@ msgstr "Vilka är de viktigaste lärdomarna?"
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
-"Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
+msgstr "Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
@@ -23742,8 +23712,7 @@ msgstr "Vilka är de mest rekommenderade rätterna här?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
+msgstr "Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23773,7 +23742,7 @@ msgstr "Varför är du tillbaka idag?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Vad kan du göra?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23970,8 +23939,7 @@ msgstr "Vad vill du ge feedback om?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
+msgstr "Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24003,8 +23971,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
+msgstr "När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -24062,8 +24029,7 @@ msgstr "Vilka är vi"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
+msgstr "Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24201,6 +24167,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Med Duck.ai anonymiseras dina chattar och används aldrig för att träna AI. "
+"Slå på eller stäng av det när som helst i menyn ”%1$s”."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24454,8 +24422,7 @@ msgstr "Ja, ny användare!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, vi slänger data när du är klar med dem och de kan inte återställas."
+msgstr "Ja, vi slänger data när du är klar med dem och de kan inte återställas."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -24474,8 +24441,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
+msgstr "Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24633,7 +24599,7 @@ msgstr "Du kan bara bifoga %1$s bilder per konversation."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Du kan bara bifoga %1$s flikar åt gången."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24661,8 +24627,7 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr ""
-"Du kan återställa dina inställningar efter att du har tagit bort kakor."
+msgstr "Du kan återställa dina inställningar efter att du har tagit bort kakor."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24785,7 +24750,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Du är klar!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24838,7 +24803,7 @@ msgstr "Du har blockerat 1 webbplats"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Du har bemästrat grunderna i Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24915,8 +24880,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. YouTube-"
-"videor som visas här spåras därför av YouTube/Google."
+"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. "
+"YouTube-videor som visas här spåras därför av YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25032,8 +24997,8 @@ msgstr "Dina chattar sparas nu."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Dina chattar är privata, sparas aldrig och används inte för att träna AI-"
-"modeller"
+"Dina chattar är privata, sparas aldrig och används inte för att träna "
+"AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -25176,10 +25141,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure Hash-"
-"algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande inställningsfil "
-"lämnar din webbläsare. Vi sparar inställningsfilen med nyckeln som namn. "
-"DuckDuckGo känner aldrig till ditt lösenord."
+"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure "
+"Hash-algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande "
+"inställningsfil lämnar din webbläsare. Vi sparar inställningsfilen med "
+"nyckeln som namn. DuckDuckGo känner aldrig till ditt lösenord."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25243,6 +25208,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Dina inställningar sparas men kommer att återställas om du rensar dina "
+"cookies. Aktivera tillägget %1$sDuckDuckGo No AI%2$s för att göra det "
+"permanent."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25409,8 +25377,7 @@ msgstr "av %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
+msgstr "av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25624,8 +25591,8 @@ msgstr "den officiella webbplatsen"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat %3$s-"
-"tecken)"
+"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat "
+"%3$s-tecken)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25841,4 +25808,4 @@ msgstr "år"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ta_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ta_IN/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%s கண்டறியப்பட்டது"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -484,6 +494,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 நாள் முன்பு"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1228,6 +1243,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1855,6 +1877,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3104,6 +3131,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3711,6 +3743,11 @@ msgstr "Clipart"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3746,6 +3783,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4051,6 +4093,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4105,6 +4152,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr "குக்கீ தரவு:"
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4142,6 +4194,11 @@ msgstr "நகலெடு &amp; முகவரிப் பட்டியி�
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4238,6 +4295,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4272,6 +4334,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4397,6 +4466,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4633,9 +4707,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4663,6 +4747,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4916,6 +5005,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5083,6 +5177,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5258,6 +5357,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5365,6 +5469,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5874,6 +5983,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6118,6 +6232,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6251,6 +6370,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6332,6 +6461,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6663,6 +6797,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7084,6 +7223,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7114,6 +7258,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7131,6 +7285,11 @@ msgstr "இந்த பாடலை கிடைக்கும்:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "உங்கள் நண்பர்களை மாற்ற வைத்து, நாங்கள் வளர உதவுங்கள்!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7681,6 +7840,11 @@ msgstr "படிகளை மறை"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -9002,6 +9166,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "DuckDuckGo மூலம் அநாமதேயமாகத் தேட உங்களை அனுமதிக்கிறது"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9057,6 +9227,11 @@ msgstr "வரி வரைதல்"
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9959,6 +10134,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "20 நிமிடங்களுக்கு மேல்"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #  Marked fuzzy because of translated trademark
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
@@ -10354,6 +10534,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10904,6 +11089,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "செயல்படுத்து ஆனால் எண்கள் வேண்டாம்"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11075,6 +11265,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11679,9 +11874,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11696,6 +11901,11 @@ msgstr "வெளிர் சிவப்பு"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11952,6 +12162,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12121,6 +12336,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12565,6 +12785,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12592,6 +12822,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12714,6 +12949,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -13019,6 +13259,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "எல்லா அமைப்புகளையும் இயல்பு நிலைக்கு மாற்று"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -13027,6 +13272,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13588,6 +13838,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "அநாமதேயமாகத் தேடுங்கள்"
 
@@ -13874,6 +14129,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14283,6 +14543,11 @@ msgstr "முன்னிருப்பு தேடல் பொறியா�
 msgid "Set as Homepage"
 msgstr "முகப்புப்பக்கம் ஆக்கு"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14337,6 +14602,16 @@ msgstr "அமைப்புகள் புதுப்பிக்கப்�
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14366,6 +14641,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14414,6 +14695,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14526,6 +14812,11 @@ msgstr "புக்மார்க்லேட் மற்றும் அம�
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "விவரங்களைக் காட்டு"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14649,6 +14940,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14677,6 +14973,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14980,6 +15281,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15212,6 +15518,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15690,6 +16001,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "உங்களைக் கண்காணிக்காத தேடுபொறிக்கு மாறவும். எப்போதும்."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15802,6 +16120,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15872,6 +16195,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "உங்கள் தனியுரிமையை திரும்பப் பெறுங்கள்!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16249,9 +16586,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16352,6 +16699,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16612,6 +16973,11 @@ msgstr "இன்று"
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16949,9 +17315,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "ஒரு தேடல் முயற்சி!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -17005,6 +17381,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -17015,6 +17396,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -17038,6 +17424,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "இந்தச் செய்திகளைக் காட்டாத எங்கள் முகப்புப் பக்கத்தை முயற்சிக்கவும்:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17237,6 +17628,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17527,6 +17923,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17824,6 +18225,11 @@ msgstr "Firefox ல் பயன்படுத்தவும்"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Safari ல் பயன்படுத்தவும்"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18754,6 +19160,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "இன்று உங்களைத் திரும்ப அழைத்து வந்தது எது?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19095,6 +19506,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19441,6 +19859,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19550,6 +19974,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19589,6 +20018,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19896,6 +20330,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20371,6 +20812,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "வரு"
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
 
 #~ msgctxt "SERP footer content"
 #~ msgid "%s Billion Searches"

--- a/locales/te_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/te_IN/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -483,6 +493,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 రోజు క్రితం"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1846,6 +1868,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3080,6 +3107,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3676,6 +3708,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3711,6 +3748,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4017,6 +4059,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4071,6 +4118,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4108,6 +4160,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4204,6 +4261,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4238,6 +4300,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4363,6 +4432,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4599,9 +4673,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4629,6 +4713,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4882,6 +4971,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5048,6 +5142,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5223,6 +5322,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5330,6 +5434,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5818,6 +5927,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6057,6 +6171,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6190,6 +6309,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6271,6 +6400,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6600,6 +6734,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7021,6 +7160,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7050,6 +7194,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7066,6 +7220,11 @@ msgstr "దీనిపై ఈ పాటను పొందండి:"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7617,6 +7776,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8915,6 +9079,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8970,6 +9140,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9866,6 +10041,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "20 నిమిషాల పైన"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 # Marked fuzzy because of translated trademark
 #. e.g. More ways to add DuckDuckGo to Firefox
 #, fuzzy
@@ -10262,6 +10442,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10810,6 +10995,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "సంఖ్యలు లేకుండా"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10978,6 +11168,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11574,9 +11769,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11591,6 +11796,11 @@ msgstr "గులాబీ"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11847,6 +12057,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12016,6 +12231,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12458,6 +12678,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12485,6 +12715,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12607,6 +12842,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12909,6 +13149,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "అన్ని అమరికలను రీసెట్ చెయ్యి"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12917,6 +13162,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13474,6 +13724,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13754,6 +14009,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14151,6 +14411,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "నివాస పుటగా అమర్ఛండి"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14203,6 +14468,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14232,6 +14507,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14280,6 +14561,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14392,6 +14678,11 @@ msgstr ""
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "వివరాలు చూపించు"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14515,6 +14806,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14543,6 +14839,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14841,6 +15142,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15073,6 +15379,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15551,6 +15862,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15663,6 +15981,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15732,6 +16055,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16101,9 +16438,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16204,6 +16551,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16460,6 +16821,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16797,9 +17163,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "వెతికి చూడండి!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16853,6 +17229,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16863,6 +17244,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16885,6 +17271,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17085,6 +17476,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17369,6 +17765,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17665,6 +18066,11 @@ msgstr "ఫైర్‌ఫాక్స్‌లో వాడండి"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "సఫారీలో వాడండి"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18583,6 +18989,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "ఈ రోజు తిరిగి మిమ్మలిని వెనక్కి ఏమి తీసుకవచ్చింది?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18922,6 +19333,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19266,6 +19684,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19374,6 +19798,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19408,6 +19837,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19709,6 +20143,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20181,6 +20622,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr "ตรวจพบ %1$s"
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -177,8 +183,7 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
-"Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -189,8 +194,7 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
-"Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -207,8 +211,7 @@ msgid ""
 "model."
 msgstr ""
 "%1$s สามารถใช้ได้เฉพาะกับการสมัครใช้งาน DuckDuckGo เท่านั้น "
-"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
-"หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -216,9 +219,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s ไม่สามารถใช้งานได้ชั่วคราว "
-"โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
+msgstr "%1$s ไม่สามารถใช้งานได้ชั่วคราว โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -310,7 +311,6 @@ msgid ""
 "their servers."
 msgstr ""
 "%1$s ทํางานในสภาพแวดล้อมการดําเนินการที่เชื่อถือได้ "
-""
 "นี่หมายความว่าแม้แต่ผู้ให้บริการโมเดลก็ไม่สามารถดูคำแนะนำของคุณหรือการตอบสนองของโมเดล "
 "หรือบันทึกการแชทนี้บนเซิร์ฟเวอร์ของพวกเขา"
 
@@ -356,6 +356,12 @@ msgid "%s used"
 msgstr "%1$s ที่ใช้"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s มุมมอง"
@@ -392,8 +398,7 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น "
-"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -403,9 +408,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น "
-"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+msgstr "%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -425,8 +428,7 @@ msgstr "%1$sคลิก%2$sเพิ่ม%3$sเลือก%4$sอนุญ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s "
-"จากนั้นคลิก%8$sตกลง%9$s"
+"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s จากนั้นคลิก%8$sตกลง%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -471,16 +473,13 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s "
-"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
+"%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s "
-"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
+msgstr "%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -599,6 +598,12 @@ msgstr "ความพยายาม 1 ครั้งถูกบล็อก
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 วันที่ผ่านมา"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -940,9 +945,8 @@ msgid ""
 "aichat%s."
 msgstr ""
 "AI Chat ช่วยให้คุณสนทนาแบบไม่ต้องระบุชื่อด้วยโมเดลแชท AI ของบริษัทอื่น "
-"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search "
-"คุณยังคงสามารถเข้าถึง AI Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
-"%1$sduckduckgo.com/aichat%2$s"
+"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search คุณยังคงสามารถเข้าถึง AI Chat "
+"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$sduckduckgo.com/aichat%2$s"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1005,8 +1009,7 @@ msgid ""
 msgstr ""
 "คำตอบที่ได้รับความช่วยเหลือจาก AI ขณะนี้ยังไม่รองรับคำถามที่ถามต่อโดยตรง "
 "แต่เรามีและมักจะเชื่อมโยงไปยัง %1$sDuck.ai%2$s สำหรับคำถามที่ถามต่อ "
-"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic "
-"และอีกมากมาย"
+"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic และอีกมากมาย"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1191,8 +1194,7 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
-"หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1227,9 +1229,7 @@ msgstr "โฆษณา"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+msgstr "การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1237,8 +1237,7 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1505,6 +1504,14 @@ msgid "Advanced Models"
 msgstr "โมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "ลงโฆษณาในการค้นหา"
@@ -1544,9 +1551,7 @@ msgstr "หลังจากดาวน์โหลดและเปิด �
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย "
-"ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
+msgstr "หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1683,8 +1688,7 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "การแชททั้งหมดจะถูกทำให้ไม่ระบุชื่อโดย DuckDuckGo "
-"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo "
-"หรือผู้ให้บริการโมเดล"
+"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo หรือผู้ให้บริการโมเดล"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1731,8 +1735,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) "
-"จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ AI"
+"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ "
+"AI"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1796,10 +1800,8 @@ msgid ""
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
 "อนุญาตให้ %1$s ค้นหาเว็บเพื่อปรับปรุงการตอบสนองต่อข้อความแจ้งที่เกี่ยวข้อง "
-"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI "
-"ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
-"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี "
-"%3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
+"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
+"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี %3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1944,8 +1946,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
-"%4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1954,8 +1955,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
-"%4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1969,8 +1969,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ "
-"เลือกความถี่ที่คุณต้องการให้แสดง หรือปิดการใช้งานโดยสมบูรณ์"
+"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ เลือกความถี่ที่คุณต้องการให้แสดง "
+"หรือปิดการใช้งานโดยสมบูรณ์"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2017,8 +2017,7 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น "
-"บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
+"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2138,8 +2137,7 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด "
-"รวมถึงแชทที่ปักหมุดไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด รวมถึงแชทที่ปักหมุดไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2148,8 +2146,7 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด "
-"การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2187,8 +2184,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ "
-"ด้วยตนเอง การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
+"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ ด้วยตนเอง "
+"การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2286,6 +2283,12 @@ msgid "Ask privately"
 msgstr "ถามเป็นการส่วนตัว"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2319,16 +2322,12 @@ msgid ""
 "answers are only available in the U.S. (English) region."
 msgstr ""
 "Assist สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
-""
 "โดยไม่ระบุตัวตนให้กับการค้นหาบางรายการโดยอิงจากการสรุปเนื้อหาเว็บที่เกี่ยวข้อง "
-"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
-"Assist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
-"(แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI เมื่อคุณคลิกปุ่ม Assist), "
-"บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
-"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา "
-"(ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ Assist UI "
+"ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อคุณคลิกปุ่ม Assist), บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
+"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2340,14 +2339,9 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist "
-""
-"เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก "
-"AI สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
-"ตามข้อมูลที่เกี่ยวข้องที่พบ "
-""
+"Assist เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ "
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -2513,8 +2507,8 @@ msgid ""
 "Assist is only available in English regions."
 msgstr ""
 "แสดง Assist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง Assist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
-"Assist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ Assist "
+"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2524,8 +2518,8 @@ msgid ""
 "For now, DuckAssist is only available in English regions."
 msgstr ""
 "แสดง DuckAssist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง DuckAssist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
-"DuckAssist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ DuckAssist "
+"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2731,8 +2725,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ "
-"PII เช่น ชื่อ ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
+"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ PII เช่น ชื่อ "
+"ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3113,17 +3107,15 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ "
-"เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
-"และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
+"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ เรารวมเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม "
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
 "และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
@@ -3132,9 +3124,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง "
-"ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private Search, การบล็อกตัวติดตาม "
-"และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private "
+"Search, การบล็อกตัวติดตาม และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3241,11 +3232,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"ตามค่าเริ่มต้น "
-"การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
+"ตามค่าเริ่มต้น การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
 "(ในเบราว์เซอร์ของคุณ) คุณสามารถใช้ Cloud Save "
-"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ "
-"(บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
+"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ (บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวตนได้บนระบบคลาวด์และรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
 
 # smartling.placeholder_format=C
@@ -3254,9 +3243,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง "
-"คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู "
-"%1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
+"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3265,8 +3253,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง "
-"OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
+"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3753,8 +3741,7 @@ msgstr ""
 "Chat (ผ่านบริการ Duck.ai ของเรา) ให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI "
 "ของบุคคลที่สาม ซึ่งรองรับโมเดลจาก OpenAI, Anthropic และอีกมากมาย "
 "การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม "
-"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
-"%1$shttps://duck.ai%2$s โดยตรง"
+"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3831,6 +3818,12 @@ msgid "Chat privately with AI"
 msgstr "แชทแบบส่วนตัวกับ AI"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3879,8 +3872,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo "
-"หรือเซิร์ฟเวอร์ระยะไกล การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
+"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo หรือเซิร์ฟเวอร์ระยะไกล "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3893,11 +3886,9 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "แชทจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
-"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3920,8 +3911,7 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน "
-"Duck.ai "
+"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน Duck.ai "
 "จะได้รับการตรวจสอบโดยไม่ระบุชื่อโดยผู้ให้บริการกลั่นกรองเนื้อหาสำหรับ %2$s"
 
 # smartling.placeholder_format=C
@@ -3982,9 +3972,7 @@ msgstr "ตรวจสอบการสะกดคำ"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"ตรวจสอบ subreddit ของ DuckDuckGo "
-"เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
+msgstr "ตรวจสอบ subreddit ของ DuckDuckGo เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4277,9 +4265,8 @@ msgid ""
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชท "
-""
-"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน "
-"AI Chat เป็นเวลา 7 วันขึ้นไป"
+"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน AI "
+"Chat เป็นเวลา 7 วันขึ้นไป"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4290,8 +4277,8 @@ msgid ""
 "on your browser."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชทล่าสุด "
-"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 "
-"วันหากไม่ได้ใช้ Duck.ai ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
+"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 วันหากไม่ได้ใช้ Duck.ai "
+"ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4300,8 +4287,7 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ "
-"บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
+"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4310,8 +4296,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s "
-"บริการแชท AI ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
+"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s บริการแชท AI "
+"ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4353,8 +4339,7 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน "
-"Mac)"
+"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน Mac)"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4385,8 +4370,7 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows "
-"ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
+"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4478,8 +4462,7 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
 "คลิกหรือแตะ %1$sลบข้อมูลของฉัน%2$s การดำเนินการนี้จะลบข้อมูลออกจากระบบคลาวด์ "
-"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ "
-"%3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
+"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ %3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4560,8 +4543,7 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก "
-"%3$sDuckDuckGo%4$s"
+"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4611,6 +4593,12 @@ msgid "Close"
 msgstr "ปิด"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4653,6 +4641,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "ปิดการค้นหา"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4757,8 +4751,7 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save "
-"ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
+"Cloud Save ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
 "ซึ่งเป็นการดำเนินการที่ไม่บังคับ"
 
 # smartling.placeholder_format=C
@@ -5027,6 +5020,12 @@ msgid "Continue Blocking Ads"
 msgstr "บล็อกโฆษณาต่อไป"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5092,6 +5091,12 @@ msgid "Cookie data:"
 msgstr "ข้อมูลคุกกี้:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5137,6 +5142,12 @@ msgstr "คัดลอกและวาง %1$sabout:preferences#search%2$s �
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "คัดลอกรหัส"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5252,6 +5263,12 @@ msgid "Create Image"
 msgstr "สร้างภาพ"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5293,6 +5310,14 @@ msgstr "สร้างโดย"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "สร้างโดย %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5446,6 +5471,12 @@ msgstr "ปรับแต่งการตอบสนอง"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "ปรับแต่งการตอบสนอง"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5730,10 +5761,22 @@ msgid "Delete Server Data?"
 msgstr "ลบข้อมูลเซิร์ฟเวอร์?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "ลบข้อความ"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5766,6 +5809,12 @@ msgstr "ลบรูปภาพ"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "ลบรูปภาพใช่ไหม"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6076,6 +6125,12 @@ msgid "Dismiss promotion"
 msgstr "ปิดการเลื่อนระดับ"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6218,8 +6273,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ "
-"AI ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ AI "
+"ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6228,8 +6283,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s "
-"เพื่อค้นหาโดยไม่มีฟีเจอร์ AI และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s เพื่อค้นหาโดยไม่มีฟีเจอร์ AI "
+"และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6284,6 +6339,12 @@ msgstr "ดาวน์โหลดเสร็จสมบูรณ์"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "ดาวน์โหลด DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6493,6 +6554,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai โดย DuckDuckGo แชท AI ส่วนตัว ไม่มีค่าใช้จ่าย"
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6501,8 +6568,7 @@ msgid ""
 "pages automatically in Settings."
 msgstr ""
 "ตอนนี้ Duck.ai สามารถช่วยตอบคําถามเกี่ยวกับหน้าเว็บที่คุณกำลังดูอยู่ได้แล้ว "
-"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน "
-"ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
+"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6553,8 +6619,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo "
-"แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://duck.ai"
+"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://"
+"duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6569,8 +6635,7 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
-"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6591,9 +6656,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม "
-"การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai แต่คุณยังสามารถไปที่ "
-"%1$sduck.ai%2$s โดยตรง"
+"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai "
+"แต่คุณยังสามารถไปที่ %1$sduck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6604,10 +6668,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม "
-"รวมถึงโมเดลจาก OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat "
-"และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai "
-"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
+"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม รวมถึงโมเดลจาก "
+"OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo "
+"Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://"
+"duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6637,6 +6701,12 @@ msgid ""
 msgstr "คำตอบของ Duck.ai ไม่ได้อิงตามแหล่งที่มาที่เจาะจงหรือผ่านการตรวจสอบความถูกต้อง"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6662,9 +6732,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI "
-"แบบไม่ระบุตัวตน, แชท AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, "
-"โมเดล AI โอเพนซอร์ส, AI ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
+"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI แบบไม่ระบุตัวตน, แชท "
+"AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, โมเดล AI โอเพนซอร์ส, AI "
+"ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6693,12 +6763,10 @@ msgid ""
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
 "DuckAssist สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง "
-"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
-"DuckAssist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
-"(แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
-"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) สำหรับตอนนี้ DuckAssist "
-"มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ DuckAssist "
+"UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
+"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) "
+"สำหรับตอนนี้ DuckAssist มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6707,9 +6775,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo "
-"AI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก "
-"OpenAI, Anthropic และอื่นๆ อีกมากมาย"
+"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo AI "
+"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก OpenAI, Anthropic "
+"และอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6718,9 +6786,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo "
-"%1$sAI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ที่รองรับโมเดลการแชทจาก OpenAI และ Anthropic"
+"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo %1$sAI "
+"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ที่รองรับโมเดลการแชทจาก OpenAI และ "
+"Anthropic"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6733,10 +6801,8 @@ msgid ""
 "checked for accuracy."
 msgstr ""
 "DuckAssist "
-""
 "เป็นคุณลักษณะใหม่ในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia "
-"และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
 "จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ขับเคลื่อนด้วย AI เพื่อสร้างข้อมูลสรุป "
 "โปรดทราบว่าขณะนี้คำตอบนั้นอิงจาก Wikipedia และเนื้อหาที่เกี่ยวข้อง "
 "และไม่ได้มีการตรวจสอบความถูกต้อง"
@@ -6754,16 +6820,11 @@ msgid ""
 "sources and based on %scrawling the web%s."
 msgstr ""
 "DuckAssist "
-""
 "เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
-"ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
-"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ "
-"โดยอ้างอิงแหล่งที่มาของคำตอบ "
-""
+"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ "
+"AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
+"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ โดยอ้างอิงแหล่งที่มาของคำตอบ "
 "เพื่อให้คุณสามารถไปยังแหล่งข้อมูลเพื่อดูข้อมูลโดยละเอียดเพิ่มเติมได้อย่างง่ายดาย "
-""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -6773,8 +6834,7 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"คำตอบ DuckAssist "
-"สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
+"คำตอบ DuckAssist สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6782,9 +6842,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว "
-"โปรดแชทต่อในวันพรุ่งนี้"
+msgstr "DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว โปรดแชทต่อในวันพรุ่งนี้"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6793,8 +6851,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
+"%2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6803,8 +6861,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
+"%2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6821,8 +6879,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
-"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ "
+"%1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6830,9 +6888,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว "
-"โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
+msgstr "DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6957,8 +7013,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น "
-"ชื่อ ที่อยู่อีเมล หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
+"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น ชื่อ ที่อยู่อีเมล "
+"หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -6966,8 +7022,7 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s "
-"ของ Duck.ai"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s ของ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6976,8 +7031,7 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ "
-"%2$s ของเรา"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ %2$s ของเรา"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6986,9 +7040,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม "
-"รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google และ Facebook "
-"ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
+"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google "
+"และ Facebook ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7000,11 +7053,9 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ "
-"เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
+"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
 "ข้อมูลดังกล่าวจะได้รับการจัดเก็บไว้บนอุปกรณ์ของคุณเท่านั้น เมื่อคุณค้นหา "
-"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา "
-"ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
+"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
 "จากนั้นเราจะทิ้งข้อมูลดังกล่าวในทันทีเพื่อให้ไม่มีการระบุตัวตนของคุณได้ "
 "%1$sดูข้อมูลเพิ่มเติมเกี่ยวกับวิธีที่เราออกแบบเทคโนโลยีนี้เพื่อปกป้องความเป็นส่วนตัวของคุณ%2$s"
 
@@ -7026,9 +7077,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ "
-"ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น และใกล้คุณมากขึ้น "
-"%1$sดูข้อมูลเพิ่มเติม%2$s"
+"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น "
+"และใกล้คุณมากขึ้น %1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7114,9 +7164,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน "
-"เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo จากนั้นเราจะสุ่มคำ "
-"4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
+"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo "
+"จากนั้นเราจะสุ่มคำ 4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
 "เพื่อให้มั่นใจว่ารหัสผ่านมีความยาวอักขระอย่างน้อย 18-20 ตัว"
 
 # smartling.placeholder_format=C
@@ -7284,6 +7333,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "เปิดใช้เว็บไซต์ที่เยี่ยมชมบ่อยที่สุด"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7318,9 +7373,7 @@ msgstr "เปิดใช้งานการค้นหาเว็บ"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น "
-"คุณสามารถเปลี่ยนใจได้ในภายหลัง"
+msgstr "เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น คุณสามารถเปลี่ยนใจได้ในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7526,8 +7579,7 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s "
-"การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
+"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7553,8 +7605,7 @@ msgstr "ป้อนข้อความ"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s "
-"นามแฝง%6$s: d%7$s"
+"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s นามแฝง%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7579,6 +7630,12 @@ msgstr "ป้อนรหัสผ่านเพื่อโหลดการ
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "คู่มือบันเทิง"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7742,6 +7799,18 @@ msgid "Explicit lyrics"
 msgstr "เนื้อเพลงที่โจ่งแจ้ง"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7843,6 +7912,12 @@ msgid "FREE"
 msgstr "ฟรี"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7915,9 +7990,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง "
-"จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
+msgstr "โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8006,9 +8079,7 @@ msgstr "กรองภาพที่สร้างโดย AI จากผ�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
-"กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ "
-"%1$sดูข้อมูลเพิ่มเติม%2$s"
+msgstr "กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ %1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8253,6 +8324,12 @@ msgid "Free Up Storage"
 msgstr "เพิ่มพื้นที่จัดเก็บ"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8274,7 +8351,7 @@ msgstr "แก้ไข แชร์ และใช้ได้อย่าง�
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์ ได้อย่างอิสระ"
+msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8374,8 +8451,7 @@ msgid ""
 "strong>."
 msgstr ""
 "จากแถบเมนูแอปบน Mac ให้เลือก <strong>DuckDuckGo</strong> &gt; "
-"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก "
-"<strong>ติดตั้งการอัปเดต</strong>"
+"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก <strong>ติดตั้งการอัปเดต</strong>"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8711,9 +8787,7 @@ msgstr "เริ่ม"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ "
-"เพียงครั้งเดียว"
+msgstr "รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ เพียงครั้งเดียว"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8728,8 +8802,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo "
-"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
+"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8740,8 +8814,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo "
-"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
+"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8765,6 +8839,12 @@ msgstr "รับคําตอบที่ DuckDuckGo Help"
 msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr "รับความช่วยเหลือด้านคอมพิวเตอร์"
+
+# smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8802,6 +8882,18 @@ msgid "Get the Latest Version"
 msgstr "รับเวอร์ชันล่าสุด"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8822,6 +8914,12 @@ msgstr "ฟังเพลงนี้ที่:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "แนะนำเราให้เพื่อนของคุณ"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8852,9 +8950,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device › Copy Text "
-"Code%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device › Copy Text Code%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8863,8 +8960,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8874,9 +8971,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
-"แล้วสแกนรหัสนี้:"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8886,9 +8982,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF "
+"การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8904,8 +9000,7 @@ msgid ""
 "“Location Services” is turned on."
 msgstr ""
 "ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" "
-"เปิดอยู่"
+"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" เปิดอยู่"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8914,8 +9009,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$s แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
+"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการหาตําแหน่งที่ตั้ง%2$s "
+"แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9508,6 +9603,12 @@ msgid "Hide Tips"
 msgstr "ซ่อนเคล็ดลับ"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9591,9 +9692,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist "
-"เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
+msgstr "เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9686,8 +9785,7 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9829,7 +9927,6 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-""
 "ฉันจะบอกเพื่อนร่วมงานอย่างมีไหวพริบเกี่ยวกับการเคาะดินสออย่างต่อเนื่องได้อย่างไร "
 "และฉันควรจะพูดว่าอะไร"
 
@@ -9952,9 +10049,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ "
-"ที่คล้ายกันหรือไม่และเพราะเหตุใด"
+msgstr "ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ ที่คล้ายกันหรือไม่และเพราะเหตุใด"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -9989,8 +10084,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > "
-"ทั่วไป > รีเซ็ต > \"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > ทั่วไป > รีเซ็ต > "
+"\"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10000,9 +10095,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ "
-"ให้ไปที่ %1$s⋮ > เมนู > การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s "
-"และตรวจสอบว่า DuckDuckGo ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ ให้ไปที่ %1$s⋮ > เมนู > "
+"การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s และตรวจสอบว่า DuckDuckGo "
+"ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10037,8 +10132,7 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
-"คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
+"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
 "คุณสามารถบันทึกโค้ดนี้ลงในอุปกรณ์ของคุณเป็นไฟล์ข้อความได้"
 
 # smartling.placeholder_format=C
@@ -10055,8 +10149,7 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ "
-"%2$s ของเรา"
+"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ %2$s ของเรา"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10064,8 +10157,7 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" "
-"(เปิดด้วย)"
+"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" (เปิดด้วย)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10207,7 +10299,6 @@ msgid ""
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
 "ในเบราว์เซอร์เก่ากว่าบางรายการ "
-""
 "เราจำเป็นต้องเปลี่ยนเส้นทางการคลิกของคุณผ่านเซิร์ฟเวอร์ของเราเพื่อป้องกันการรั่วไหลของข้อมูลการค้นหา "
 "%1$sดูข้อมูลเพิ่มเติม%2$s"
 
@@ -10643,11 +10734,9 @@ msgid ""
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
 "รายการต่างๆ "
-""
 "ได้รับการจัดลำดับตามความเกี่ยวข้องกับข้อความค้นหาของคุณและจัดส่งผ่านเครือข่ายโฆษณาของ "
-"Microsoft การคลิกนำไปสู่หน้า Landing Page "
-"ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา DuckDuckGo "
-"ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
+"Microsoft การคลิกนำไปสู่หน้า Landing Page ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา "
+"DuckDuckGo ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10656,8 +10745,7 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว "
-"และมีความปลอดภัยมากกว่า"
+"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว และมีความปลอดภัยมากกว่า"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11124,6 +11212,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "ช่วยให้คุณค้นหาแบบไม่ระบุตัวตนได้ด้วย DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "ไลบีเรีย"
 
@@ -11192,6 +11287,12 @@ msgstr "รูปวาดที่เป็นเส้น"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "ไลน์เอาต์ที่ได้"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12284,6 +12385,12 @@ msgid "More than 20 minutes"
 msgstr "มากกว่า 20 นาที"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12604,11 +12711,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
-"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12770,6 +12875,12 @@ msgstr "ไม่ ขอบคุณ"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "ไม่ ขอบคุณ"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13424,14 +13535,20 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows "
-"%3$sให้คลิกไอคอน %4$s > การตั้งค่า%5$s"
+"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows %3$sให้คลิกไอคอน %4$s "
+"> การตั้งค่า%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "เปิดแต่ไม่มีตัวเลข"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13447,8 +13564,7 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ "
-"โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
+"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13474,9 +13590,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น "
-"มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
+msgstr "เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13644,6 +13758,12 @@ msgid "Open create and edit images suggestions"
 msgstr "เปิดสร้างและแก้ไขคำแนะนำรูปภาพ"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13807,8 +13927,7 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"เครื่องมือค้นหาอื่นๆ "
-"จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
+"เครื่องมือค้นหาอื่นๆ จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
 "แต่เราไม่ติดตามคุณอย่างแน่นอน"
 
 # smartling.placeholder_format=C
@@ -13822,8 +13941,7 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: "
-"เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
+"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13831,9 +13949,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย "
-"พร้อมใช้งานบน %1$siOS และ Android%2$s"
+"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย พร้อมใช้งานบน %1$siOS และ Android%2$s"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14086,8 +14203,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, "
-"ลายนิ้วมือจากเบราว์เซอร์ หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
+"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, ลายนิ้วมือจากเบราว์เซอร์ "
+"หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14287,10 +14404,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้คำตอบที่ได้รับความช่วยเหลือจาก "
-"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
-"หากต้องการปิดและซ่อนปุ่ม Assist ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
+"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
+"ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14300,9 +14416,8 @@ msgid ""
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า "
-"หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด ให้ไปที่%1$sการตั้งค่า "
-"DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด "
+"ให้ไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14313,8 +14428,8 @@ msgid ""
 "Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
-"หากต้องการปิดและซ่อนปุ่ม Assist โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
+"โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14362,9 +14477,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ "
-"DuckDuckGo"
+msgstr "เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14385,10 +14498,22 @@ msgid "Pin"
 msgstr "หมุด"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "ปักหมุดแชทที่นี่จาก %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14406,6 +14531,12 @@ msgstr "สีชมพู"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "ปักหมุด"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14717,6 +14848,12 @@ msgid "Poor formatting"
 msgstr "การจัดรูปแบบที่ไม่ดี"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14923,6 +15060,12 @@ msgstr "ภาพก่อนหน้านี้"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "แท็บก่อนหน้านี้"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15259,9 +15402,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น "
-"[แทรกข้อความของคุณเองที่นี่]"
+msgstr "ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น [แทรกข้อความของคุณเองที่นี่]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15463,6 +15604,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "การใช้เหตุผล AI ที่มีการควบคุมภายในปานกลาง"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15498,6 +15651,12 @@ msgid "Recent chat storage can be adjusted in %s."
 msgstr "พื้นที่จัดเก็บแชทล่าสุดสามารถปรับได้ใน %1$s"
 
 # smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
 msgctxt "Description for recent chats feature"
 msgid ""
@@ -15526,9 +15685,8 @@ msgid ""
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
 "การแชทล่าสุดจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15651,6 +15809,12 @@ msgstr "ลองค้นหาใหม่โดยไม่รวมเว็
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "ลดการใช้งาน"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15798,8 +15962,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ "
-"&quot;รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
+"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ &quot;"
+"รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15889,8 +16053,7 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"ถาม\" ออก "
-"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"ถาม\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -15899,8 +16062,7 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"สร้าง\" ออก "
-"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"สร้าง\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -15959,9 +16121,8 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo "
-"เพื่อช่วยปรับปรุงบริการค้นหาของเรา ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ "
-"%1$s เพื่อช่วยปรับปรุงบริการ"
+"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo เพื่อช่วยปรับปรุงบริการค้นหาของเรา "
+"ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ %1$s เพื่อช่วยปรับปรุงบริการ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15969,8 +16130,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ "
-"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ "
+"ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15979,9 +16140,8 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo "
-"รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ และจะไม่ระบุตัวตน "
-"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ "
+"และจะไม่ระบุตัวตน โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16028,6 +16188,12 @@ msgid "Reset All Settings"
 msgstr "รีเซ็ตการตั้งค่าทั้งหมด"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16038,6 +16204,12 @@ msgstr "รีเซ็ตใน %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "ความละเอียด"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16061,9 +16233,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
 "%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -16073,9 +16244,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
 "อยู่ภายใต้%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -16086,11 +16256,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่น ๆ "
-"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search "
-"Assist อยู่ภายใต้ %1$sข้อกำหนดการให้บริการ%2$sของเรา"
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่น ๆ "
+"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search Assist อยู่ภายใต้ "
+"%1$sข้อกำหนดการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16677,8 +16846,7 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s "
-"(หรือ%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ%5$sเพิ่มใหม่%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16687,8 +16855,7 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ "
-"%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ %5$sเพิ่มใหม่%6$s)"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16737,6 +16904,12 @@ msgid "Search %s to find results closer to you?"
 msgstr "ค้นหา %1$s เพื่อดูผลลัพธ์ที่ใกล้กับคุณมากขึ้นหรือไม่"
 
 # smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Search Anonymously"
 msgstr "ค้นหาแบบไม่ระบุตัวตน"
 
@@ -16761,11 +16934,10 @@ msgid ""
 "subset of English speaking regions."
 msgstr ""
 "Search Assist สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น "
-"ๆ คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ "
-"(เฉพาะเมื่อคลิก Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ Search Assist "
-"มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
+"คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ (เฉพาะเมื่อคลิก "
+"Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ "
+"Search Assist มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16773,8 +16945,7 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ "
-"ลองค้นหาอีกครั้ง"
+"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ ลองค้นหาอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16783,9 +16954,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ "
-"ในการทำเช่นนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ "
-"AI เพื่อสร้างคำตอบสั้น ๆ ตามข้อมูลที่พบ"
+"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการทำเช่นนี้ "
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
+"ตามข้อมูลที่พบ"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16906,8 +17077,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" "
-"โดยตรงบน Wikipedia"
+"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" โดยตรงบน "
+"Wikipedia"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16927,8 +17098,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "ค้นหาอย่างเป็นส่วนตัวด้วยแอปหรือส่วนขยายของเรา "
-"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ "
-"%1$sduckduckgo.com%2$s"
+"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ %1$sduckduckgo."
+"com%2$s"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16947,10 +17118,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-""
 "การตั้งค่าการค้นหาจะถูกเก็บไว้ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคลและที่เก็บข้อมูลภายในในเบราว์เซอร์ของคุณ "
 "แต่คุณยังสามารถใช้ Cloud Save "
-""
 "เพื่อจัดเก็บการตั้งค่าของคุณโดยไม่ระบุตัวตนบนเซิร์ฟเวอร์ระยะไกลในคลาวด์ได้อีกด้วย "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวบุคคลได้บนระบบคลาวด์ "
 "และวลีรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
@@ -17072,7 +17241,6 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-""
 "จัดเก็บแชทได้เกือบไม่จำกัดบนเซิร์ฟเวอร์ของเราอย่างปลอดภัยด้วยการเข้ารหัสแบบครบวงจร "
 "และเข้าถึงได้จากอุปกรณ์ที่ซิงค์ทั้งหมดของคุณ"
 
@@ -17101,6 +17269,12 @@ msgid ""
 msgstr ""
 "จัดเก็บอย่างปลอดภัยบนเซิร์ฟเวอร์ของ DuckDuckGo ด้วยการเข้ารหัสแบบครบวงจร "
 "ไม่มีใครนอกจากคุณที่สามารถเห็นข้อมูลของคุณ แม้แต่เรา"
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17245,8 +17419,7 @@ msgstr "เลือก %1$s\"การตั้งค่าสำหรับ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s "
-"ลงในช่องการป้อนข้อมูล"
+"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s ลงในช่องการป้อนข้อมูล"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17311,8 +17484,7 @@ msgstr "เลือก%1$sจัดการส่วนเสริม%2$sจ�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน "
-"Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน Windows)"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17320,8 +17492,7 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน "
-"Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17385,9 +17556,7 @@ msgstr "เลือก%1$sการตั้งค่า%2$s จากนั้
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ "
-"ตามต้องการ)"
+msgstr "เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ ตามต้องการ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17509,8 +17678,7 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ส่งพรอมต์ไปยังโมเดล AI "
-"พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
+"ส่งพรอมต์ไปยังโมเดล AI พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
 "คำแนะนำเหล่านี้จะใช้กับการสนทนาทั้งหมดของคุณต่อไป"
 
 # smartling.placeholder_format=C
@@ -17609,6 +17777,12 @@ msgid "Set as Homepage"
 msgstr "ตั้งเป็นหน้าแรก"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17621,16 +17795,13 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ตั้งค่า Sync & Backup "
-"หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
+"ตั้งค่า Sync & Backup หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง "
-"หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
+msgstr "ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17676,6 +17847,18 @@ msgid "Seychelles"
 msgstr "เซเชลส์"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17713,6 +17896,13 @@ msgid ""
 msgstr ""
 "แชร์ตำแหน่งที่ตั้งระดับเมืองกับโมเดล AI เพื่อเพิ่มความเกี่ยวข้อง Duck.ai "
 "จะไม่เปิดเผยตำแหน่งที่แน่นอนของคุณให้กับเรา หรือกับโมเดล AI"
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17771,6 +17961,12 @@ msgstr "แชร์ URL ของหน้า"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "แชร์ข้อเสนอแนะเชิงบวก"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17906,6 +18102,12 @@ msgstr "แสดงข้อมูล Bookmarklet และการตั้�
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "แสดงรายละเอียด"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18055,6 +18257,12 @@ msgid "Show more"
 msgstr "แสดงเพิ่มเติม"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18088,6 +18296,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "แสดงแถบด้านข้าง"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18190,8 +18404,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ "
-"DuckDuckGo"
+"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18458,6 +18671,12 @@ msgid "Something went wrong, please try again later."
 msgstr "เกิดข้อผิดพลาดบางอย่าง โปรดลองอีกครั้งในภายหลัง"
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18533,9 +18752,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s "
-"เพื่อลองอีกครั้ง"
+msgstr "ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s เพื่อลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18742,6 +18959,12 @@ msgstr "เริ่มใช้ขีดจำกัดรายเดือน
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "เริ่มใช้ขีดจำกัดรายสัปดาห์"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19008,9 +19231,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ "
-"สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
+msgstr "เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19322,6 +19543,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "เปลี่ยนไปใช้เครื่องมือค้นหาที่จะไม่ติดตามคุณอย่างแน่นอน"
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19435,9 +19664,8 @@ msgid ""
 msgstr ""
 "รหัสกู้คืนการซิงค์\n"
 "\n"
-"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท "
-"Duck.ai ของคุณระหว่างอุปกรณ์หลายเครื่อง "
-"และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
+"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท Duck.ai "
+"ของคุณระหว่างอุปกรณ์หลายเครื่อง และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
 "\n"
 "เก็บรักษาข้อมูลนี้ให้ปลอดภัย\n"
 "ทุกคนที่มีสิทธิ์เข้าถึงรหัสนี้สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณ\n"
@@ -19447,11 +19675,9 @@ msgstr ""
 "วิธีการทำงานของโค้ดนี้คืออะไร?\n"
 "1. ไปที่ Duck.ai ในเบราว์เซอร์ของคุณ แล้วเปิดการตั้งค่า Duck.ai\n"
 "2. เลือก \"เปิดใช้งาน Sync & Backup\" จากนั้นเลือก \"Recover Synced Data\"\n"
-"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code "
-"here\"\n"
+"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code here\"\n"
 "\n"
-"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup "
-"เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
+"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
 "ข้อมูลของคุณจะถูกลบออกจากเซิร์ฟเวอร์และไม่สามารถกู้คืนได้"
 
 # smartling.placeholder_format=C
@@ -19471,6 +19697,12 @@ msgstr "ซิงค์กับอุปกรณ์อื่น"
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "ซิงค์และสำรองข้อมูล ไม่สามารถใช้งานได้ชั่วคราว"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19560,6 +19792,22 @@ msgid "Take Back Your Privacy!"
 msgstr "ทวงคืนความเป็นส่วนตัวของคุณ!"
 
 # smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
 msgid "Take Our Survey"
@@ -19580,9 +19828,7 @@ msgstr "ควบคุมข้อมูลส่วนบุคคลของ
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai "
-"ดีขึ้นได้อย่างไรบ้าง"
+msgstr "ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai ดีขึ้นได้อย่างไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -19797,7 +20043,6 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-""
 "นั่นหมายความว่าข้อมูลที่ส่งระหว่างอุปกรณ์ของคุณกับหน้าเว็บเบื้องหลังลิงก์นี้มีความเสี่ยงมากขึ้นต่อการถูกดักข้อมูลโดยบุคคลที่สาม "
 "ในบางกรณีซึ่งเกิดขึ้นไม่บ่อย ข้อมูลนี้รวมถึงรหัสผ่านหรือรายละเอียดการชำระเงิน"
 
@@ -19839,7 +20084,6 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-""
 "คีย์การเข้ารหัสจะถูกบันทึกไว้เฉพาะในที่เก็บข้อมูลในเครื่องของเบราว์เซอร์ของคุณ "
 "และมีเพียงคุณเท่านั้นที่สามารถเข้าถึงได้"
 
@@ -19862,9 +20106,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ "
-"บนเซิร์ฟเวอร์ของเขา"
+msgstr "ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ บนเซิร์ฟเวอร์ของเขา"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19957,7 +20199,6 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-""
 "สิทธิ์ของเบราว์เซอร์เหล่านี้ใช้เพื่อเพิ่มการปกป้องความเป็นส่วนตัวบนเว็บไซต์ที่คุณเยี่ยมชมโดยการบล็อกตัวติดตามที่ซ่อนอยู่ "
 "การเข้ารหัสการเชื่อมต่อเมื่อสามารถทำได้ และการตั้งค่าให้ DuckDuckGo "
 "เป็นเครื่องมือค้นหาเริ่มต้นของคุณ"
@@ -20005,9 +20246,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป "
-"ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
+msgstr "เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20022,10 +20261,22 @@ msgid "This Month"
 msgstr "เดือนนี้"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "สัปดาห์นี้"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20066,9 +20317,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s "
-"แชท AI อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s "
-"สำหรับข้อมูลเพิ่มเติม)"
+"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s แชท AI "
+"อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s สำหรับข้อมูลเพิ่มเติม)"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20154,6 +20404,22 @@ msgid "This information isn’t useful"
 msgstr "ข้อมูลนี้ไม่เป็นประโยชน์"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20172,8 +20438,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน "
-"ผู้ให้บริการโมเดลอื่นๆ เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
+"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน ผู้ให้บริการโมเดลอื่นๆ "
+"เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20182,8 +20448,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ "
-"ผู้ให้บริการโมเดลอื่นๆ ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
+"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ ผู้ให้บริการโมเดลอื่นๆ "
+"ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20220,7 +20486,6 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-""
 "การดำเนินการนี้จะบันทึกการแชทของคุณด้วยการเข้ารหัสแบบครบวงจรบนเซิร์ฟเวอร์ที่ปลอดภัยของ "
 "DuckDuckGo ซึ่งต่อมาสามารถเข้าถึงได้จากเบราว์เซอร์ใดก็ตาม"
 
@@ -20231,9 +20496,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
-"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
-"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
+"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20243,9 +20507,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
-"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
-"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
+"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
 "เรามีหน้าเริ่มต้นที่ไม่แสดงคำตอบที่ได้รับความช่วยเหลือจาก AI ด้วยที่ %1$s"
 
 # smartling.placeholder_format=C
@@ -20285,9 +20548,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ "
-"Sync & Backup คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ "
-"ที่เชื่อมต่อกับ Sync & Backup"
+"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ Sync & Backup "
+"คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ ที่เชื่อมต่อกับ Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20296,8 +20558,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ "
-"เว้นแต่ว่าจะมีการปักหมุดไว้ การกระทำนี้ย้อนกลับไม่ได้"
+"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ เว้นแต่ว่าจะมีการปักหมุดไว้ "
+"การกระทำนี้ย้อนกลับไม่ได้"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20315,9 +20577,7 @@ msgstr "การตั้งค่าทั้งหมดของคุณจ
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น "
-"ดำเนินการต่อหรือไม่"
+msgstr "การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น ดำเนินการต่อหรือไม่"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20436,7 +20696,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "วิธีการพิมพ์เส้นทาง:%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
+msgstr ""
+"วิธีการพิมพ์เส้นทาง:"
+"%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20446,8 +20708,7 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ "
-"คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
+"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
 "รหัสนี้อาจถูกบันทึกเป็น PDF บนอุปกรณ์ที่คุณใช้ตั้งค่าการซิงค์ในตอนแรก"
 
 # smartling.placeholder_format=C
@@ -20482,6 +20743,12 @@ msgstr "วันนี้"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "วันนี้"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20703,9 +20970,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: "
-"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr "แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20713,9 +20978,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: "
-"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr "แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20895,9 +21158,21 @@ msgid "Try Them Out"
 msgstr "ลองใช้ดู"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "ลองค้นหา"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -20962,6 +21237,12 @@ msgid "Try for free"
 msgstr "ลองใช้ฟรี"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -20974,6 +21255,12 @@ msgstr "ลองใช้ฟรี"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "ลองใช้ฟรี! VPN ที่ปลอดภัย, AI ที่ล้ำสมัยและเป็นส่วนตัว และอื่นๆ อีกมากมาย"
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21001,6 +21288,12 @@ msgstr "ลองเบราว์เซอร์ของเรา"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "ลองใช้หน้าแรกของเราที่ไม่แสดงข้อความเหล่านี้:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21115,8 +21408,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา "
-"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา %1$sDuckDuckGo No "
+"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21125,8 +21418,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา "
-"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา %1$sDuckDuckGo No "
+"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21246,6 +21539,12 @@ msgstr "เปิด %1$sตำแหน่งที่แม่นยำ%2$s �
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "เปิด Duck Player เพื่อดู YouTube โดยไม่ต้องมีโฆษณาที่ตรงเป้าหมาย"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21440,8 +21739,7 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s "
-"จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -21449,8 +21747,7 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: "
-"https://duckduckgo.com"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21566,8 +21863,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus "
-"ถึง 2 เท่า โดยการอัปเกรดเป็น Pro"
+"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า "
+"โดยการอัปเกรดเป็น Pro"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21608,6 +21905,12 @@ msgstr "ปลดล็อกโมเดล AI ขั้นสูงด้ว�
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "ปลดล็อก AI ขั้นสูงด้วยการสมัครของคุณ!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -21701,8 +22004,7 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai "
-"และเข้าถึงโมเดลขั้นสูง"
+"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai และเข้าถึงโมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -21930,9 +22232,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ "
-"นักต้มตุ๋น และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย "
-"ไม่จำเป็นต้องมีบัญชี"
+"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ นักต้มตุ๋น "
+"และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย ไม่จำเป็นต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21969,14 +22270,18 @@ msgid "Use in Safari"
 msgstr "ใช้งานบน Safari"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
-"เก็บรักษาไว้ให้ปลอดภัย"
+msgstr "ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ เก็บรักษาไว้ให้ปลอดภัย"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22155,9 +22460,7 @@ msgstr "หมู่เกาะเวอร์จิน"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr ""
-"ไปที่ %1$sการตั้งค่า Assist%2$s "
-"เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
+msgstr "ไปที่ %1$sการตั้งค่า Assist%2$s เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22165,9 +22468,7 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr ""
-"ไปที่ %1$sการตั้งค่า DuckAssist%2$s "
-"เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
+msgstr "ไปที่ %1$sการตั้งค่า DuckAssist%2$s เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22190,9 +22491,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s "
-"> %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another "
-"Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s > %3$sSync "
+"& Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22202,9 +22502,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก "
-"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก \"เปิด\" ภายใต้ Sync "
+"& Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22214,9 +22513,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ "
-"%1$sDuck.ai Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s "
-"จากนั้นเลือก %7$sSync With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ %1$sDuck.ai "
+"Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync "
+"With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22226,9 +22525,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า "
-"Duck.ai เลือก \"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า Duck.ai เลือก "
+"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF "
+"การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22280,10 +22579,7 @@ msgstr "แชทด้วยเสียงสิ้นสุดลง"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-""
-"เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล "
-"AI"
+msgstr "เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22448,10 +22744,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ "
-"เพราะเราต้องสตรีมเนื้อหาจากที่นั่น DuckDuckGo "
-"เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube "
-"ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
+"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ เพราะเราต้องสตรีมเนื้อหาจากที่นั่น "
+"DuckDuckGo เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22463,9 +22757,7 @@ msgstr "เราทำให้ไม่ระบุตัวตน"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s "
-"แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
+msgstr "เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22477,9 +22769,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
-"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย โปรดแชร์การสนทนานี้กับ "
-"DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"โปรดแชร์การสนทนานี้กับ DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22491,8 +22782,7 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
-"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
 "โปรดแชร์คำแนะนำและการตอบสนองของคุณเพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
@@ -22506,9 +22796,7 @@ msgstr "เราสามารถใช้%1$sตำแหน่งที่�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"เราไม่สามารถอ่านไฟล์ที่แนบมาได้ "
-"เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
+msgstr "เราไม่สามารถอ่านไฟล์ที่แนบมาได้ เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22536,8 +22824,7 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ "
-"เราไม่ติดตามคุณ อย่างแน่นอน"
+"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ เราไม่ติดตามคุณ อย่างแน่นอน"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22550,9 +22837,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ "
-"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
+msgstr "เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22561,8 +22846,7 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ "
-"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
+"เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22629,8 +22913,7 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"เรามีข้อตกลงกับผู้ให้บริการ AI "
-"ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
+"เรามีข้อตกลงกับผู้ให้บริการ AI ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22665,7 +22948,6 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-""
 "เราใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนของคุณเพียงเพื่อให้ได้ผลลัพธ์ที่แม่นยำยิ่งขึ้นและใกล้คุณมากขึ้นเท่านั้น "
 "คุณสามารถเปลี่ยนใจได้เสมอในภายหลัง"
 
@@ -22673,9 +22955,7 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo "
-"ให้ดียิ่งขึ้นสำหรับทุกคน"
+msgstr "เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo ให้ดียิ่งขึ้นสำหรับทุกคน"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22711,8 +22991,7 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ "
-"ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
+"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22745,8 +23024,7 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล "
-"เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
+"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -22854,9 +23132,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว "
-"คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
+msgstr "ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22870,8 +23146,7 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว "
-"เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
+"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22892,8 +23167,7 @@ msgid ""
 "to train AI models."
 msgstr ""
 "ยินดีต้อนรับสู่ DuckDuckGo AI Chat! เซสชันแชทนี้ขับเคลื่อนโดย %2$s ของ %1$s "
-"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo "
-"หรือใช้เพื่อฝึกโมเดล AI"
+"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo หรือใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23000,9 +23274,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ "
-"\"เราต้องทำให้ได้ดีกว่านี้\""
+msgstr "มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ \"เราต้องทำให้ได้ดีกว่านี้\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23021,11 +23293,10 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo "
-"สำหรับผู้ที่สนใจใช้ Duck.ai อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ "
-"DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ ที่ชัดเจนพร้อมชื่อหัวข้อ "
-"โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น ง่าย "
-"และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
+"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo สำหรับผู้ที่สนใจใช้ Duck.ai "
+"อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ "
+"ที่ชัดเจนพร้อมชื่อหัวข้อ โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น "
+"ง่าย และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23135,6 +23406,12 @@ msgstr "คุณไม่พอใจอะไรมากที่สุด"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "สิ่งใดทำให้คุณกลับมาในวันนี้"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23551,6 +23828,14 @@ msgid "Wintry Mix"
 msgstr "อากาศผสมฤดูหนาว"
 
 # smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -23844,9 +24129,7 @@ msgstr "คุณสามารถเข้าถึง DuckDuckGo AI Chat ไ�
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน "
-"%2$sการตั้งค่าการค้นหา%3$s"
+msgstr "คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน %2$sการตั้งค่าการค้นหา%3$s"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -23855,8 +24138,7 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน "
-"%1$sการตั้งค่าการค้นหา%2$s"
+"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
@@ -23971,6 +24253,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "คุณสามารถแนบได้เพียง %1$s ภาพเท่านั้นต่อการสนทนา"
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -23988,9 +24277,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s "
-"คุณต้องเลิกบล็อกไซต์อื่นก่อน"
+msgstr "คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s คุณต้องเลิกบล็อกไซต์อื่นก่อน"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24047,8 +24334,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, "
-"และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า"
+"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 "
+"เท่า"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24110,6 +24397,12 @@ msgid ""
 msgstr "คุณจะได้รับการอัปเดตแอป DuckDuckGo อัตโนมัติเมื่อคุณมีเวอร์ชันล่าสุด"
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24117,8 +24410,7 @@ msgid ""
 "browse privately too. It’s already installed and can:"
 msgstr ""
 "ตอนนี้คุณกำลังค้นหาแบบเป็นส่วนตัวใน Chrome ใช้แอปของเราแทน Chrome "
-"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน "
-"แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
+"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24131,8 +24423,7 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว "
-"%1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
+"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว %1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24156,6 +24447,12 @@ msgstr "คุณบล็อก %1$s เว็บไซต์แล้ว"
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "คุณได้บล็อก 1 ไซต์"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24202,8 +24499,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว "
-"ลบแชทที่เก่าที่สุด %1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว ลบแชทที่เก่าที่สุด "
+"%1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24213,9 +24510,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท "
-"%1$s รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ "
-"แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท %1$s "
+"รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24229,8 +24525,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน "
-"การดูวิดีโอ YouTube ที่นี่จะถูกติดตามโดย YouTube/Google"
+"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน การดูวิดีโอ YouTube "
+"ที่นี่จะถูกติดตามโดย YouTube/Google"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24313,17 +24609,14 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo "
-"ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
+"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo "
-"ไม่เคยเข้าถึงข้อมูลนี้"
+msgstr "เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo ไม่เคยเข้าถึงข้อมูลนี้"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24371,8 +24664,7 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
-"เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24380,8 +24672,7 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
-"เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24481,8 +24772,7 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า "
-"%1$sSHA-2%2$s "
+"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า %1$sSHA-2%2$s "
 "เฉพาะคีย์และไฟล์การตั้งค่าที่เกี่ยวข้องเท่านั้นที่ออกจากเบราว์เซอร์ของคุณ "
 "เราบันทึกไฟล์การตั้งค่าโดยใช้คีย์เป็นชื่อ DuckDuckGo จะไม่ทราบรหัสผ่านของคุณ"
 
@@ -24499,8 +24789,7 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo "
-"และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
+"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
 "เพื่อให้ผู้ให้บริการโมเดลไม่สามารถเชื่อมโยงการสนทนาของคุณกลับไปยังคุณ"
 
 # smartling.placeholder_format=C
@@ -24540,16 +24829,22 @@ msgid "Your searches can’t be tied back to you"
 msgstr "การค้นหาของคุณไม่สามารถเชื่อมโยงกลับไปหาคุณ"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว "
-"แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
-"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร "
-"%3$sศึกษาเพิ่มเติม%4$s"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
+"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -24912,9 +25207,7 @@ msgstr "เว็บไซต์อย่างเป็นทางการ"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s "
-"ตัวที่เข้ารหัสแล้ว)"
+msgstr "หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s ตัวที่เข้ารหัสแล้ว)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25125,3 +25418,9 @@ msgstr "ปี"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "ปี"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "ตรวจพบ %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s ไฟล์ที่ใช้"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -183,7 +183,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
+"Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -194,7 +195,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
+"Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -211,7 +213,8 @@ msgid ""
 "model."
 msgstr ""
 "%1$s สามารถใช้ได้เฉพาะกับการสมัครใช้งาน DuckDuckGo เท่านั้น "
-"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
+"หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -219,7 +222,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s ไม่สามารถใช้งานได้ชั่วคราว โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
+msgstr ""
+"%1$s ไม่สามารถใช้งานได้ชั่วคราว "
+"โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -311,6 +316,7 @@ msgid ""
 "their servers."
 msgstr ""
 "%1$s ทํางานในสภาพแวดล้อมการดําเนินการที่เชื่อถือได้ "
+""
 "นี่หมายความว่าแม้แต่ผู้ให้บริการโมเดลก็ไม่สามารถดูคำแนะนำของคุณหรือการตอบสนองของโมเดล "
 "หรือบันทึกการแชทนี้บนเซิร์ฟเวอร์ของพวกเขา"
 
@@ -359,7 +365,7 @@ msgstr "%1$s ที่ใช้"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s ใช้ขีดจำกัดเร็วกว่าโมเดลพื้นฐานสูงสุดถึง 2-5 เท่า %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -398,7 +404,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น "
+"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -408,7 +415,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+msgstr ""
+"%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น "
+"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -428,7 +437,8 @@ msgstr "%1$sคลิก%2$sเพิ่ม%3$sเลือก%4$sอนุญ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s จากนั้นคลิก%8$sตกลง%9$s"
+"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s "
+"จากนั้นคลิก%8$sตกลง%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -473,13 +483,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
+"%1$sเรียนรู้เพิ่มเติม%2$s "
+"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
+msgstr ""
+"%1$sเรียนรู้เพิ่มเติม%2$s "
+"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -603,7 +616,7 @@ msgstr "1 วันที่ผ่านมา"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 ไฟล์ที่ใช้"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -945,8 +958,9 @@ msgid ""
 "aichat%s."
 msgstr ""
 "AI Chat ช่วยให้คุณสนทนาแบบไม่ต้องระบุชื่อด้วยโมเดลแชท AI ของบริษัทอื่น "
-"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search คุณยังคงสามารถเข้าถึง AI Chat "
-"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$sduckduckgo.com/aichat%2$s"
+"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search "
+"คุณยังคงสามารถเข้าถึง AI Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
+"%1$sduckduckgo.com/aichat%2$s"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1009,7 +1023,8 @@ msgid ""
 msgstr ""
 "คำตอบที่ได้รับความช่วยเหลือจาก AI ขณะนี้ยังไม่รองรับคำถามที่ถามต่อโดยตรง "
 "แต่เรามีและมักจะเชื่อมโยงไปยัง %1$sDuck.ai%2$s สำหรับคำถามที่ถามต่อ "
-"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic และอีกมากมาย"
+"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic "
+"และอีกมากมาย"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1194,7 +1209,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
+"หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1229,7 +1245,9 @@ msgstr "โฆษณา"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+msgstr ""
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1237,7 +1255,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1509,7 +1528,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
+msgstr "โมเดลขั้นสูงอาจใช้ขีดจำกัดเร็วกว่าโมเดลอื่นถึง 2-5 เท่า %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1551,7 +1570,9 @@ msgstr "หลังจากดาวน์โหลดและเปิด �
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
+msgstr ""
+"หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย "
+"ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1688,7 +1709,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "การแชททั้งหมดจะถูกทำให้ไม่ระบุชื่อโดย DuckDuckGo "
-"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo หรือผู้ให้บริการโมเดล"
+"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo "
+"หรือผู้ให้บริการโมเดล"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1735,8 +1757,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ "
-"AI"
+"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) "
+"จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ AI"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1800,8 +1822,10 @@ msgid ""
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
 "อนุญาตให้ %1$s ค้นหาเว็บเพื่อปรับปรุงการตอบสนองต่อข้อความแจ้งที่เกี่ยวข้อง "
-"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
-"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี %3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
+"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI "
+"ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
+"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี "
+"%3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1946,7 +1970,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
+"%4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -1955,7 +1980,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
+"%4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -1969,8 +1995,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ เลือกความถี่ที่คุณต้องการให้แสดง "
-"หรือปิดการใช้งานโดยสมบูรณ์"
+"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ "
+"เลือกความถี่ที่คุณต้องการให้แสดง หรือปิดการใช้งานโดยสมบูรณ์"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2017,7 +2043,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
+"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น "
+"บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2137,7 +2164,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด รวมถึงแชทที่ปักหมุดไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด "
+"รวมถึงแชทที่ปักหมุดไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2146,7 +2174,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด "
+"การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2184,8 +2213,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ ด้วยตนเอง "
-"การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
+"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ "
+"ด้วยตนเอง การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2286,7 +2315,7 @@ msgstr "ถามเป็นการส่วนตัว"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "ถามเป็นการส่วนตัว"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2322,12 +2351,16 @@ msgid ""
 "answers are only available in the U.S. (English) region."
 msgstr ""
 "Assist สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
+""
 "โดยไม่ระบุตัวตนให้กับการค้นหาบางรายการโดยอิงจากการสรุปเนื้อหาเว็บที่เกี่ยวข้อง "
-"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ Assist UI "
-"ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อคุณคลิกปุ่ม Assist), บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
-"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
+"Assist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
+"(แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI เมื่อคุณคลิกปุ่ม Assist), "
+"บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
+"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา "
+"(ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2339,9 +2372,14 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ "
+"Assist "
+""
+"เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก "
+"AI สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ "
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
+"ตามข้อมูลที่เกี่ยวข้องที่พบ "
+""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -2507,8 +2545,8 @@ msgid ""
 "Assist is only available in English regions."
 msgstr ""
 "แสดง Assist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง Assist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ Assist "
-"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
+"Assist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2518,8 +2556,8 @@ msgid ""
 "For now, DuckAssist is only available in English regions."
 msgstr ""
 "แสดง DuckAssist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง DuckAssist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ DuckAssist "
-"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
+"DuckAssist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2725,8 +2763,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ PII เช่น ชื่อ "
-"ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
+"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ "
+"PII เช่น ชื่อ ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3107,15 +3145,17 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ เรารวมเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
+"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ "
+"เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม "
 "และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
@@ -3124,8 +3164,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private "
-"Search, การบล็อกตัวติดตาม และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง "
+"ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private Search, การบล็อกตัวติดตาม "
+"และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3232,9 +3273,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"ตามค่าเริ่มต้น การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
+"ตามค่าเริ่มต้น "
+"การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
 "(ในเบราว์เซอร์ของคุณ) คุณสามารถใช้ Cloud Save "
-"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ (บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
+"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ "
+"(บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวตนได้บนระบบคลาวด์และรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
 
 # smartling.placeholder_format=C
@@ -3243,8 +3286,9 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
-"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง "
+"คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู "
+"%1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3253,8 +3297,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
-"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง "
+"OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3741,7 +3785,8 @@ msgstr ""
 "Chat (ผ่านบริการ Duck.ai ของเรา) ให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI "
 "ของบุคคลที่สาม ซึ่งรองรับโมเดลจาก OpenAI, Anthropic และอีกมากมาย "
 "การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม "
-"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
+"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
+"%1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3821,7 +3866,7 @@ msgstr "แชทแบบส่วนตัวกับ AI"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "แชทแบบส่วนตัวกับ AI ยอดนิยม"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3872,8 +3917,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo หรือเซิร์ฟเวอร์ระยะไกล "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
+"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo "
+"หรือเซิร์ฟเวอร์ระยะไกล การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3886,9 +3931,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "แชทจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
+"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3911,7 +3958,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน Duck.ai "
+"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน "
+"Duck.ai "
 "จะได้รับการตรวจสอบโดยไม่ระบุชื่อโดยผู้ให้บริการกลั่นกรองเนื้อหาสำหรับ %2$s"
 
 # smartling.placeholder_format=C
@@ -3972,7 +4020,9 @@ msgstr "ตรวจสอบการสะกดคำ"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "ตรวจสอบ subreddit ของ DuckDuckGo เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
+msgstr ""
+"ตรวจสอบ subreddit ของ DuckDuckGo "
+"เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4265,8 +4315,9 @@ msgid ""
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชท "
-"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน AI "
-"Chat เป็นเวลา 7 วันขึ้นไป"
+""
+"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน "
+"AI Chat เป็นเวลา 7 วันขึ้นไป"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4277,8 +4328,8 @@ msgid ""
 "on your browser."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชทล่าสุด "
-"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 วันหากไม่ได้ใช้ Duck.ai "
-"ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
+"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 "
+"วันหากไม่ได้ใช้ Duck.ai ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4287,7 +4338,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
+"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ "
+"บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4296,8 +4348,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s บริการแชท AI "
-"ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
+"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s "
+"บริการแชท AI ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4339,7 +4391,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน Mac)"
+"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน "
+"Mac)"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4370,7 +4423,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
+"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows "
+"ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4462,7 +4516,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
 "คลิกหรือแตะ %1$sลบข้อมูลของฉัน%2$s การดำเนินการนี้จะลบข้อมูลออกจากระบบคลาวด์ "
-"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ %3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
+"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ "
+"%3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4543,7 +4598,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก %3$sDuckDuckGo%4$s"
+"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก "
+"%3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4596,7 +4652,7 @@ msgstr "ปิด"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "ปิด"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4646,7 +4702,7 @@ msgstr "ปิดการค้นหา"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "ปิดความเห็นที่สอง"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4751,7 +4807,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
+"Cloud Save "
+"ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
 "ซึ่งเป็นการดำเนินการที่ไม่บังคับ"
 
 # smartling.placeholder_format=C
@@ -5023,7 +5080,7 @@ msgstr "บล็อกโฆษณาต่อไป"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "คุยแชทล่าสุดต่อที่นี่ หรือลบด้วย Fire Button"
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5094,7 +5151,7 @@ msgstr "ข้อมูลคุกกี้:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "คัดลอกแล้ว"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5147,7 +5204,7 @@ msgstr "คัดลอกรหัส"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "คัดลอกลิงก์"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5266,7 +5323,7 @@ msgstr "สร้างภาพ"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "สร้างลิงก์แชร์"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5317,7 +5374,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
+msgstr "การสร้างลิงก์จะเป็นการคัดลอกแชท ซึ่งทุกคนที่เปิดลิงก์จะสามารถดูได้"
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5476,7 +5533,7 @@ msgstr "ปรับแต่งการตอบสนอง"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "ปรับแต่งการตอบสนอง"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5764,7 +5821,7 @@ msgstr "ลบข้อมูลเซิร์ฟเวอร์?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "ลบลิงก์ที่แชร์"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5776,7 +5833,7 @@ msgstr "ลบข้อความ"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "ลบแชท"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5814,7 +5871,7 @@ msgstr "ลบรูปภาพใช่ไหม"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "ลบฉัน"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6128,7 +6185,7 @@ msgstr "ปิดการเลื่อนระดับ"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "ปิดทัวร์"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6273,8 +6330,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ AI "
-"ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ "
+"AI ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6283,8 +6340,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s เพื่อค้นหาโดยไม่มีฟีเจอร์ AI "
-"และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s "
+"เพื่อค้นหาโดยไม่มีฟีเจอร์ AI และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6344,7 +6401,7 @@ msgstr "ดาวน์โหลด DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "ดาวน์โหลด DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6557,7 +6614,7 @@ msgstr "Duck.ai โดย DuckDuckGo แชท AI ส่วนตัว ไม�
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "ตอนนี้ Duck.ai สามารถวิเคราะห์ไฟล์ PDF ได้แล้ว ลองดูสิ!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6568,7 +6625,8 @@ msgid ""
 "pages automatically in Settings."
 msgstr ""
 "ตอนนี้ Duck.ai สามารถช่วยตอบคําถามเกี่ยวกับหน้าเว็บที่คุณกำลังดูอยู่ได้แล้ว "
-"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
+"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน "
+"ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6619,8 +6677,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://"
-"duck.ai"
+"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo "
+"แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6635,7 +6693,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
+"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6656,8 +6715,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai "
-"แต่คุณยังสามารถไปที่ %1$sduck.ai%2$s โดยตรง"
+"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม "
+"การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai แต่คุณยังสามารถไปที่ "
+"%1$sduck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6668,10 +6728,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม รวมถึงโมเดลจาก "
-"OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo "
-"Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://"
-"duck.ai%2$s โดยตรง"
+"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม "
+"รวมถึงโมเดลจาก OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat "
+"และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai "
+"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6704,7 +6764,7 @@ msgstr "คำตอบของ Duck.ai ไม่ได้อิงตามแ
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai รองรับโมเดลจาก Anthropic, OpenAI และอื่นๆ"
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6732,9 +6792,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI แบบไม่ระบุตัวตน, แชท "
-"AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, โมเดล AI โอเพนซอร์ส, AI "
-"ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
+"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI "
+"แบบไม่ระบุตัวตน, แชท AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, "
+"โมเดล AI โอเพนซอร์ส, AI ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6763,10 +6823,12 @@ msgid ""
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
 "DuckAssist สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง "
-"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ DuckAssist "
-"UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
-"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) "
-"สำหรับตอนนี้ DuckAssist มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
+"DuckAssist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
+"(แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
+"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) สำหรับตอนนี้ DuckAssist "
+"มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6775,9 +6837,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo AI "
-"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก OpenAI, Anthropic "
-"และอื่นๆ อีกมากมาย"
+"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo "
+"AI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก "
+"OpenAI, Anthropic และอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6786,9 +6848,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo %1$sAI "
-"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ที่รองรับโมเดลการแชทจาก OpenAI และ "
-"Anthropic"
+"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo "
+"%1$sAI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ที่รองรับโมเดลการแชทจาก OpenAI และ Anthropic"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6801,8 +6863,10 @@ msgid ""
 "checked for accuracy."
 msgstr ""
 "DuckAssist "
+""
 "เป็นคุณลักษณะใหม่ในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia "
+"และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
 "จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ขับเคลื่อนด้วย AI เพื่อสร้างข้อมูลสรุป "
 "โปรดทราบว่าขณะนี้คำตอบนั้นอิงจาก Wikipedia และเนื้อหาที่เกี่ยวข้อง "
 "และไม่ได้มีการตรวจสอบความถูกต้อง"
@@ -6820,11 +6884,16 @@ msgid ""
 "sources and based on %scrawling the web%s."
 msgstr ""
 "DuckAssist "
+""
 "เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ "
-"AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
-"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ โดยอ้างอิงแหล่งที่มาของคำตอบ "
+"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
+"ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
+"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ "
+"โดยอ้างอิงแหล่งที่มาของคำตอบ "
+""
 "เพื่อให้คุณสามารถไปยังแหล่งข้อมูลเพื่อดูข้อมูลโดยละเอียดเพิ่มเติมได้อย่างง่ายดาย "
+""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -6834,7 +6903,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"คำตอบ DuckAssist สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
+"คำตอบ DuckAssist "
+"สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6842,7 +6912,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว โปรดแชทต่อในวันพรุ่งนี้"
+msgstr ""
+"DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว "
+"โปรดแชทต่อในวันพรุ่งนี้"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6851,8 +6923,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
-"%2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6861,8 +6933,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
-"%2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6879,8 +6951,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ "
-"%1$s ไปที่ %2$s"
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
+"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6888,7 +6960,9 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
+msgstr ""
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว "
+"โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7013,8 +7087,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น ชื่อ ที่อยู่อีเมล "
-"หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
+"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น "
+"ชื่อ ที่อยู่อีเมล หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7022,7 +7096,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s ของ Duck.ai"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s "
+"ของ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7031,7 +7106,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ %2$s ของเรา"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ "
+"%2$s ของเรา"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7040,8 +7116,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google "
-"และ Facebook ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
+"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม "
+"รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google และ Facebook "
+"ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7053,9 +7130,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
+"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ "
+"เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
 "ข้อมูลดังกล่าวจะได้รับการจัดเก็บไว้บนอุปกรณ์ของคุณเท่านั้น เมื่อคุณค้นหา "
-"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
+"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา "
+"ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
 "จากนั้นเราจะทิ้งข้อมูลดังกล่าวในทันทีเพื่อให้ไม่มีการระบุตัวตนของคุณได้ "
 "%1$sดูข้อมูลเพิ่มเติมเกี่ยวกับวิธีที่เราออกแบบเทคโนโลยีนี้เพื่อปกป้องความเป็นส่วนตัวของคุณ%2$s"
 
@@ -7077,8 +7156,9 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น "
-"และใกล้คุณมากขึ้น %1$sดูข้อมูลเพิ่มเติม%2$s"
+"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ "
+"ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น และใกล้คุณมากขึ้น "
+"%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7164,8 +7244,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo "
-"จากนั้นเราจะสุ่มคำ 4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
+"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน "
+"เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo จากนั้นเราจะสุ่มคำ "
+"4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
 "เพื่อให้มั่นใจว่ารหัสผ่านมีความยาวอักขระอย่างน้อย 18-20 ตัว"
 
 # smartling.placeholder_format=C
@@ -7336,7 +7417,7 @@ msgstr "เปิดใช้เว็บไซต์ที่เยี่ยม
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "เปิดใช้งานตอนนี้"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7373,7 +7454,9 @@ msgstr "เปิดใช้งานการค้นหาเว็บ"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น คุณสามารถเปลี่ยนใจได้ในภายหลัง"
+msgstr ""
+"เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น "
+"คุณสามารถเปลี่ยนใจได้ในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7579,7 +7662,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
+"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s "
+"การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7605,7 +7689,8 @@ msgstr "ป้อนข้อความ"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s นามแฝง%6$s: d%7$s"
+"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s "
+"นามแฝง%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7635,7 +7720,7 @@ msgstr "คู่มือบันเทิง"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "แชททั้งหมด"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7802,13 +7887,13 @@ msgstr "เนื้อเพลงที่โจ่งแจ้ง"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "สำรวจ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "สำรวจ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7915,7 +8000,7 @@ msgstr "ฟรี"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "ฟรี & เลือกได้"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -7990,7 +8075,9 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
+msgstr ""
+"โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง "
+"จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8079,7 +8166,9 @@ msgstr "กรองภาพที่สร้างโดย AI จากผ�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ %1$sดูข้อมูลเพิ่มเติม%2$s"
+msgstr ""
+"กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ "
+"%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8327,7 +8416,7 @@ msgstr "เพิ่มพื้นที่จัดเก็บ"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "ฟรีและส่วนตัวเสมอ"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8351,7 +8440,7 @@ msgstr "แก้ไข แชร์ และใช้ได้อย่าง�
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์"
+msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์ ได้อย่างอิสระ"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8451,7 +8540,8 @@ msgid ""
 "strong>."
 msgstr ""
 "จากแถบเมนูแอปบน Mac ให้เลือก <strong>DuckDuckGo</strong> &gt; "
-"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก <strong>ติดตั้งการอัปเดต</strong>"
+"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก "
+"<strong>ติดตั้งการอัปเดต</strong>"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8787,7 +8877,9 @@ msgstr "เริ่ม"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ เพียงครั้งเดียว"
+msgstr ""
+"รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ "
+"เพียงครั้งเดียว"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -8802,8 +8894,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
-"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo "
+"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8814,8 +8906,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
-"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo "
+"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8844,7 +8936,7 @@ msgstr "รับความช่วยเหลือด้านคอมพ
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "รับขีดจำกัดการใช้งานที่สูงขึ้นด้วยการสมัครสมาชิก DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8885,13 +8977,13 @@ msgstr "รับเวอร์ชันล่าสุด"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "ดาวน์โหลดแอป"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
+msgstr "รับเบราว์เซอร์ DuckDuckGo ฟรี %1$sเพื่อบล็อกโฆษณาบน YouTube%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -8919,7 +9011,7 @@ msgstr "แนะนำเราให้เพื่อนของคุณ"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "รายการตรวจสอบการเริ่มต้นใช้งาน"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8950,8 +9042,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device › Copy Text Code%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device › Copy Text "
+"Code%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8960,8 +9053,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8971,8 +9064,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
+"แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8982,9 +9076,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF "
-"การกู้คืนของคุณ"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9000,7 +9094,8 @@ msgid ""
 "“Location Services” is turned on."
 msgstr ""
 "ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" เปิดอยู่"
+"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" "
+"เปิดอยู่"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9009,8 +9104,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการหาตําแหน่งที่ตั้ง%2$s "
-"แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
+"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
+"บริการหาตําแหน่งที่ตั้ง%2$s แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9606,7 +9701,7 @@ msgstr "ซ่อนเคล็ดลับ"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "ซ่อนบทเรียน"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9692,7 +9787,9 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
+msgstr ""
+"เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist "
+"เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -9785,7 +9882,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -9927,6 +10025,7 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
+""
 "ฉันจะบอกเพื่อนร่วมงานอย่างมีไหวพริบเกี่ยวกับการเคาะดินสออย่างต่อเนื่องได้อย่างไร "
 "และฉันควรจะพูดว่าอะไร"
 
@@ -10049,7 +10148,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ ที่คล้ายกันหรือไม่และเพราะเหตุใด"
+msgstr ""
+"ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ "
+"ที่คล้ายกันหรือไม่และเพราะเหตุใด"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10084,8 +10185,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > ทั่วไป > รีเซ็ต > "
-"\"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > "
+"ทั่วไป > รีเซ็ต > \"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10095,9 +10196,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ ให้ไปที่ %1$s⋮ > เมนู > "
-"การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s และตรวจสอบว่า DuckDuckGo "
-"ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ "
+"ให้ไปที่ %1$s⋮ > เมนู > การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s "
+"และตรวจสอบว่า DuckDuckGo ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10132,7 +10233,8 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
+"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
+"คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
 "คุณสามารถบันทึกโค้ดนี้ลงในอุปกรณ์ของคุณเป็นไฟล์ข้อความได้"
 
 # smartling.placeholder_format=C
@@ -10149,7 +10251,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ %2$s ของเรา"
+"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ "
+"%2$s ของเรา"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10157,7 +10260,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" (เปิดด้วย)"
+"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" "
+"(เปิดด้วย)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10299,6 +10403,7 @@ msgid ""
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
 "ในเบราว์เซอร์เก่ากว่าบางรายการ "
+""
 "เราจำเป็นต้องเปลี่ยนเส้นทางการคลิกของคุณผ่านเซิร์ฟเวอร์ของเราเพื่อป้องกันการรั่วไหลของข้อมูลการค้นหา "
 "%1$sดูข้อมูลเพิ่มเติม%2$s"
 
@@ -10734,9 +10839,11 @@ msgid ""
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
 "รายการต่างๆ "
+""
 "ได้รับการจัดลำดับตามความเกี่ยวข้องกับข้อความค้นหาของคุณและจัดส่งผ่านเครือข่ายโฆษณาของ "
-"Microsoft การคลิกนำไปสู่หน้า Landing Page ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา "
-"DuckDuckGo ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
+"Microsoft การคลิกนำไปสู่หน้า Landing Page "
+"ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา DuckDuckGo "
+"ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10745,7 +10852,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว และมีความปลอดภัยมากกว่า"
+"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว "
+"และมีความปลอดภัยมากกว่า"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11216,7 +11324,7 @@ msgstr "ช่วยให้คุณค้นหาแบบไม่ระบ
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "ช่วยให้คุณสลับระหว่างการส่งคำค้นหาและพรอมต์ไปยัง Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11292,7 +11400,7 @@ msgstr "ไลน์เอาต์ที่ได้"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "ลิงก์หมดอายุใน 7 วัน"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12388,7 +12496,7 @@ msgstr "มากกว่า 20 นาที"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "เคล็ดลับเพิ่มเติม"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12711,9 +12819,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
+"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12880,7 +12990,7 @@ msgstr "ไม่ ขอบคุณ"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "ไม่ ขอบคุณ"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13535,8 +13645,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows %3$sให้คลิกไอคอน %4$s "
-"> การตั้งค่า%5$s"
+"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows "
+"%3$sให้คลิกไอคอน %4$s > การตั้งค่า%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13548,7 +13658,7 @@ msgstr "เปิดแต่ไม่มีตัวเลข"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "การเริ่มใช้งานเสร็จสมบูรณ์"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13564,7 +13674,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
+"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ "
+"โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13590,7 +13701,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
+msgstr ""
+"เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น "
+"มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -13761,7 +13874,7 @@ msgstr "เปิดสร้างและแก้ไขคำแนะนำ
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "เปิดรายการตรวจสอบการเริ่มต้นใช้งาน"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -13927,7 +14040,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"เครื่องมือค้นหาอื่นๆ จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
+"เครื่องมือค้นหาอื่นๆ "
+"จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
 "แต่เราไม่ติดตามคุณอย่างแน่นอน"
 
 # smartling.placeholder_format=C
@@ -13941,7 +14055,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
+"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: "
+"เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -13949,8 +14064,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
-"เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย พร้อมใช้งานบน %1$siOS และ Android%2$s"
+"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย "
+"พร้อมใช้งานบน %1$siOS และ Android%2$s"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14203,8 +14319,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, ลายนิ้วมือจากเบราว์เซอร์ "
-"หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
+"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, "
+"ลายนิ้วมือจากเบราว์เซอร์ หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14404,9 +14520,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
+""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้คำตอบที่ได้รับความช่วยเหลือจาก "
-"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
-"ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
+"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
+"หากต้องการปิดและซ่อนปุ่ม Assist ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14416,8 +14533,9 @@ msgid ""
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด "
-"ให้ไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า "
+"หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด ให้ไปที่%1$sการตั้งค่า "
+"DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14428,8 +14546,8 @@ msgid ""
 "Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
-"โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
+"หากต้องการปิดและซ่อนปุ่ม Assist โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14477,7 +14595,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ DuckDuckGo"
+msgstr ""
+"เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ "
+"DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14501,7 +14621,7 @@ msgstr "หมุด"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "ปักหมุดแชท"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14513,7 +14633,7 @@ msgstr "ปักหมุดแชทที่นี่จาก %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "ปักหมุดฉัน"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14536,7 +14656,7 @@ msgstr "ปักหมุด"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "แชทที่ปักหมุดไว้จะปรากฏที่ด้านบนสุดของแชทล่าสุด"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14851,7 +14971,7 @@ msgstr "การจัดรูปแบบที่ไม่ดี"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
+msgstr "มีโมเดล AI ยอดนิยมให้ใช้งาน ไม่ต้องมีบัญชี แชทไม่ระบุชื่อโดยเรา"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15065,7 +15185,7 @@ msgstr "แท็บก่อนหน้านี้"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "เคล็ดลับก่อนหน้านี้"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15402,7 +15522,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น [แทรกข้อความของคุณเองที่นี่]"
+msgstr ""
+"ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น "
+"[แทรกข้อความของคุณเองที่นี่]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -15607,13 +15729,13 @@ msgstr "การใช้เหตุผล AI ที่มีการคว�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "การให้เหตุผลสามารถให้คำตอบที่ดีกว่าสำหรับคำถามที่ซับซ้อน"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "การใช้เหตุผลจะละเอียดกว่า แต่ใช้ขีดจำกัดเร็วกว่า 2-5 เท่า %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15654,7 +15776,7 @@ msgstr "พื้นที่จัดเก็บแชทล่าสุดส
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "แชทล่าสุด"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15685,8 +15807,9 @@ msgid ""
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
 "การแชทล่าสุดจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15814,7 +15937,7 @@ msgstr "ลดการใช้งาน"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "ลดการใช้งานด้วยโมเดลที่มีประสิทธิภาพมากขึ้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15962,8 +16085,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ &quot;"
-"รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
+"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ "
+"&quot;รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16053,7 +16176,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"ถาม\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"ถาม\" ออก "
+"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16062,7 +16186,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"สร้าง\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"สร้าง\" ออก "
+"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16121,8 +16246,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo เพื่อช่วยปรับปรุงบริการค้นหาของเรา "
-"ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ %1$s เพื่อช่วยปรับปรุงบริการ"
+"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo "
+"เพื่อช่วยปรับปรุงบริการค้นหาของเรา ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ "
+"%1$s เพื่อช่วยปรับปรุงบริการ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16130,8 +16256,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ "
-"ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ "
+"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16140,8 +16266,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ "
-"และจะไม่ระบุตัวตน โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo "
+"รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ และจะไม่ระบุตัวตน "
+"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16191,7 +16318,7 @@ msgstr "รีเซ็ตการตั้งค่าทั้งหมด"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "รีเซ็ตบทช่วยสอน"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16209,7 +16336,7 @@ msgstr "ความละเอียด"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "การตอบสนอง"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16233,8 +16360,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
 "%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -16244,8 +16372,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
 "อยู่ภายใต้%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -16256,10 +16385,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่น ๆ "
-"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search Assist อยู่ภายใต้ "
-"%1$sข้อกำหนดการให้บริการ%2$sของเรา"
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่น ๆ "
+"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search "
+"Assist อยู่ภายใต้ %1$sข้อกำหนดการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16846,7 +16976,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s "
+"(หรือ%5$sเพิ่มใหม่%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16855,7 +16986,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ %5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ "
+"%5$sเพิ่มใหม่%6$s)"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16907,7 +17039,7 @@ msgstr "ค้นหา %1$s เพื่อดูผลลัพธ์ที่
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "ปุ่มสลับการค้นหาและ Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16934,10 +17066,11 @@ msgid ""
 "subset of English speaking regions."
 msgstr ""
 "Search Assist สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
-"คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ (เฉพาะเมื่อคลิก "
-"Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ "
-"Search Assist มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น "
+"ๆ คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ "
+"(เฉพาะเมื่อคลิก Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ Search Assist "
+"มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16945,7 +17078,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ ลองค้นหาอีกครั้ง"
+"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ "
+"ลองค้นหาอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16954,9 +17088,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการทำเช่นนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
-"ตามข้อมูลที่พบ"
+"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ "
+"ในการทำเช่นนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ "
+"AI เพื่อสร้างคำตอบสั้น ๆ ตามข้อมูลที่พบ"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17077,8 +17211,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" โดยตรงบน "
-"Wikipedia"
+"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" "
+"โดยตรงบน Wikipedia"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17098,8 +17232,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "ค้นหาอย่างเป็นส่วนตัวด้วยแอปหรือส่วนขยายของเรา "
-"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ %1$sduckduckgo."
-"com%2$s"
+"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ "
+"%1$sduckduckgo.com%2$s"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17118,8 +17252,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
+""
 "การตั้งค่าการค้นหาจะถูกเก็บไว้ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคลและที่เก็บข้อมูลภายในในเบราว์เซอร์ของคุณ "
 "แต่คุณยังสามารถใช้ Cloud Save "
+""
 "เพื่อจัดเก็บการตั้งค่าของคุณโดยไม่ระบุตัวตนบนเซิร์ฟเวอร์ระยะไกลในคลาวด์ได้อีกด้วย "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวบุคคลได้บนระบบคลาวด์ "
 "และวลีรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
@@ -17241,6 +17377,7 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
+""
 "จัดเก็บแชทได้เกือบไม่จำกัดบนเซิร์ฟเวอร์ของเราอย่างปลอดภัยด้วยการเข้ารหัสแบบครบวงจร "
 "และเข้าถึงได้จากอุปกรณ์ที่ซิงค์ทั้งหมดของคุณ"
 
@@ -17274,7 +17411,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "จัดเก็บอย่างปลอดภัยบนเซิร์ฟเวอร์ที่เข้ารหัสของเรา"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17419,7 +17556,8 @@ msgstr "เลือก %1$s\"การตั้งค่าสำหรับ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s ลงในช่องการป้อนข้อมูล"
+"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s "
+"ลงในช่องการป้อนข้อมูล"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -17484,7 +17622,8 @@ msgstr "เลือก%1$sจัดการส่วนเสริม%2$sจ�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน "
+"Windows)"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -17492,7 +17631,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน "
+"Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17556,7 +17696,9 @@ msgstr "เลือก%1$sการตั้งค่า%2$s จากนั้
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ ตามต้องการ)"
+msgstr ""
+"เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ "
+"ตามต้องการ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -17678,7 +17820,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ส่งพรอมต์ไปยังโมเดล AI พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
+"ส่งพรอมต์ไปยังโมเดล AI "
+"พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
 "คำแนะนำเหล่านี้จะใช้กับการสนทนาทั้งหมดของคุณต่อไป"
 
 # smartling.placeholder_format=C
@@ -17780,7 +17923,7 @@ msgstr "ตั้งเป็นหน้าแรก"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "ตั้งค่าน้ำเสียงและสไตล์ในการตอบกลับของ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -17795,13 +17938,16 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ตั้งค่า Sync & Backup หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
+"ตั้งค่า Sync & Backup "
+"หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
+msgstr ""
+"ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง "
+"หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -17850,13 +17996,13 @@ msgstr "เซเชลส์"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "แชร์"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "แชร์"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -17902,7 +18048,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "แชร์แชท"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17966,7 +18112,7 @@ msgstr "แชร์ข้อเสนอแนะเชิงบวก"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "ขอบเขตการแชร์"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18107,7 +18253,7 @@ msgstr "แสดงรายละเอียด"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "แสดงบทช่วยสอน Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18260,7 +18406,7 @@ msgstr "แสดงเพิ่มเติม"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "แสดงโมเดลเพิ่มเติม"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18301,7 +18447,7 @@ msgstr "แสดงแถบด้านข้าง"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "แสดงเคล็ดลับทีละขั้นตอนเพื่อให้ใช้งาน Duck.ai ได้อย่างเต็มประสิทธิภาพ"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18404,7 +18550,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ DuckDuckGo"
+"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ "
+"DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18674,7 +18821,7 @@ msgstr "เกิดข้อผิดพลาดบางอย่าง โ�
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "เกิดข้อผิดพลาดบางอย่าง โปรดลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18752,7 +18899,9 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s เพื่อลองอีกครั้ง"
+msgstr ""
+"ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s "
+"เพื่อลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -18964,7 +19113,7 @@ msgstr "เริ่มใช้ขีดจำกัดรายสัปดา
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "เริ่มแชทใหม่"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19231,7 +19380,9 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
+msgstr ""
+"เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ "
+"สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -19548,7 +19699,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "เปลี่ยนเป็นความเห็นที่สองนี้"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19664,8 +19815,9 @@ msgid ""
 msgstr ""
 "รหัสกู้คืนการซิงค์\n"
 "\n"
-"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท Duck.ai "
-"ของคุณระหว่างอุปกรณ์หลายเครื่อง และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
+"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท "
+"Duck.ai ของคุณระหว่างอุปกรณ์หลายเครื่อง "
+"และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
 "\n"
 "เก็บรักษาข้อมูลนี้ให้ปลอดภัย\n"
 "ทุกคนที่มีสิทธิ์เข้าถึงรหัสนี้สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณ\n"
@@ -19675,9 +19827,11 @@ msgstr ""
 "วิธีการทำงานของโค้ดนี้คืออะไร?\n"
 "1. ไปที่ Duck.ai ในเบราว์เซอร์ของคุณ แล้วเปิดการตั้งค่า Duck.ai\n"
 "2. เลือก \"เปิดใช้งาน Sync & Backup\" จากนั้นเลือก \"Recover Synced Data\"\n"
-"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code here\"\n"
+"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code "
+"here\"\n"
 "\n"
-"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
+"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup "
+"เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
 "ข้อมูลของคุณจะถูกลบออกจากเซิร์ฟเวอร์และไม่สามารถกู้คืนได้"
 
 # smartling.placeholder_format=C
@@ -19702,7 +19856,7 @@ msgstr "ซิงค์และสำรองข้อมูล ไม่ส�
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "ซิงค์แชทข้ามอุปกรณ์"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19798,6 +19952,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"พก Duck.ai ไปกับคุณได้ทุกที่ "
+"รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"ไม่ว่าคุณจะอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -19806,6 +19963,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"พก Duck.ai ไปกับคุณทุกที่ "
+"รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"ไม่ว่าคุณจะท่องเว็บอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19828,7 +19988,9 @@ msgstr "ควบคุมข้อมูลส่วนบุคคลของ
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai ดีขึ้นได้อย่างไรบ้าง"
+msgstr ""
+"ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai "
+"ดีขึ้นได้อย่างไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20043,6 +20205,7 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
+""
 "นั่นหมายความว่าข้อมูลที่ส่งระหว่างอุปกรณ์ของคุณกับหน้าเว็บเบื้องหลังลิงก์นี้มีความเสี่ยงมากขึ้นต่อการถูกดักข้อมูลโดยบุคคลที่สาม "
 "ในบางกรณีซึ่งเกิดขึ้นไม่บ่อย ข้อมูลนี้รวมถึงรหัสผ่านหรือรายละเอียดการชำระเงิน"
 
@@ -20084,6 +20247,7 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
+""
 "คีย์การเข้ารหัสจะถูกบันทึกไว้เฉพาะในที่เก็บข้อมูลในเครื่องของเบราว์เซอร์ของคุณ "
 "และมีเพียงคุณเท่านั้นที่สามารถเข้าถึงได้"
 
@@ -20106,7 +20270,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ บนเซิร์ฟเวอร์ของเขา"
+msgstr ""
+"ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ "
+"บนเซิร์ฟเวอร์ของเขา"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20199,6 +20365,7 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
+""
 "สิทธิ์ของเบราว์เซอร์เหล่านี้ใช้เพื่อเพิ่มการปกป้องความเป็นส่วนตัวบนเว็บไซต์ที่คุณเยี่ยมชมโดยการบล็อกตัวติดตามที่ซ่อนอยู่ "
 "การเข้ารหัสการเชื่อมต่อเมื่อสามารถทำได้ และการตั้งค่าให้ DuckDuckGo "
 "เป็นเครื่องมือค้นหาเริ่มต้นของคุณ"
@@ -20246,7 +20413,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
+msgstr ""
+"เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป "
+"ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20264,7 +20433,7 @@ msgstr "เดือนนี้"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "การตอบกลับนี้"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20276,7 +20445,7 @@ msgstr "สัปดาห์นี้"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "แชทนี้จะยังคงอยู่ใน Duck.ai และเป็นส่วนตัวสำหรับคุณ"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20317,8 +20486,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s แชท AI "
-"อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s สำหรับข้อมูลเพิ่มเติม)"
+"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s "
+"แชท AI อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s "
+"สำหรับข้อมูลเพิ่มเติม)"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20410,6 +20580,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก "
+"ปักหมุด เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20417,7 +20589,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
+msgstr "นี่เป็นเพียงแชทตัวอย่างเท่านั้น ใช้ Fire Button ในเมนูด้านข้างเพื่อลบ!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20438,8 +20610,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน ผู้ให้บริการโมเดลอื่นๆ "
-"เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
+"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน "
+"ผู้ให้บริการโมเดลอื่นๆ เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20448,8 +20620,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ ผู้ให้บริการโมเดลอื่นๆ "
-"ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
+"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ "
+"ผู้ให้บริการโมเดลอื่นๆ ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20486,6 +20658,7 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
+""
 "การดำเนินการนี้จะบันทึกการแชทของคุณด้วยการเข้ารหัสแบบครบวงจรบนเซิร์ฟเวอร์ที่ปลอดภัยของ "
 "DuckDuckGo ซึ่งต่อมาสามารถเข้าถึงได้จากเบราว์เซอร์ใดก็ตาม"
 
@@ -20496,8 +20669,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
-"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
+"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
+"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20507,8 +20681,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
-"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
+"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
+"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
 "เรามีหน้าเริ่มต้นที่ไม่แสดงคำตอบที่ได้รับความช่วยเหลือจาก AI ด้วยที่ %1$s"
 
 # smartling.placeholder_format=C
@@ -20548,8 +20723,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ Sync & Backup "
-"คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ ที่เชื่อมต่อกับ Sync & Backup"
+"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ "
+"Sync & Backup คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ "
+"ที่เชื่อมต่อกับ Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20558,8 +20734,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ เว้นแต่ว่าจะมีการปักหมุดไว้ "
-"การกระทำนี้ย้อนกลับไม่ได้"
+"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ "
+"เว้นแต่ว่าจะมีการปักหมุดไว้ การกระทำนี้ย้อนกลับไม่ได้"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20577,7 +20753,9 @@ msgstr "การตั้งค่าทั้งหมดของคุณจ
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น ดำเนินการต่อหรือไม่"
+msgstr ""
+"การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น "
+"ดำเนินการต่อหรือไม่"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20696,9 +20874,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"วิธีการพิมพ์เส้นทาง:"
-"%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
+msgstr "วิธีการพิมพ์เส้นทาง:%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20708,7 +20884,8 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
+"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ "
+"คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
 "รหัสนี้อาจถูกบันทึกเป็น PDF บนอุปกรณ์ที่คุณใช้ตั้งค่าการซิงค์ในตอนแรก"
 
 # smartling.placeholder_format=C
@@ -20748,7 +20925,7 @@ msgstr "วันนี้"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
+msgstr "เปิด/ปิดเพื่อลองใช้แชท AI ส่วนตัว หรือ %1$sปิดใช้งานในเมนู %2$s %3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20970,7 +21147,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr ""
+"แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: "
+"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20978,7 +21157,9 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr ""
+"แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: "
+"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21161,7 +21342,7 @@ msgstr "ลองใช้ดู"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "ลองใช้โมเดลอื่น"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21172,7 +21353,7 @@ msgstr "ลองค้นหา"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "ลองใช้คำแนะนำ"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21240,7 +21421,7 @@ msgstr "ลองใช้ฟรี"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "ลองใช้ฟรี"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21260,7 +21441,7 @@ msgstr "ลองใช้ฟรี! VPN ที่ปลอดภัย, AI ท�
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "ลองใช้ฟรี 7 วัน"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21293,7 +21474,7 @@ msgstr "ลองใช้หน้าแรกของเราที่ไม
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "ลองใช้การให้เหตุผล"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21408,8 +21589,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา %1$sDuckDuckGo No "
-"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา "
+"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21418,8 +21599,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา %1$sDuckDuckGo No "
-"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา "
+"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21544,7 +21725,7 @@ msgstr "เปิด Duck Player เพื่อดู YouTube โดยไม�
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "เปิดใช้งานปุ่มสลับ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21739,7 +21920,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s "
+"จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -21747,7 +21929,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: https://duckduckgo.com"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21863,8 +22046,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า "
-"โดยการอัปเกรดเป็น Pro"
+"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus "
+"ถึง 2 เท่า โดยการอัปเกรดเป็น Pro"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21910,7 +22093,7 @@ msgstr "ปลดล็อก AI ขั้นสูงด้วยการส�
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "ปลดล็อกโมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22004,7 +22187,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai และเข้าถึงโมเดลขั้นสูง"
+"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai "
+"และเข้าถึงโมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22232,8 +22416,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ นักต้มตุ๋น "
-"และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย ไม่จำเป็นต้องมีบัญชี"
+"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ "
+"นักต้มตุ๋น และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย "
+"ไม่จำเป็นต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22273,7 +22458,7 @@ msgstr "ใช้งานบน Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "ใช้ Fire Button เพื่อลบแชทออกจากประวัติ"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22281,7 +22466,9 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr "ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ เก็บรักษาไว้ให้ปลอดภัย"
+msgstr ""
+"ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
+"เก็บรักษาไว้ให้ปลอดภัย"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -22460,7 +22647,9 @@ msgstr "หมู่เกาะเวอร์จิน"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr "ไปที่ %1$sการตั้งค่า Assist%2$s เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
+msgstr ""
+"ไปที่ %1$sการตั้งค่า Assist%2$s "
+"เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -22468,7 +22657,9 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr "ไปที่ %1$sการตั้งค่า DuckAssist%2$s เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
+msgstr ""
+"ไปที่ %1$sการตั้งค่า DuckAssist%2$s "
+"เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -22491,8 +22682,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s > %3$sSync "
-"& Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s "
+"> %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another "
+"Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22502,8 +22694,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก \"เปิด\" ภายใต้ Sync "
-"& Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก "
+"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22513,9 +22706,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ %1$sDuck.ai "
-"Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync "
-"With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ "
+"%1$sDuck.ai Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s "
+"จากนั้นเลือก %7$sSync With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22525,9 +22718,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า Duck.ai เลือก "
-"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF "
-"การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า "
+"Duck.ai เลือก \"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22579,7 +22772,10 @@ msgstr "แชทด้วยเสียงสิ้นสุดลง"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล AI"
+msgstr ""
+""
+"เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล "
+"AI"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -22744,8 +22940,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ เพราะเราต้องสตรีมเนื้อหาจากที่นั่น "
-"DuckDuckGo เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
+"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ "
+"เพราะเราต้องสตรีมเนื้อหาจากที่นั่น DuckDuckGo "
+"เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube "
+"ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22757,7 +22955,9 @@ msgstr "เราทำให้ไม่ระบุตัวตน"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
+msgstr ""
+"เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s "
+"แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -22769,8 +22969,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
-"โปรดแชร์การสนทนานี้กับ DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
+"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย โปรดแชร์การสนทนานี้กับ "
+"DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22782,7 +22983,8 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
+"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
 "โปรดแชร์คำแนะนำและการตอบสนองของคุณเพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
@@ -22796,7 +22998,9 @@ msgstr "เราสามารถใช้%1$sตำแหน่งที่�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "เราไม่สามารถอ่านไฟล์ที่แนบมาได้ เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
+msgstr ""
+"เราไม่สามารถอ่านไฟล์ที่แนบมาได้ "
+"เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22824,7 +23028,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ เราไม่ติดตามคุณ อย่างแน่นอน"
+"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ "
+"เราไม่ติดตามคุณ อย่างแน่นอน"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22837,7 +23042,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
+msgstr ""
+"เนื่องจากเราไม่ได้ติดตามคุณ "
+"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22846,7 +23053,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
+"เนื่องจากเราไม่ได้ติดตามคุณ "
+"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22913,7 +23121,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"เรามีข้อตกลงกับผู้ให้บริการ AI ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
+"เรามีข้อตกลงกับผู้ให้บริการ AI "
+"ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22948,6 +23157,7 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
+""
 "เราใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนของคุณเพียงเพื่อให้ได้ผลลัพธ์ที่แม่นยำยิ่งขึ้นและใกล้คุณมากขึ้นเท่านั้น "
 "คุณสามารถเปลี่ยนใจได้เสมอในภายหลัง"
 
@@ -22955,7 +23165,9 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo ให้ดียิ่งขึ้นสำหรับทุกคน"
+msgstr ""
+"เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo "
+"ให้ดียิ่งขึ้นสำหรับทุกคน"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22991,7 +23203,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
+"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ "
+"ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23024,7 +23237,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
+"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล "
+"เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23132,7 +23346,9 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
+msgstr ""
+"ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว "
+"คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23146,7 +23362,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
+"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว "
+"เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23167,7 +23384,8 @@ msgid ""
 "to train AI models."
 msgstr ""
 "ยินดีต้อนรับสู่ DuckDuckGo AI Chat! เซสชันแชทนี้ขับเคลื่อนโดย %2$s ของ %1$s "
-"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo หรือใช้เพื่อฝึกโมเดล AI"
+"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo "
+"หรือใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23274,7 +23492,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ \"เราต้องทำให้ได้ดีกว่านี้\""
+msgstr ""
+"มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ "
+"\"เราต้องทำให้ได้ดีกว่านี้\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -23293,10 +23513,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo สำหรับผู้ที่สนใจใช้ Duck.ai "
-"อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ "
-"ที่ชัดเจนพร้อมชื่อหัวข้อ โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น "
-"ง่าย และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
+"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo "
+"สำหรับผู้ที่สนใจใช้ Duck.ai อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ "
+"DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ ที่ชัดเจนพร้อมชื่อหัวข้อ "
+"โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น ง่าย "
+"และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23411,7 +23632,7 @@ msgstr "สิ่งใดทำให้คุณกลับมาในวั
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "ทำอะไรได้บ้าง"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23834,6 +24055,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"เมื่อใช้ Duck.ai การแชทของคุณจะไม่ระบุชื่อและจะไม่ถูกนำไปใช้เพื่อฝึก AI "
+"เปิดหรือปิดใช้งานได้ตลอดเวลาในเมนู '%1$s'"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24129,7 +24352,9 @@ msgstr "คุณสามารถเข้าถึง DuckDuckGo AI Chat ไ�
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน %2$sการตั้งค่าการค้นหา%3$s"
+msgstr ""
+"คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน "
+"%2$sการตั้งค่าการค้นหา%3$s"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24138,7 +24363,8 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน %1$sการตั้งค่าการค้นหา%2$s"
+"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน "
+"%1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
@@ -24257,7 +24483,7 @@ msgstr "คุณสามารถแนบได้เพียง %1$s ภา
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "คุณสามารถแนบได้เพียง %1$s แท็บเท่านั้นในแต่ละครั้ง"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24277,7 +24503,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s คุณต้องเลิกบล็อกไซต์อื่นก่อน"
+msgstr ""
+"คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s "
+"คุณต้องเลิกบล็อกไซต์อื่นก่อน"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -24334,8 +24562,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 "
-"เท่า"
+"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, "
+"และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24400,7 +24628,7 @@ msgstr "คุณจะได้รับการอัปเดตแอป Du
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "เรียบร้อยแล้ว!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24410,7 +24638,8 @@ msgid ""
 "browse privately too. It’s already installed and can:"
 msgstr ""
 "ตอนนี้คุณกำลังค้นหาแบบเป็นส่วนตัวใน Chrome ใช้แอปของเราแทน Chrome "
-"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
+"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน "
+"แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24423,7 +24652,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว %1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
+"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว "
+"%1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -24452,7 +24682,7 @@ msgstr "คุณได้บล็อก 1 ไซต์"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "คุณเชี่ยวชาญพื้นฐานของ Duck.ai แล้ว"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24499,8 +24729,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว ลบแชทที่เก่าที่สุด "
-"%1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว "
+"ลบแชทที่เก่าที่สุด %1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24510,8 +24740,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท %1$s "
-"รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท "
+"%1$s รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ "
+"แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24525,8 +24756,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน การดูวิดีโอ YouTube "
-"ที่นี่จะถูกติดตามโดย YouTube/Google"
+"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน "
+"การดูวิดีโอ YouTube ที่นี่จะถูกติดตามโดย YouTube/Google"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24609,14 +24840,17 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
+"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo "
+"ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo ไม่เคยเข้าถึงข้อมูลนี้"
+msgstr ""
+"เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo "
+"ไม่เคยเข้าถึงข้อมูลนี้"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -24664,7 +24898,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
+"เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -24672,7 +24907,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
+"เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -24772,7 +25008,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า %1$sSHA-2%2$s "
+"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า "
+"%1$sSHA-2%2$s "
 "เฉพาะคีย์และไฟล์การตั้งค่าที่เกี่ยวข้องเท่านั้นที่ออกจากเบราว์เซอร์ของคุณ "
 "เราบันทึกไฟล์การตั้งค่าโดยใช้คีย์เป็นชื่อ DuckDuckGo จะไม่ทราบรหัสผ่านของคุณ"
 
@@ -24789,7 +25026,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
+"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo "
+"และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
 "เพื่อให้ผู้ให้บริการโมเดลไม่สามารถเชื่อมโยงการสนทนาของคุณกลับไปยังคุณ"
 
 # smartling.placeholder_format=C
@@ -24835,6 +25073,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น "
+"เปิดใช้งานส่วนขยาย %1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -24843,8 +25083,10 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
-"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร %3$sศึกษาเพิ่มเติม%4$s"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว "
+"แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
+"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร "
+"%3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -25207,7 +25449,9 @@ msgstr "เว็บไซต์อย่างเป็นทางการ"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s ตัวที่เข้ารหัสแล้ว)"
+msgstr ""
+"หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s "
+"ตัวที่เข้ารหัสแล้ว)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "
@@ -25423,4 +25667,4 @@ msgstr "ปี"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/tl_PH/LC_MESSAGES/duckduckgo.po
+++ b/locales/tl_PH/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4015,6 +4057,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4069,6 +4116,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4106,6 +4158,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4202,6 +4259,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4236,6 +4298,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4361,6 +4430,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4597,9 +4671,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4627,6 +4711,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4880,6 +4969,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5046,6 +5140,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5221,6 +5320,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5328,6 +5432,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5816,6 +5925,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6055,6 +6169,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6188,6 +6307,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6269,6 +6398,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6600,6 +6734,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7021,6 +7160,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7050,6 +7194,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7066,6 +7220,11 @@ msgstr "Kunin ang kantang ito sa:"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7617,6 +7776,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8916,6 +9080,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8971,6 +9141,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9867,6 +10042,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10261,6 +10441,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10809,6 +10994,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "May pagina pero walang bilang"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10977,6 +11167,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11573,9 +11768,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11590,6 +11795,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11846,6 +12056,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12015,6 +12230,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12457,6 +12677,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12484,6 +12714,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12606,6 +12841,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12908,6 +13148,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12916,6 +13161,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13473,6 +13723,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13755,6 +14010,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14152,6 +14412,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Gawing Homepage"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14204,6 +14469,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14233,6 +14508,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14281,6 +14562,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14392,6 +14678,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14516,6 +14807,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14544,6 +14840,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14842,6 +15143,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15074,6 +15380,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15552,6 +15863,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15664,6 +15982,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15733,6 +16056,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16102,9 +16439,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16205,6 +16552,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16461,6 +16822,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16798,9 +17164,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Subukang maghanap!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16854,6 +17230,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16864,6 +17245,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16886,6 +17272,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17086,6 +17477,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17370,6 +17766,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17665,6 +18066,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18578,6 +18984,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18917,6 +19328,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19263,6 +19681,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19373,6 +19797,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19407,6 +19836,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19706,6 +20140,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20180,6 +20621,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
@@ -111,6 +111,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -292,6 +297,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -486,6 +496,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1226,6 +1241,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1850,6 +1872,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3084,6 +3111,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3688,6 +3720,11 @@ msgstr "sitelen musi"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3723,6 +3760,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4030,6 +4072,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4084,6 +4131,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4121,6 +4173,11 @@ msgstr "o kepeken %sabout:preferences#search%s lon ilo pi nimi tawa"
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4217,6 +4274,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4251,6 +4313,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4376,6 +4445,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4612,9 +4686,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4642,6 +4726,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4895,6 +4984,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5062,6 +5156,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5237,6 +5336,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5344,6 +5448,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5832,6 +5941,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6071,6 +6185,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6204,6 +6323,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6285,6 +6414,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6618,6 +6752,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7039,6 +7178,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7068,6 +7212,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7086,6 +7240,11 @@ msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr ""
 "o toki tawa jan pona sina pi lipu ni! o pali e lipu DuckDuckGo suli sin!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7636,6 +7795,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8941,6 +9105,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8996,6 +9166,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9892,6 +10067,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "tenpo mute"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10286,6 +10466,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10836,6 +11021,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "lon taso nanpa ala."
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11006,6 +11196,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11604,9 +11799,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11621,6 +11826,11 @@ msgstr "loje walo"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11877,6 +12087,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12047,6 +12262,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12489,6 +12709,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12516,6 +12746,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12638,6 +12873,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12940,6 +13180,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "pakala tawa ala e nimi tawa kama ale "
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12948,6 +13193,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13508,6 +13758,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "o lukin lon nasin jan nimi ala"
 
@@ -13790,6 +14045,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14196,6 +14456,11 @@ msgstr "pali e ona sama ilo tawa lukin sama nasin pona"
 msgid "Set as Homepage"
 msgstr "o kepeken e ni tan lipu lawa"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14248,6 +14513,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14277,6 +14552,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14325,6 +14606,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14436,6 +14722,11 @@ msgstr "lukin e ilo bookmarklet en sitelen mute pi nimi tawa kama"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14560,6 +14851,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14588,6 +14884,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14886,6 +15187,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15118,6 +15424,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15596,6 +15907,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "kama pona tawa e ilo lukin li tawa ala monsi sina. tenpo ala."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15708,6 +16026,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15778,6 +16101,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "o jo e len sina!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16148,9 +16485,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16251,6 +16598,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16509,6 +16870,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16846,9 +17212,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "sina pali e lukin!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16902,6 +17278,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16912,6 +17293,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16935,6 +17321,11 @@ msgstr ""
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "pali e lipu lili tomo sina. tenpo ala la, ona li lukin toki ni:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17134,6 +17525,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17422,6 +17818,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17720,6 +18121,11 @@ msgstr "kepeken lon ilo Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "kepeken lon ilo Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18636,6 +19042,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "tenpo suno ni la, sina kama ni seme?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18977,6 +19388,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19323,6 +19741,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19433,6 +19857,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19469,6 +19898,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19771,6 +20205,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20245,6 +20686,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgctxt "SERP footer content"

--- a/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
+++ b/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1843,6 +1865,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3077,6 +3104,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3673,6 +3705,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3708,6 +3745,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4013,6 +4055,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4067,6 +4114,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4104,6 +4156,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4200,6 +4257,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4234,6 +4296,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4359,6 +4428,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4595,9 +4669,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4625,6 +4709,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4878,6 +4967,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5044,6 +5138,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5219,6 +5318,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5326,6 +5430,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5814,6 +5923,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6053,6 +6167,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6186,6 +6305,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6267,6 +6396,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6596,6 +6730,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7017,6 +7156,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7046,6 +7190,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7062,6 +7216,11 @@ msgstr ""
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7613,6 +7772,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8908,6 +9072,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8963,6 +9133,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9859,6 +10034,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10253,6 +10433,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10801,6 +10986,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr ""
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10969,6 +11159,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11565,9 +11760,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11582,6 +11787,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11838,6 +12048,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12007,6 +12222,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12449,6 +12669,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12476,6 +12706,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12598,6 +12833,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12900,6 +13140,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr ""
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12908,6 +13153,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13465,6 +13715,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13745,6 +14000,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14142,6 +14402,11 @@ msgstr ""
 msgid "Set as Homepage"
 msgstr "Mekim Fran pes"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14194,6 +14459,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14223,6 +14498,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14271,6 +14552,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14382,6 +14668,11 @@ msgstr ""
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14506,6 +14797,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14534,6 +14830,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14832,6 +15133,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15064,6 +15370,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15542,6 +15853,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15654,6 +15972,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15723,6 +16046,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16092,9 +16429,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16195,6 +16542,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16451,6 +16812,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16788,8 +17154,18 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
+msgstr ""
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
 msgstr ""
 
 #. Message prompting users to add more information to their search term.
@@ -16844,6 +17220,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16854,6 +17235,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16876,6 +17262,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17076,6 +17467,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17360,6 +17756,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17655,6 +18056,11 @@ msgstr ""
 
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
 msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -18568,6 +18974,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18907,6 +19318,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19251,6 +19669,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19359,6 +19783,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19393,6 +19822,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19690,6 +20124,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20162,6 +20603,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Nearby"

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "%1$s algılandı"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s dosya kullanıldı"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -364,7 +364,7 @@ msgstr "%1$s kullanıldı"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -623,7 +623,7 @@ msgstr "1 gün önce"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "1 dosya kullanıldı"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -926,8 +926,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
+msgstr "Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1544,6 +1543,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Gelişmiş modeller, limitleri diğer modellere göre 2-5 kat daha hızlı "
+"tüketebilir. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1585,8 +1586,7 @@ msgstr "İndirdikten ve açtıktan sonra %1$sYükle%2$s seçeneğine tıklayın"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
+msgstr "İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1882,8 +1882,7 @@ msgstr "Zaten senkronize edildi."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
+msgstr "Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2173,8 +2172,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
+msgstr "Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2341,7 +2339,7 @@ msgstr "Özel olarak sor"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Özel olarak sor"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2481,15 +2479,13 @@ msgstr "Ses"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2937,8 +2933,7 @@ msgstr "Bu siteyi tüm sonuçlarda engelleyin"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
+msgstr "Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3365,8 +3360,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
+msgstr "Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3908,7 +3902,7 @@ msgstr "AI ile gizli sohbet edin"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Popüler Yapay Zekâlarla özel olarak sohbet edin"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4424,8 +4418,7 @@ msgstr "%1$sEkle%2$s seçeneğine tıklayın"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr ""
-"%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
+msgstr "%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -4538,15 +4531,13 @@ msgstr "Açılır menüden %1$sArama Ayarlarını Değiştir%2$s seçeneğine t�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sSet as Default%s towards the bottom"
-msgstr ""
-"Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
+msgstr "Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
+msgstr "Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4627,8 +4618,7 @@ msgstr "Adres çubuğundaki %1$sizinler simgesine%2$s tıklayın"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
+msgstr "Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4680,8 +4670,7 @@ msgstr "Arama çubuğundaki büyüteç simgesine tıklayın"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
+msgstr "Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -4714,7 +4703,7 @@ msgstr "Kapat"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Kapat"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4764,7 +4753,7 @@ msgstr "Aramayı kapat"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "İkinci görüşü kapat"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5141,7 +5130,7 @@ msgstr "Reklamları Engellemeye Devam Et"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "Son sohbetlere buradan devam edin. Veya bunları Fire Button ile silin."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5212,7 +5201,7 @@ msgstr "Çerez verileri:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Kopyalandı"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5267,7 +5256,7 @@ msgstr "Kodu Kopyala"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Bağlantıyı Kopyala"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5386,7 +5375,7 @@ msgstr "Görsel Oluştur"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Paylaşım Bağlantısı Oluştur"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5438,6 +5427,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Bir bağlantı oluşturmak, sohbetin bağlantıyı açan herkes tarafından "
+"görüntülenebilen bir kopyasını oluşturur."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5596,7 +5587,7 @@ msgstr "Yanıtları Özelleştir"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Yanıtları özelleştirin"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5663,8 +5654,7 @@ msgstr "Günlük limit doldu"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr "Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5887,7 +5877,7 @@ msgstr "Sunucu Verileri Silinsin mi?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Paylaşılan Bağlantıyı Sil"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5899,7 +5889,7 @@ msgstr "Deşifreyi silin"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Bir sohbeti silin"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5937,7 +5927,7 @@ msgstr "Görsel silinsin mi?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Beni sil"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6255,7 +6245,7 @@ msgstr "Promosyonu kapat"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Turu kapat"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6362,8 +6352,7 @@ msgstr "DuckDuckGo'yu listede göremiyor musunuz?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
+msgstr "Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6474,7 +6463,7 @@ msgstr "DuckDuckGo'yu indirin"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "DuckDuckGo'yu indirin"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6695,7 +6684,7 @@ msgstr "DuckDuckGo tarafından Duck.ai. Gizli AI sohbeti. Ücretsiz."
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai artık PDF dosyalarını analiz edebiliyor. Hemen deneyin!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6794,8 +6783,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+msgstr "Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6851,14 +6839,13 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr ""
-"Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
+msgstr "Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai; Anthropic, OpenAI ve diğerlerinin modellerini destekler."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6876,8 +6863,7 @@ msgstr "Duck.ai aboneliği yükseltildi!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
+msgstr "Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7514,7 +7500,7 @@ msgstr "En Çok Ziyaret Edilen Siteleri Etkinleştir"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Şimdi Etkinleştir"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7564,8 +7550,7 @@ msgstr "Duck.ai'da sesli dikte özelliğini etkinleştir"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
+msgstr "Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7674,8 +7659,7 @@ msgstr "Duck.ai'ı beğeniyor musunuz?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
+msgstr "'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7819,7 +7803,7 @@ msgstr "Eğlence rehberi"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Tüm Sohbet"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7986,13 +7970,13 @@ msgstr "Müstehcen şarkı sözleri"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai'ı Keşfedin"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Duck.ai'ı Keşfedin"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8099,7 +8083,7 @@ msgstr "Ücretsiz"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "ÜCRETSİZ ve İSTEĞE BAĞLI"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8303,8 +8287,7 @@ msgstr "Finansal danışman"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
+msgstr "%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8355,8 +8338,7 @@ msgstr "Size daha yakın sonuçlar bulun."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
+msgstr "Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8526,7 +8508,7 @@ msgstr "Depolama Alanını Boşalt"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Ücretsiz ve her zaman gizli"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8538,8 +8520,7 @@ msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
+msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8551,8 +8532,7 @@ msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Kullanılabilen"
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr ""
-"Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
+msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -9046,7 +9026,7 @@ msgstr "Bilgisayar yardımı alın"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "DuckDuckGo aboneliği ile daha yüksek kullanım sınırları elde edin."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9089,13 +9069,15 @@ msgstr "En Son Sürümü İndirin"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Uygulamayı indirin"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"%1$sYouTube'daki reklamları engellemek için %2$sücretsiz DuckDuckGo "
+"Tarayıcısını edinin."
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9123,7 +9105,7 @@ msgstr "Arkadaşlarınızı getirin ve büyümemize yardımcı olun!"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Başlangıç kontrol listesi"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9668,8 +9650,7 @@ msgstr "DuckDuckGo'yu geliştirmemize yardımcı olun"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
+msgstr "Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9727,8 +9708,7 @@ msgstr "Arkadaşlarınızın ve ailenizin Duck Side'a katılmalarına yardımcı
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
+msgstr "Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9816,7 +9796,7 @@ msgstr "İpuçlarını Gizle"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Öğreticiyi Gizle"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9865,8 +9845,7 @@ msgstr "E-posta adresinizi gizleyin"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
+msgstr "Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10114,8 +10093,7 @@ msgstr "Yapay zeka destekli cevapların ne kadar görünmesini istiyorsun?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
+msgstr "Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10265,15 +10243,14 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi kitaplar/"
-"diziler nelerdir ve neden?"
+"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi "
+"kitaplar/diziler nelerdir ve neden?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
+msgstr "Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -11447,6 +11424,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Arama sorguları göndermek ile Duck.ai'a istemler göndermek arasında geçiş "
+"yapmanızı sağlar"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11522,7 +11501,7 @@ msgstr "Kazanılan Kenar Atışları"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Bağlantının süresi 7 gün içinde doluyor."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11538,8 +11517,7 @@ msgstr "Bağlantılar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
+msgstr "Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12413,8 +12391,7 @@ msgstr "Aylık limit doldu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr "Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12564,8 +12541,7 @@ msgstr "Daha fazla bilgiyi %1$s %2$s makalesinde bulabilirsiniz."
 # smartling.placeholder_format=C
 #. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
 msgid "More info in the %s section of the %s %s article."
-msgstr ""
-"Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
+msgstr "Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt ""
@@ -12627,7 +12603,7 @@ msgstr "20 dakikadan uzun"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Daha fazla ipucu"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12939,7 +12915,7 @@ msgstr "Yeni Sohbet"
 #. Title shown to the joiner device (the one that is not logged in) after the two devices have successfully paired. %s is a line break so the title wraps after "to"; rendered via <Translate>. This screen prompts the user to save the recovery code.
 msgctxt "Title for the joiner-device success screen"
 msgid "New device added to %sSync & Backup."
-msgstr "%1$sSync & Backup'a yeni cihaz eklendi."
+msgstr "Sync & Backup'a %1$syeni cihaz eklendi."
 
 # smartling.placeholder_format=C
 #. Warning in the About Chat History and About Sync modals explaining that prompts and responses are temporarily stored encrypted on DuckDuckGo's server for connection recovery, and that disabling chat history deletes pinned chats.
@@ -13121,7 +13097,7 @@ msgstr "Hayır Teşekkürler"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Hayır Teşekkürler"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13789,7 +13765,7 @@ msgstr "Açık ama numarasız"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Karşılama tamamlandı"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -14007,7 +13983,7 @@ msgstr "Görsel oluşturma ve düzenleme önerilerini aç"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Başlangıç kontrol listesini açın"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14760,7 +14736,7 @@ msgstr "Sabitleyin"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Bir sohbeti sabitleyin"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14772,7 +14748,7 @@ msgstr "%1$s %2$s sohbetlerini buraya sabitle"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Beni sabitle"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14795,7 +14771,7 @@ msgstr "Sabitlenmiş"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Sabitlenmiş sohbetler, son sohbetlerinin en üstünde görünür."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15053,16 +15029,14 @@ msgstr "Lütfen bekleyin..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr ""
-"DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
+msgstr "DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
+msgstr "Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15125,6 +15099,8 @@ msgstr "Kötü biçimlendirme"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Popüler yapay zeka modelleri mevcut. Hesaba gerek yok. Sohbetler tarafımızca "
+"anonimleştirilir."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15338,7 +15314,7 @@ msgstr "Önceki sekmeler"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Önceki ipuçları"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15633,8 +15609,7 @@ msgstr "Bana sor"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
+msgstr "Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15885,13 +15860,15 @@ msgstr "Orta düzeyde yerleşik moderasyona sahip mantıklı yapay zeka"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Akıl yürütme, karmaşık sorulara daha iyi yanıtlar verebilir."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Akıl yürütme daha kapsamlıdır, ancak limitleri 2-5 kat daha hızlı tüketir. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15932,7 +15909,7 @@ msgstr "Son sohbet depolama ayarları %1$s'dan yapılabilir."
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Son sohbetler"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16093,7 +16070,7 @@ msgstr "Kullanımı Azalt"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Daha verimli bir modelle kullanımı azaltın"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16243,8 +16220,9 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya &quot;"
-"Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden yükleyin."
+"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya "
+"&quot;Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden "
+"yükleyin."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16478,7 +16456,7 @@ msgstr "Tüm Ayarları Sıfırla"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Öğreticiyi sıfırla"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16496,7 +16474,7 @@ msgstr "Çözünürlük"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Yanıt"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16622,8 +16600,7 @@ msgstr "Sonuçlar, engellenmiş sitelerden gelen bilgileri içermez."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
+msgstr "Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16986,8 +16963,7 @@ msgstr "En son 30 sohbetinizi cihazınıza yerel olarak kaydedin."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
+msgstr "Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17200,14 +17176,13 @@ msgstr "Ara"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr ""
-"Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
+msgstr "Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Arama ve Duck.ai'u Aç/Kapat"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17473,8 +17448,7 @@ msgstr "DuckDuckGo ile Ara"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
+msgstr "Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17592,7 +17566,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Şifreli sunucumuzda güvenli bir şekilde saklanır."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17703,8 +17677,7 @@ msgstr "En son güncellemelerimizden bazılarını gör"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
+msgstr "Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17773,8 +17746,7 @@ msgstr "Varsayılan Arama Motoru açılır menüsünden %1$sDuckDuckGo%2$s'yu se
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr "Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17840,8 +17812,7 @@ msgstr "%1$sArama Motoru%2$s bölümünü seçin"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
+msgstr "%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17866,8 +17837,7 @@ msgstr "Açılır menüden %1$sSeçenekler%2$s ögesini seçin."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
+msgstr "%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17897,8 +17867,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr "Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18117,7 +18086,7 @@ msgstr "Giriş sayfası olarak ayarla"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Duck.ai’ın yanıtlarının tonunu ve tarzını ayarla."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18190,13 +18159,13 @@ msgstr "Seyşeller"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Paylaş"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Paylaş"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18245,7 +18214,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Sohbeti paylaş"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18309,7 +18278,7 @@ msgstr "Olumlu geri bildirim paylaşın"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Paylaşım kapsamı"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18450,7 +18419,7 @@ msgstr "Ayrıntıları Göster"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Duck.ai eğitimini göster"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18461,8 +18430,7 @@ msgstr "DuckAssist <sup>BETA'</sup>yı göster"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
+msgstr "DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18579,8 +18547,7 @@ msgstr "Tüm sonuçları gösterin"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
+msgstr "Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18605,7 +18572,7 @@ msgstr "Daha fazla göster"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Daha fazla model göster"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18646,7 +18613,7 @@ msgstr "Kenar çubuğunu göster"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18740,14 +18707,12 @@ msgstr "En çok ziyaret edilen bağlantıları yeni sekme sayfasında gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr "Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr "Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18776,8 +18741,7 @@ msgstr "Siz yazarken arama kutusunun altında öneriler gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
+msgstr "Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18864,8 +18828,7 @@ msgstr "Site İsimleri"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
+msgstr "Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19029,7 +18992,7 @@ msgstr "Bir şeyler ters gitti. Lütfen daha sonra tekrar deneyin."
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Bir hata oluştu. Lütfen tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19087,8 +19050,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
+msgstr "Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19122,8 +19084,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
+msgstr "Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19177,8 +19138,7 @@ msgstr "Kaynak metin temizlendi"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
+msgstr "Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19330,7 +19290,7 @@ msgstr "Haftalık Limiti Kullanmaya Başlayın"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Yeni bir sohbet başlatın"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19438,8 +19398,7 @@ msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicileri engelleyin."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
+msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19857,8 +19816,7 @@ msgstr "Model değiştir"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
+msgstr "Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -19918,7 +19876,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Bu ikinci görüşe geç"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20078,7 +20036,7 @@ msgstr "Senkronizasyon ve Yedekleme geçici olarak kullanılamıyor"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Sohbetleri cihazlar arasında senkronize edin."
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20174,6 +20132,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Duck.ai'ı her yere yanınızda götürün. Ücretsiz uygulamamıza entegre ederek, "
+"nerede olursanız olun daha hızlı erişim sağlayın."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20182,6 +20142,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Duck.ai'ı her yere yanınızda götürün. Daha hızlı erişim için, nerede "
+"olursanız olun, ücretsiz tarayıcımıza entegre edilmiş bu özelliği edinin."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20474,8 +20436,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
+msgstr "Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20644,8 +20605,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
+msgstr "Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20657,7 +20617,7 @@ msgstr "Bu Ay"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Bu Yanıt"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20669,7 +20629,7 @@ msgstr "Bu Hafta"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Bu sohbet Duck.ai'da kalır ve size özeldir."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20810,6 +20770,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Bu sadece bir örnek sohbet. Menüyü (üç nokta) açın, ardından sohbetlerinizin "
+"en üstünde kalması için Sabitle seçeneğini seçin!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20817,7 +20779,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
+msgstr "Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20939,8 +20901,7 @@ msgstr "Bu video henüz burada izlenemiyor. %1$s üzerinden izleyebilirsiniz."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
+msgstr "Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20960,8 +20921,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
+msgstr "Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20979,8 +20939,7 @@ msgstr "Tüm ayarlarınız silinecek. Devam edilsin mi?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
+msgstr "Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21054,8 +21013,7 @@ msgstr "İpuçları"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
+msgstr "İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21087,8 +21045,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
+msgstr "Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -21162,6 +21119,8 @@ msgstr "Bugün"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Gizli yapay zekâ sohbetini denemek için geçiş yapın veya %1$s %2$s "
+"menüsünden devre dışı bırakın.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21342,8 +21301,7 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr ""
-"DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
+msgstr "DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -21510,8 +21468,7 @@ msgstr "Bu tür mesajları görmeyi durdurmak için %1$s'u deneyin."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
+msgstr "Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21580,7 +21537,7 @@ msgstr "Deneyin"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Farklı bir model deneyin"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21591,7 +21548,7 @@ msgstr "Bir şeyler arayın!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Bir öneri deneyin"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21661,7 +21618,7 @@ msgstr "Ücretsiz deneyin"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Ücretsiz deneyin"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21683,7 +21640,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "7 gün boyunca ücretsiz deneyin"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21716,7 +21673,7 @@ msgstr "Bu mesajları asla göstermeyen giriş sayfamızı deneyin:"
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Akıl yürütmeyi deneyin"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21963,14 +21920,13 @@ msgstr "Daha doğru sonuçlar için %1$sKesin Konum%2$s'u açın"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
+msgstr "YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Duck.ai'ı Aç/Kapat"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21982,8 +21938,7 @@ msgstr "Daha doğru sonuçlar için \"Kesin Konum\"u açın."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
+msgstr "Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22189,8 +22144,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: https://duckduckgo."
-"com"
+"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22224,8 +22179,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
+msgstr "Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22352,7 +22306,7 @@ msgstr "Abone olarak gelişmiş yapay zeka özelliklerine erişin!"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Gelişmiş modellerin kilidini açın"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22693,8 +22647,7 @@ msgstr "DuckDuckGo Private Search'ü kullanın"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
+msgstr "iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22722,7 +22675,7 @@ msgstr "Safari'de kullanın"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Bir sohbeti geçmişten silmek için Fire Button'ı kullanın."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23268,8 +23221,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
+msgstr "En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23371,8 +23323,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
+msgstr "Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -23451,8 +23402,7 @@ msgstr "Biz dahil hiç kimse arama geçmişinize ulaşamaz."
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr ""
-"Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
+msgstr "Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -23924,7 +23874,7 @@ msgstr "Bugün sizi ne geri getirdi?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Neler yapabilirsiniz?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24171,8 +24121,7 @@ msgstr "<strong>%1$s</strong>Nerede İzlenir?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
+msgstr "Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -24352,6 +24301,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"Duck.ai ile sohbetleriniz anonimleştirilir ve asla yapay zekâyı eğitmek için "
+"kullanılmaz. '%1$s' menüsünden istediğiniz zaman açıp kapatabilirsiniz."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24702,8 +24653,7 @@ msgstr "Bunu istediğin zaman %1$sArama Ayarları%2$s'ndan değiştirebilirsin"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
+msgstr "Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24742,8 +24692,7 @@ msgstr "Aylık limiti kullanarak sohbet etmeye devam edebilirsiniz."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
+msgstr "Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24786,7 +24735,7 @@ msgstr "Konuşma başına en fazla %1$s görsel ekleyebilirsiniz."
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "Bir defada yalnızca %1$s sekme ekleyebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24935,7 +24884,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Her şey hazır!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24988,7 +24937,7 @@ msgstr "1 siteyi engellediniz"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Duck.ai'ın temel özelliklerini öğrendiniz"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25023,8 +24972,7 @@ msgstr "Tek bir oturum için maksimum sesli sohbet süresine ulaştınız."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
+msgstr "Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -25254,8 +25202,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
+msgstr "Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25302,8 +25249,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
+msgstr "Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -25399,6 +25345,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Ayarlarınız kaydedildi, ancak çerezleri temizlemek onları sıfırlayacaktır. "
+"Kalıcı hale getirmek için %1$sDuckDuckGo No AI%2$s uzantısını etkinleştirin."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25438,8 +25386,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
+msgstr "Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25481,8 +25428,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
+msgstr "Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25565,8 +25511,7 @@ msgstr "(bir %1$s ürünü)"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
+msgstr "DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25997,4 +25942,4 @@ msgstr "y"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,6 +122,12 @@ msgstr "%1$s gün önce"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s algılandı"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -353,6 +359,12 @@ msgstr "%1$s takip girişimi engellendi"
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
 msgstr "%1$s kullanıldı"
+
+# smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -606,6 +618,12 @@ msgstr "Son 24 saat içinde DuckDuckGo tarafından 1 girişim engellendi"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 gün önce"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -908,7 +926,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
+msgstr ""
+"Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1519,6 +1538,14 @@ msgid "Advanced Models"
 msgstr "Gelişmiş Modeller"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Arama Ağı'nda Reklam Verin"
@@ -1558,7 +1585,8 @@ msgstr "İndirdikten ve açtıktan sonra %1$sYükle%2$s seçeneğine tıklayın"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
+msgstr ""
+"İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1854,7 +1882,8 @@ msgstr "Zaten senkronize edildi."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
+msgstr ""
+"Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2144,7 +2173,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
+msgstr ""
+"Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2308,6 +2338,12 @@ msgid "Ask privately"
 msgstr "Özel olarak sor"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2445,13 +2481,15 @@ msgstr "Ses"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr ""
+"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr ""
+"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2899,7 +2937,8 @@ msgstr "Bu siteyi tüm sonuçlarda engelleyin"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
+msgstr ""
+"Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3326,7 +3365,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
+msgstr ""
+"Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3865,6 +3905,12 @@ msgid "Chat privately with AI"
 msgstr "AI ile gizli sohbet edin"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4378,7 +4424,8 @@ msgstr "%1$sEkle%2$s seçeneğine tıklayın"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr "%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
+msgstr ""
+"%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -4491,13 +4538,15 @@ msgstr "Açılır menüden %1$sArama Ayarlarını Değiştir%2$s seçeneğine t�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sSet as Default%s towards the bottom"
-msgstr "Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
+msgstr ""
+"Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
+msgstr ""
+"Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4578,7 +4627,8 @@ msgstr "Adres çubuğundaki %1$sizinler simgesine%2$s tıklayın"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
+msgstr ""
+"Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4630,7 +4680,8 @@ msgstr "Arama çubuğundaki büyüteç simgesine tıklayın"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
+msgstr ""
+"Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -4658,6 +4709,12 @@ msgstr "Küçük resim"
 #. An accessible label for a button that closes a modal dialog
 msgid "Close"
 msgstr "Kapat"
+
+# smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4702,6 +4759,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Aramayı kapat"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5075,6 +5138,12 @@ msgid "Continue Blocking Ads"
 msgstr "Reklamları Engellemeye Devam Et"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5140,6 +5209,12 @@ msgid "Cookie data:"
 msgstr "Çerez verileri:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5187,6 +5262,12 @@ msgstr ""
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Kodu Kopyala"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5302,6 +5383,12 @@ msgid "Create Image"
 msgstr "Görsel Oluştur"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5343,6 +5430,14 @@ msgstr "Oluşturan"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "%1$s tarafından oluşturuldu"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5498,6 +5593,12 @@ msgid "Customize responses"
 msgstr "Yanıtları Özelleştir"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
 msgid "Customize this page"
 msgstr "Bu sayfayı özelleştirin"
@@ -5562,7 +5663,8 @@ msgstr "Günlük limit doldu"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr ""
+"Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -5782,10 +5884,22 @@ msgid "Delete Server Data?"
 msgstr "Sunucu Verileri Silinsin mi?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Deşifreyi silin"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5818,6 +5932,12 @@ msgstr "Görseli sil"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Görsel silinsin mi?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6132,6 +6252,12 @@ msgid "Dismiss promotion"
 msgstr "Promosyonu kapat"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6236,7 +6362,8 @@ msgstr "DuckDuckGo'yu listede göremiyor musunuz?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
+msgstr ""
+"Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6342,6 +6469,12 @@ msgstr "İndirme tamamlandı"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "DuckDuckGo'yu indirin"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6559,6 +6692,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "DuckDuckGo tarafından Duck.ai. Gizli AI sohbeti. Ücretsiz."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6655,7 +6794,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6711,7 +6851,14 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr "Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
+msgstr ""
+"Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6729,7 +6876,8 @@ msgstr "Duck.ai aboneliği yükseltildi!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
+msgstr ""
+"Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7363,6 +7511,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "En Çok Ziyaret Edilen Siteleri Etkinleştir"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7410,7 +7564,8 @@ msgstr "Duck.ai'da sesli dikte özelliğini etkinleştir"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
+msgstr ""
+"Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7519,7 +7674,8 @@ msgstr "Duck.ai'ı beğeniyor musunuz?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
+msgstr ""
+"'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7658,6 +7814,12 @@ msgstr "Ayarlarınızı yüklemek için parolanızı girin."
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "Eğlence rehberi"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7821,6 +7983,18 @@ msgid "Explicit lyrics"
 msgstr "Müstehcen şarkı sözleri"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7920,6 +8094,12 @@ msgstr "BO"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Ücretsiz"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8123,7 +8303,8 @@ msgstr "Finansal danışman"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
+msgstr ""
+"%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8174,7 +8355,8 @@ msgstr "Size daha yakın sonuçlar bulun."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
+msgstr ""
+"Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8341,6 +8523,12 @@ msgid "Free Up Storage"
 msgstr "Depolama Alanını Boşalt"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8350,7 +8538,8 @@ msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
+msgstr ""
+"Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8362,7 +8551,8 @@ msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Kullanılabilen"
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
+msgstr ""
+"Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8853,6 +9043,12 @@ msgid "Get computer help"
 msgstr "Bilgisayar yardımı alın"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8890,6 +9086,18 @@ msgid "Get the Latest Version"
 msgstr "En Son Sürümü İndirin"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8910,6 +9118,12 @@ msgstr "Bu şarkıyı şuradan edinin:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Arkadaşlarınızı getirin ve büyümemize yardımcı olun!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9454,7 +9668,8 @@ msgstr "DuckDuckGo'yu geliştirmemize yardımcı olun"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
+msgstr ""
+"Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -9512,7 +9727,8 @@ msgstr "Arkadaşlarınızın ve ailenizin Duck Side'a katılmalarına yardımcı
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
+msgstr ""
+"Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -9597,6 +9813,12 @@ msgid "Hide Tips"
 msgstr "İpuçlarını Gizle"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9643,7 +9865,8 @@ msgstr "E-posta adresinizi gizleyin"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
+msgstr ""
+"Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -9891,7 +10114,8 @@ msgstr "Yapay zeka destekli cevapların ne kadar görünmesini istiyorsun?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
+msgstr ""
+"Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10041,14 +10265,15 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi "
-"kitaplar/diziler nelerdir ve neden?"
+"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi kitaplar/"
+"diziler nelerdir ve neden?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
+msgstr ""
+"Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -11217,6 +11442,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "DuckDuckGo ile anonim olarak arama yapmanıza imkan verir"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Liberya"
 
@@ -11287,6 +11519,12 @@ msgid "Lineouts Won"
 msgstr "Kazanılan Kenar Atışları"
 
 # smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
 msgid "Link font:"
 msgstr "Bağlantı yazı tipi:"
@@ -11300,7 +11538,8 @@ msgstr "Bağlantılar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
+msgstr ""
+"Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12174,7 +12413,8 @@ msgstr "Aylık limit doldu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr ""
+"Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -12324,7 +12564,8 @@ msgstr "Daha fazla bilgiyi %1$s %2$s makalesinde bulabilirsiniz."
 # smartling.placeholder_format=C
 #. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
 msgid "More info in the %s section of the %s %s article."
-msgstr "Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
+msgstr ""
+"Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt ""
@@ -12381,6 +12622,12 @@ msgstr "%1$s hakkında daha fazla istatistik"
 msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "20 dakikadan uzun"
+
+# smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12869,6 +13116,12 @@ msgstr "Hayır Teşekkürler"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Hayır Teşekkürler"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13533,6 +13786,12 @@ msgid "On but no numbers"
 msgstr "Açık ama numarasız"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13743,6 +14002,12 @@ msgstr "Sohbet önerilerini aç"
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
 msgstr "Görsel oluşturma ve düzenleme önerilerini aç"
+
+# smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14492,10 +14757,22 @@ msgid "Pin"
 msgstr "Sabitleyin"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "%1$s %2$s sohbetlerini buraya sabitle"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14513,6 +14790,12 @@ msgstr "Pembe"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Sabitlenmiş"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14770,14 +15053,16 @@ msgstr "Lütfen bekleyin..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr "DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
+msgstr ""
+"DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
+msgstr ""
+"Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -14834,6 +15119,12 @@ msgstr "Lehçe"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Kötü biçimlendirme"
+
+# smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15042,6 +15333,12 @@ msgstr "Önceki görsel"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Önceki sekmeler"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15336,7 +15633,8 @@ msgstr "Bana sor"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
+msgstr ""
+"Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15584,6 +15882,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Orta düzeyde yerleşik moderasyona sahip mantıklı yapay zeka"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15617,6 +15927,12 @@ msgstr "Son Sekmeler"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Son sohbet depolama ayarları %1$s'dan yapılabilir."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15774,6 +16090,12 @@ msgid "Reduce Usage"
 msgstr "Kullanımı Azalt"
 
 # smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
@@ -15921,9 +16243,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya "
-"&quot;Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden "
-"yükleyin."
+"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya &quot;"
+"Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden yükleyin."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16154,6 +16475,12 @@ msgid "Reset All Settings"
 msgstr "Tüm Ayarları Sıfırla"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16164,6 +16491,12 @@ msgstr "%1$s sonra sıfırlanır"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Çözünürlük"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16289,7 +16622,8 @@ msgstr "Sonuçlar, engellenmiş sitelerden gelen bilgileri içermez."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
+msgstr ""
+"Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -16652,7 +16986,8 @@ msgstr "En son 30 sohbetinizi cihazınıza yerel olarak kaydedin."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
+msgstr ""
+"Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -16865,7 +17200,14 @@ msgstr "Ara"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr "Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
+msgstr ""
+"Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17131,7 +17473,8 @@ msgstr "DuckDuckGo ile Ara"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
+msgstr ""
+"Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -17246,6 +17589,12 @@ msgstr ""
 "erişemeyiz."
 
 # smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid "Security issue"
 msgstr "Güvenlik Sorunu"
@@ -17354,7 +17703,8 @@ msgstr "En son güncellemelerimizden bazılarını gör"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
+msgstr ""
+"Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -17423,7 +17773,8 @@ msgstr "Varsayılan Arama Motoru açılır menüsünden %1$sDuckDuckGo%2$s'yu se
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr ""
+"Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17489,7 +17840,8 @@ msgstr "%1$sArama Motoru%2$s bölümünü seçin"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
+msgstr ""
+"%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -17514,7 +17866,8 @@ msgstr "Açılır menüden %1$sSeçenekler%2$s ögesini seçin."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
+msgstr ""
+"%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -17544,7 +17897,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr ""
+"Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -17760,6 +18114,12 @@ msgid "Set as Homepage"
 msgstr "Giriş sayfası olarak ayarla"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17827,6 +18187,18 @@ msgid "Seychelles"
 msgstr "Seyşeller"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17867,6 +18239,13 @@ msgstr ""
 "Alaka düzeyini artırmak için şehir düzeyinde bir konumu yapay zeka "
 "modelleriyle paylaşın. Duck.ai hiçbir zaman kesin konumunuzu bize veya yapay "
 "zeka modellerine göstermez."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17925,6 +18304,12 @@ msgstr "Sayfa URL'sini paylaşın"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Olumlu geri bildirim paylaşın"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18062,6 +18447,12 @@ msgid "Show Detail"
 msgstr "Ayrıntıları Göster"
 
 # smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
 msgstr "DuckAssist <sup>BETA'</sup>yı göster"
@@ -18070,7 +18461,8 @@ msgstr "DuckAssist <sup>BETA'</sup>yı göster"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
+msgstr ""
+"DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18187,7 +18579,8 @@ msgstr "Tüm sonuçları gösterin"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
+msgstr ""
+"Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -18207,6 +18600,12 @@ msgstr "Haritayı göster"
 msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr "Daha fazla göster"
+
+# smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18242,6 +18641,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Kenar çubuğunu göster"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18335,12 +18740,14 @@ msgstr "En çok ziyaret edilen bağlantıları yeni sekme sayfasında gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr ""
+"Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr ""
+"Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18369,7 +18776,8 @@ msgstr "Siz yazarken arama kutusunun altında öneriler gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
+msgstr ""
+"Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18456,7 +18864,8 @@ msgstr "Site İsimleri"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
+msgstr ""
+"Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18617,6 +19026,12 @@ msgid "Something went wrong, please try again later."
 msgstr "Bir şeyler ters gitti. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18672,7 +19087,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
+msgstr ""
+"Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -18706,7 +19122,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18760,7 +19177,8 @@ msgstr "Kaynak metin temizlendi"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
+msgstr ""
+"Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -18909,6 +19327,12 @@ msgid "Start Using Weekly Limit"
 msgstr "Haftalık Limiti Kullanmaya Başlayın"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. A prompt to start a new web search.
 msgid "Start searching!"
 msgstr "Aramaya başlayın!"
@@ -19014,7 +19438,8 @@ msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicileri engelleyin."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
+msgstr ""
+"Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19432,7 +19857,8 @@ msgstr "Model değiştir"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr "Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
+msgstr ""
+"Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -19485,6 +19911,14 @@ msgstr "Daha verimli bir modele geçin"
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Sizi asla takip etmeyin arama motoruna geçiş yapın."
+
+# smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19641,6 +20075,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Senkronizasyon ve Yedekleme geçici olarak kullanılamıyor"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19726,6 +20166,22 @@ msgstr "Tacikistan"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Gizliliğinizi Geri Alın!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20018,7 +20474,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
+msgstr ""
+"Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20187,7 +20644,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
+msgstr ""
+"Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -20196,10 +20654,22 @@ msgid "This Month"
 msgstr "Bu Ay"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Bu Hafta"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20334,6 +20804,22 @@ msgid "This information isn’t useful"
 msgstr "Bu bilgi yararlı değil"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -20453,7 +20939,8 @@ msgstr "Bu video henüz burada izlenemiyor. %1$s üzerinden izleyebilirsiniz."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
+msgstr ""
+"Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20473,7 +20960,8 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
+msgstr ""
+"Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -20491,7 +20979,8 @@ msgstr "Tüm ayarlarınız silinecek. Devam edilsin mi?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
+msgstr ""
+"Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20565,7 +21054,8 @@ msgstr "İpuçları"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
+msgstr ""
+"İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -20597,7 +21087,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
+msgstr ""
+"Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -20665,6 +21156,12 @@ msgstr "Bugün"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Bugün"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20845,7 +21342,8 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr "DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
+msgstr ""
+"DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -21012,7 +21510,8 @@ msgstr "Bu tür mesajları görmeyi durdurmak için %1$s'u deneyin."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
+msgstr ""
+"Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -21078,9 +21577,21 @@ msgid "Try Them Out"
 msgstr "Deneyin"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Bir şeyler arayın!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21147,6 +21658,12 @@ msgid "Try for free"
 msgstr "Ücretsiz deneyin"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21161,6 +21678,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Ücretsiz deneyin! Güvenli bir VPN, gelişmiş ve özel bir yapay zeka ve daha "
 "fazlası."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21188,6 +21711,12 @@ msgstr "Ayarlarınızı hiçbir zaman"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "Bu mesajları asla göstermeyen giriş sayfamızı deneyin:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21434,7 +21963,14 @@ msgstr "Daha doğru sonuçlar için %1$sKesin Konum%2$s'u açın"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
+msgstr ""
+"YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21446,7 +21982,8 @@ msgstr "Daha doğru sonuçlar için \"Kesin Konum\"u açın."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
+msgstr ""
+"Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -21652,8 +22189,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: "
-"https://duckduckgo.com"
+"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21687,7 +22224,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
+msgstr ""
+"Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21809,6 +22347,12 @@ msgstr "DuckDuckGo aboneliğiyle gelişmiş yapay zeka modellerinin kilidini aç
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "Abone olarak gelişmiş yapay zeka özelliklerine erişin!"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22149,7 +22693,8 @@ msgstr "DuckDuckGo Private Search'ü kullanın"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
+msgstr ""
+"iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -22172,6 +22717,12 @@ msgstr "Firefox'ta kullanın"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Safari'de kullanın"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22717,7 +23268,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
+msgstr ""
+"En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22819,7 +23371,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
+msgstr ""
+"Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -22898,7 +23451,8 @@ msgstr "Biz dahil hiç kimse arama geçmişinize ulaşamaz."
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr "Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
+msgstr ""
+"Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -23367,6 +23921,12 @@ msgid "What brought you back today?"
 msgstr "Bugün sizi ne geri getirdi?"
 
 # smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -23611,7 +24171,8 @@ msgstr "<strong>%1$s</strong>Nerede İzlenir?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
+msgstr ""
+"Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -23783,6 +24344,14 @@ msgstr "Galibiyetler"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Karla karışık yağmur"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24133,7 +24702,8 @@ msgstr "Bunu istediğin zaman %1$sArama Ayarları%2$s'ndan değiştirebilirsin"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
+msgstr ""
+"Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -24172,7 +24742,8 @@ msgstr "Aylık limiti kullanarak sohbet etmeye devam edebilirsiniz."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
+msgstr ""
+"Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -24209,6 +24780,13 @@ msgstr "Konuşma başına en fazla %1$s resim ekleyebilirsiniz."
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "Konuşma başına en fazla %1$s görsel ekleyebilirsiniz."
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24354,6 +24932,12 @@ msgstr ""
 "olarak gönderilir."
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -24401,6 +24985,12 @@ msgid "You've blocked 1 site"
 msgstr "1 siteyi engellediniz"
 
 # smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
 msgctxt "Title for image generation limit reached message"
 msgid "You've reached the image creation limit"
@@ -24433,7 +25023,8 @@ msgstr "Tek bir oturum için maksimum sesli sohbet süresine ulaştınız."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
+msgstr ""
+"Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -24663,7 +25254,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
+msgstr ""
+"Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24710,7 +25302,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
+msgstr ""
+"Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -24800,6 +25393,14 @@ msgid "Your searches can’t be tied back to you"
 msgstr "Aramalarınız sizinle ilişkilendirilemez"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
@@ -24837,7 +25438,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
+msgstr ""
+"Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24879,7 +25481,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -24962,7 +25565,8 @@ msgstr "(bir %1$s ürünü)"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
+msgstr ""
+"DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25388,3 +25992,9 @@ msgstr "yıl"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "y"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -22,7 +23,8 @@ msgstr "Пошукові ярлики !Bang"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
+msgstr ""
+"\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -122,6 +124,12 @@ msgstr "%1$s днів тому"
 msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%1$s виявлено"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -355,6 +363,12 @@ msgid "%s used"
 msgstr "%1$s використано"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s перегляд"
@@ -473,7 +487,8 @@ msgstr "%1$sДізнайтеся, як ми зберігаємо приватн�
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
+msgstr ""
+"%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -600,6 +615,12 @@ msgstr "1 спроба була заблокована DuckDuckGo за оста�
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 день тому"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -893,7 +914,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
+msgstr ""
+"Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1009,10 +1031,9 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "Наразі можливість ставити подальші запитання штучному інтелекту не "
-"підтримується. Однак ми також пропонуємо і часто посилаємось на "
-"%1$sDuck.ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai "
-"— це наша служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic "
-"тощо."
+"підтримується. Однак ми також пропонуємо і часто посилаємось на %1$sDuck."
+"ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai — це наша "
+"служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic тощо."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1511,6 +1532,14 @@ msgid "Advanced Models"
 msgstr "Удосконалені моделі"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "Розмістити рекламу в Пошуку"
@@ -1792,7 +1821,8 @@ msgstr "Дозволити анонімний перегляд файлів у �
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
+msgstr ""
+"Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2125,7 +2155,8 @@ msgstr "Ти ще тут?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
+msgstr ""
+"Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2295,6 +2326,12 @@ msgid "Ask privately"
 msgstr "Запитайте приватно"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2330,10 +2367,11 @@ msgstr ""
 "Assist може анонімно генерувати відповіді ШІ на деякі пошукові запити, "
 "узагальнюючи релевантний веб-контент. Можна вибрати частоту відображення "
 "Assist: «Ніколи» (повністю приховує інтерфейс Assist із результатів пошуку), "
-"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки «Assist» "
-"), «Іноді» (відображаються лише відповіді ШІ в разі високої релевантності) "
-"або «Часто» (відображається частіше у різних пошукових запитах). Наразі "
-"відповіді штучного інтелекту доступні лише в США (англійською)."
+"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки "
+"«Assist» ), «Іноді» (відображаються лише відповіді ШІ в разі високої "
+"релевантності) або «Часто» (відображається частіше у різних пошукових "
+"запитах). Наразі відповіді штучного інтелекту доступні лише в США "
+"(англійською)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -3846,6 +3884,12 @@ msgid "Chat privately with AI"
 msgstr "Спілкуйтеся у приватному чаті зі штучним інтелектом"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -4004,7 +4048,8 @@ msgstr "Перевірте сабреддіт DuckDuckGo, щоб дізнати�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
+msgstr ""
+"Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4420,7 +4465,8 @@ msgstr "Оберіть %1$sНалаштування%2$s з меню вибору
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
+msgstr ""
+"Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4536,7 +4582,8 @@ msgstr "Натисніть на вкладку %1$sЗагальні%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr "Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
+msgstr ""
+"Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4553,7 +4600,8 @@ msgstr "Натисніть %1$sзначок дозволів%2$s в адресн
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
+msgstr ""
+"Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4635,6 +4683,12 @@ msgid "Close"
 msgstr "Закрити"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4677,6 +4731,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "Закрити пошук"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5050,6 +5110,12 @@ msgid "Continue Blocking Ads"
 msgstr "Продовжити блокування реклами"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -5115,6 +5181,12 @@ msgid "Cookie data:"
 msgstr "Дані файлів cookie:"
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5160,6 +5232,12 @@ msgstr "Скопіюйте і вставте %1$sabout:preferences#search%2$s в
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "Скопіювати код"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5277,6 +5355,12 @@ msgid "Create Image"
 msgstr "Створити зображення"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5318,6 +5402,14 @@ msgstr "Створено"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "Створено %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5471,6 +5563,12 @@ msgstr "Налаштувати відповіді"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "Налаштувати відповіді"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5759,10 +5857,22 @@ msgid "Delete Server Data?"
 msgstr "Видалити дані сервера?"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "Видалити транскрипт"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5795,6 +5905,12 @@ msgstr "Видалити зображення"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "Видалити зображення?"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6105,6 +6221,12 @@ msgid "Dismiss promotion"
 msgstr "Відхилити рекламу"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6313,6 +6435,12 @@ msgstr "Завантаження завершено"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "Завантажити DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6530,6 +6658,12 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai від DuckDuckGo. Приватний чат на бази ШІ. Безкоштовно."
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -6685,6 +6819,12 @@ msgstr ""
 "точність."
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6700,7 +6840,8 @@ msgstr "Duck.ai оновлено!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
+msgstr ""
+"Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6744,10 +6885,10 @@ msgstr ""
 "У відповідь на деякі пошукові запити DuckAssist іноді анонімно шукає та "
 "узагальнює інформацію. Можна вибрати частоту відображення DuckAssist: "
 "«Ніколи» (повністю приховує інтерфейс DuckAssist із результатів пошуку), «На "
-"вимогу» (відображається лише при натисканні кнопки «Допомога»), «Іноді» "
-"(показується лише в разі високої релевантності) або «Часто» (відображається "
-"частіше у різних пошукових запитах). Наразі DuckAssist доступний лише у США "
-"(англійською)."
+"вимогу» (відображається лише при натисканні кнопки «Допомога»), "
+"«Іноді» (показується лише в разі високої релевантності) або "
+"«Часто» (відображається частіше у різних пошукових запитах). Наразі "
+"DuckAssist доступний лише у США (англійською)."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6807,8 +6948,8 @@ msgstr ""
 "основі штучного інтелекту. Відповіді DuckAssist завжди містять пряме "
 "посилання на одне або два джерела відповіді, тому ви можете швидко знайти "
 "більш детальну інформацію. Важливо пам'ятати, що відповіді автоматично "
-"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих "
-"веб-сторінках%2$s."
+"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих веб-"
+"сторінках%2$s."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7012,8 +7153,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s "
-"Duck.ai."
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7021,7 +7162,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
+msgstr ""
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7216,7 +7358,8 @@ msgstr "Редагувати запит"
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
-msgstr "Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr ""
+"Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is editing an image.
@@ -7229,7 +7372,8 @@ msgstr "Редагування зображення..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
+msgstr ""
+"Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7324,6 +7468,12 @@ msgstr "Увімкнути найвідвідуваніші сайти"
 msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr "Увімкнути найвідвідуваніші сайти"
+
+# smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7485,7 +7635,8 @@ msgstr "Користуєтеся Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
+msgstr ""
+"Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7533,13 +7684,15 @@ msgstr "Переконайтеся, що доступ до розташуван�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
+msgstr ""
+"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
+msgstr ""
+"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7631,6 +7784,12 @@ msgstr "Введіть парольну фразу для завантаженн
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "Гід з розваг"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7733,7 +7892,8 @@ msgstr "Поясніть прийняту відповідь простими с
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
+msgstr ""
+"Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7794,6 +7954,18 @@ msgstr "Відвертий вміст"
 msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr "Відверті тексти"
+
+# smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7895,6 +8067,12 @@ msgstr "FPV"
 msgctxt "Text for the free badge"
 msgid "FREE"
 msgstr "Безкоштовно"
+
+# smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8057,7 +8235,8 @@ msgstr "Відфільтровує створені ШІ зображення з
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
+msgstr ""
+"Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8094,7 +8273,8 @@ msgstr "Фінансовий радник"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
+msgstr ""
+"Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8106,7 +8286,8 @@ msgstr "Знайдіть <b>%1$s</b> у папці завантажень"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
+msgstr ""
+"Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8310,6 +8491,12 @@ msgstr "Без абонплати"
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
 msgstr "Звільнити місце"
+
+# smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8567,19 +8754,22 @@ msgstr "Загальне призначення"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Штучний інтелект загального призначення з вбудованою високою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення з вбудованою високою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Штучний інтелект загального призначення з вбудованою низькою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення з вбудованою низькою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Штучний інтелект загального призначення із вбудованою середньою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення із вбудованою середньою модерацією"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8640,7 +8830,8 @@ msgstr "Згенероване зображення"
 #. Title text shown for an assistant response that contains a generated image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Generated image. Cost %s (internal only)"
-msgstr "Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr ""
+"Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Aria label for the carousel (list of generated images) in the image generation mode.
@@ -8828,6 +9019,12 @@ msgid "Get computer help"
 msgstr "Отримати комп'ютерну допомогу"
 
 # smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -8865,6 +9062,18 @@ msgid "Get the Latest Version"
 msgstr "Отримати останню версію"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8885,6 +9094,12 @@ msgstr "Придбати цю пісню на:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Залучайте ваших друзів та допомагайте нам рости!"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9574,6 +9789,12 @@ msgid "Hide Tips"
 msgstr "Приховати підказки"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9894,7 +10115,8 @@ msgctxt "Full sentence for preparing for a conversation"
 msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
-msgstr "Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
+msgstr ""
+"Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10763,7 +10985,8 @@ msgstr "Приєднуйтесь до нашої команди!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr "Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
+msgstr ""
+"Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11197,6 +11420,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Дозволяє користуватися анонімним пошуком з DuckDuckGo"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "Ліберія"
 
@@ -11265,6 +11495,12 @@ msgstr "Лінійний малюнок"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "Виграні коридори"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11383,7 +11619,8 @@ msgstr "Завантаження..."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more image and video results when scrolling"
-msgstr "Завантаження інших результатів для зображень та відео при прокручуванні"
+msgstr ""
+"Завантаження інших результатів для зображень та відео при прокручуванні"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -12369,6 +12606,12 @@ msgid "More than 20 minutes"
 msgstr "Понад 20 хвилин"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12854,6 +13097,12 @@ msgstr "Ні, дякую"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "Ні, дякую"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13518,6 +13767,12 @@ msgid "On but no numbers"
 msgstr "Увімкнено без номерів"
 
 # smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -13629,7 +13884,8 @@ msgstr "Відкрити вебсайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
+msgstr ""
+"Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13730,6 +13986,12 @@ msgid "Open create and edit images suggestions"
 msgstr "Відкрити пропозиції щодо створення та редагування зображень"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13792,7 +14054,8 @@ msgstr "Відкрити панель «Як працює Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
+msgstr ""
+"Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14171,8 +14434,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу "
-"IP-адресу, відбиток браузера чи інші дані з файлом."
+"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу IP-"
+"адресу, відбиток браузера чи інші дані з файлом."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14477,10 +14740,22 @@ msgid "Pin"
 msgstr "Закріплене"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "Закріпити чати тут із %1$s %2$s"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14498,6 +14773,12 @@ msgstr "Рожевий"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "Закріплено"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14538,7 +14819,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
+msgstr ""
+"Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14546,7 +14828,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
+msgstr ""
+"Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14560,7 +14843,8 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
+msgstr ""
+"Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -14816,6 +15100,12 @@ msgid "Poor formatting"
 msgstr "Погане форматування"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -15022,6 +15312,12 @@ msgstr "Попереднє зображення"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "Попередні вкладки"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15564,6 +15860,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "Міркуючий ШІ з вбудованою модерацією середнього рівня"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15597,6 +15905,12 @@ msgstr "Останні вкладки"
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
 msgstr "Налаштування сховища останніх чатів можна змінити в розділі «%1$s»."
+
+# smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15751,6 +16065,12 @@ msgstr "Повторити пошук, виключивши сайт із рез
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "Зменшити використання"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15911,7 +16231,8 @@ msgstr "Запам'ятати вибір"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
+msgstr ""
+"Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16128,6 +16449,12 @@ msgid "Reset All Settings"
 msgstr "Скинути всі налаштування"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -16138,6 +16465,12 @@ msgstr "Скидається через %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "Розширення"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16818,7 +17151,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
+msgstr ""
+"Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -16841,6 +17175,12 @@ msgstr "Пошук"
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
 msgstr "Шукати «%1$s», щоб знайти результати поблизу?"
+
+# smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17158,7 +17498,8 @@ msgstr "Друга думка"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
+msgstr ""
+"Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17220,6 +17561,12 @@ msgid ""
 msgstr ""
 "Безпечно зберігаються на сервері DuckDuckGo із застосуванням наскрізного "
 "шифрування. Ніхто, крім вас, не може бачити ваші дані, навіть ми."
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17370,18 +17717,21 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
+msgstr ""
+"Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
+msgstr ""
+"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
+msgstr ""
+"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17592,7 +17942,8 @@ msgstr "Вибраний текст із %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
+msgstr ""
+"Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -17735,6 +18086,12 @@ msgid "Set as Homepage"
 msgstr "Встановити як домашню сторінку"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17802,6 +18159,18 @@ msgid "Seychelles"
 msgstr "Сейшельські острови"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17810,7 +18179,8 @@ msgstr "Поділитися"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
+msgstr ""
+"Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -17840,6 +18210,13 @@ msgstr ""
 "Для підвищення релевантності відповідей поділіться своїм розташуванням "
 "(зазначте місто). Duck.ai ніколи не передає дані вашого точного "
 "місцезнаходження ані нам, ані моделям ШІ."
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17898,6 +18275,12 @@ msgstr "Поділитися URL сторінки"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "Надіслати позитивний відгук"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18033,6 +18416,12 @@ msgstr "Показати закладку і дані налаштувань"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Показати подробиці"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18184,6 +18573,12 @@ msgid "Show more"
 msgstr "Показати більше"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -18217,6 +18612,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "Показати бічну панель"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18309,12 +18710,14 @@ msgstr "Показує найпопулярніші посилання у нов
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
+msgstr ""
+"Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
+msgstr ""
+"Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18358,7 +18761,8 @@ msgstr "Показує привітальне повідомлення вгор�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
+msgstr ""
+"Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18580,13 +18984,20 @@ msgstr "Щось пішло не так при збереженні на сер�
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
+msgstr ""
+"Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
 msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr "Щось пішло не так, будь ласка, спробуйте пізніше."
+
+# smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18678,7 +19089,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
+msgstr ""
+"На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -18881,6 +19293,12 @@ msgstr "Почати використовувати місячний ліміт"
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "Почати використовувати тижневий ліміт"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19467,6 +19885,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Переходьте на пошукову систему, яка ніколи не стежить за вами."
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19624,6 +20050,12 @@ msgid "Sync and Backup is temporarily unavailable"
 msgstr "Синхронізація та резервне копіювання тимчасово недоступні"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -19709,6 +20141,22 @@ msgstr "Таджикистан"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Поверніть собі приватність!"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20150,7 +20598,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
+msgstr ""
+"Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20175,10 +20624,22 @@ msgid "This Month"
 msgstr "Цього місяця"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "Цього тижня"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20295,19 +20756,37 @@ msgstr "Це зображення не вдалося створити."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
+msgstr ""
+"Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
+msgstr ""
+"Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
 msgstr "Ця інформація некорисна"
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20355,7 +20834,8 @@ msgstr "Для роботи цієї сторінки необхідний Javas
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
+msgstr ""
+"Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20430,7 +20910,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
+msgstr ""
+"Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20470,7 +20951,8 @@ msgstr "Це зітре усі налаштування. Продовжити?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
+msgstr ""
+"Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -20642,6 +21124,12 @@ msgstr "Сьогодні"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "Сьогодні"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21057,9 +21545,21 @@ msgid "Try Them Out"
 msgstr "Спробуйте їх"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Спробуйте виконати пошук!"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21109,7 +21609,8 @@ msgstr "Спробуйте увімкнути анонімне розташув�
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
+msgstr ""
+"Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21126,6 +21627,12 @@ msgid "Try for free"
 msgstr "Спробуйте безкоштовно"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -21140,6 +21647,12 @@ msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr ""
 "Спробуйте безкоштовно! Безпечний VPN, просунутий приватний ШІ і багато "
 "іншого."
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21166,7 +21679,14 @@ msgstr "Спробуйте наш браузер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
+msgstr ""
+"Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21189,7 +21709,8 @@ msgstr "Спробуйте налаштувати ваше розташуван�
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
+msgstr ""
+"Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -21410,12 +21931,19 @@ msgstr "Вимкнути:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
+msgstr ""
+"Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "Увімкніть Duck Player, щоб дивитися YouTube без адресної реклами"
+
+# smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21635,7 +22163,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
+msgstr ""
+"В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -21645,7 +22174,8 @@ msgstr "В %1$sНалаштуваннях пошуку%2$s оберіть %3$sDu
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
+msgstr ""
+"В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -21665,7 +22195,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
+msgstr ""
+"Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -21787,6 +22318,12 @@ msgid "Unlock advanced AI with your subscription!"
 msgstr "Відкрийте доступ до передових можливостей ШІ з вашою підпискою!"
 
 # smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
@@ -21798,7 +22335,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
+msgstr ""
+"Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22011,7 +22549,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
+msgstr ""
+"Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22146,6 +22685,12 @@ msgstr "Використовуйте в Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Використовуйте в Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22308,7 +22853,8 @@ msgstr "Переглянути ціни на проживання"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
+msgstr ""
+"Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22415,8 +22961,8 @@ msgid ""
 msgstr ""
 "Відвідайте сайт Duck.ai в іншому браузері або в додатку DuckDuckGo та "
 "відкрийте налаштування Duck.ai. Виберіть «Увімкнути» у розділі «Sync & "
-"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте "
-"QR-код у PDF-файлі для відновлення."
+"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте QR-"
+"код у PDF-файлі для відновлення."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22694,7 +23240,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
+msgstr ""
+"Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22759,7 +23306,8 @@ msgstr "Ми ніколи не стежимо за вами."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
+msgstr ""
+"Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -22890,7 +23438,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
+msgstr ""
+"Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23307,7 +23856,8 @@ msgstr "Які страви тут варто скуштувати?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Які години роботи, місцезнаходження та контактна інформація цього місця?"
+msgstr ""
+"Які години роботи, місцезнаходження та контактна інформація цього місця?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23332,6 +23882,12 @@ msgstr "Що вас найбільше роздратувало?"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Що привело вас сюди сьогодні?"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23452,8 +24008,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Що таке збережена в хмарі закладка і чим вона відрізняється від "
-"URL-параметрів?"
+"Що таке збережена в хмарі закладка і чим вона відрізняється від URL-"
+"параметрів?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -23528,7 +24084,8 @@ msgstr "Про що б ви хотіли залишити відгук?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
+msgstr ""
+"Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -23750,6 +24307,14 @@ msgstr "Перемоги"
 msgctxt "Weather IA"
 msgid "Wintry Mix"
 msgstr "Паморозь зі снігом"
+
+# smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24180,6 +24745,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "Передбачено додавання лише %1$s зображення(-нь) на розмову."
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -24309,7 +24881,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
+msgstr ""
+"Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24320,6 +24893,12 @@ msgid ""
 msgstr ""
 "Ви будете отримувати автоматичні оновлення додатка DuckDuckGo після "
 "встановлення останньої версії."
+
+# smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24368,6 +24947,12 @@ msgstr "Ви заблокували %1$s сайти(-ів)"
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "Ви заблокували 1 сайт"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24567,7 +25152,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
+msgstr ""
+"Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -24627,7 +25213,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
+msgstr ""
+"Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -24763,6 +25350,14 @@ msgstr "Твоя роль"
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
 msgstr "Ваші пошукові запити неможливо пов'язати з вашими обліковими даними"
+
+# smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25355,3 +25950,9 @@ msgstr "роки(-ів)"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "рік"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -23,8 +22,7 @@ msgstr "Пошукові ярлики !Bang"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
+msgstr "\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -129,7 +127,7 @@ msgstr "%1$s виявлено"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "Використано файлів: %1$s"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -366,7 +364,7 @@ msgstr "%1$s використано"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s використовує ліміти у 2–5 разів швидше, ніж базові моделі %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -487,8 +485,7 @@ msgstr "%1$sДізнайтеся, як ми зберігаємо приватн�
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
+msgstr "%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -620,7 +617,7 @@ msgstr "1 день тому"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "Використано 1 файл"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -914,8 +911,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
+msgstr "Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1031,9 +1027,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "Наразі можливість ставити подальші запитання штучному інтелекту не "
-"підтримується. Однак ми також пропонуємо і часто посилаємось на %1$sDuck."
-"ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai — це наша "
-"служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic тощо."
+"підтримується. Однак ми також пропонуємо і часто посилаємось на "
+"%1$sDuck.ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai "
+"— це наша служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic "
+"тощо."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1538,6 +1535,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
+"Розширені моделі можуть використовувати ліміти в 2-5 разів швидше, ніж інші "
+"моделі. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1821,8 +1820,7 @@ msgstr "Дозволити анонімний перегляд файлів у �
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
+msgstr "Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2155,8 +2153,7 @@ msgstr "Ти ще тут?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
+msgstr "Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2329,7 +2326,7 @@ msgstr "Запитайте приватно"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "Запитайте приватно"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2367,11 +2364,10 @@ msgstr ""
 "Assist може анонімно генерувати відповіді ШІ на деякі пошукові запити, "
 "узагальнюючи релевантний веб-контент. Можна вибрати частоту відображення "
 "Assist: «Ніколи» (повністю приховує інтерфейс Assist із результатів пошуку), "
-"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки "
-"«Assist» ), «Іноді» (відображаються лише відповіді ШІ в разі високої "
-"релевантності) або «Часто» (відображається частіше у різних пошукових "
-"запитах). Наразі відповіді штучного інтелекту доступні лише в США "
-"(англійською)."
+"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки «Assist» "
+"), «Іноді» (відображаються лише відповіді ШІ в разі високої релевантності) "
+"або «Часто» (відображається частіше у різних пошукових запитах). Наразі "
+"відповіді штучного інтелекту доступні лише в США (англійською)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -3887,7 +3883,7 @@ msgstr "Спілкуйтеся у приватному чаті зі штучн�
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "Спілкуйтеся приватно з популярними ШІ"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -4048,8 +4044,7 @@ msgstr "Перевірте сабреддіт DuckDuckGo, щоб дізнати�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
+msgstr "Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4465,8 +4460,7 @@ msgstr "Оберіть %1$sНалаштування%2$s з меню вибору
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
+msgstr "Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4582,8 +4576,7 @@ msgstr "Натисніть на вкладку %1$sЗагальні%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr ""
-"Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
+msgstr "Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4600,8 +4593,7 @@ msgstr "Натисніть %1$sзначок дозволів%2$s в адресн
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
+msgstr "Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4686,7 +4678,7 @@ msgstr "Закрити"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "Закрити"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4736,7 +4728,7 @@ msgstr "Закрити пошук"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "Закрити другу думку"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -5114,6 +5106,8 @@ msgstr "Продовжити блокування реклами"
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
+"Продовжуйте нещодавні чати тут. Або видаліть їх за допомогою кнопки «Fire "
+"Button»."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5184,7 +5178,7 @@ msgstr "Дані файлів cookie:"
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "Скопійовано"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5237,7 +5231,7 @@ msgstr "Скопіювати код"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "Скопіювати посилання"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5358,7 +5352,7 @@ msgstr "Створити зображення"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "Створити посилання для поширення"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5410,6 +5404,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
+"Створення посилання робить копію чату, яку може переглянути будь-хто, хто "
+"його відкриє."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5568,7 +5564,7 @@ msgstr "Налаштувати відповіді"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "Налаштувати відповіді"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5860,7 +5856,7 @@ msgstr "Видалити дані сервера?"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "Видалити посилання для поширення"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5872,7 +5868,7 @@ msgstr "Видалити транскрипт"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "Видалити чат"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5910,7 +5906,7 @@ msgstr "Видалити зображення?"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "Видалити мене"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -6224,7 +6220,7 @@ msgstr "Відхилити рекламу"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "Відхилити тур"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6440,7 +6436,7 @@ msgstr "Завантажити DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "Завантажити DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6661,7 +6657,7 @@ msgstr "Duck.ai від DuckDuckGo. Приватний чат на бази ШІ.
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai тепер може аналізувати файли PDF. Спробуйте!"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6822,7 +6818,7 @@ msgstr ""
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai підтримує моделі від Anthropic, OpenAI та інших."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6840,8 +6836,7 @@ msgstr "Duck.ai оновлено!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
+msgstr "Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6885,10 +6880,10 @@ msgstr ""
 "У відповідь на деякі пошукові запити DuckAssist іноді анонімно шукає та "
 "узагальнює інформацію. Можна вибрати частоту відображення DuckAssist: "
 "«Ніколи» (повністю приховує інтерфейс DuckAssist із результатів пошуку), «На "
-"вимогу» (відображається лише при натисканні кнопки «Допомога»), "
-"«Іноді» (показується лише в разі високої релевантності) або "
-"«Часто» (відображається частіше у різних пошукових запитах). Наразі "
-"DuckAssist доступний лише у США (англійською)."
+"вимогу» (відображається лише при натисканні кнопки «Допомога»), «Іноді» "
+"(показується лише в разі високої релевантності) або «Часто» (відображається "
+"частіше у різних пошукових запитах). Наразі DuckAssist доступний лише у США "
+"(англійською)."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6948,8 +6943,8 @@ msgstr ""
 "основі штучного інтелекту. Відповіді DuckAssist завжди містять пряме "
 "посилання на одне або два джерела відповіді, тому ви можете швидко знайти "
 "більш детальну інформацію. Важливо пам'ятати, що відповіді автоматично "
-"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих веб-"
-"сторінках%2$s."
+"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих "
+"веб-сторінках%2$s."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7153,8 +7148,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s Duck."
-"ai."
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7162,8 +7157,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
+msgstr "DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7358,8 +7352,7 @@ msgstr "Редагувати запит"
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
-msgstr ""
-"Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr "Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is editing an image.
@@ -7372,8 +7365,7 @@ msgstr "Редагування зображення..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
+msgstr "Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7473,7 +7465,7 @@ msgstr "Увімкнути найвідвідуваніші сайти"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "Увімкнути зараз"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7635,8 +7627,7 @@ msgstr "Користуєтеся Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
+msgstr "Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -7684,15 +7675,13 @@ msgstr "Переконайтеся, що доступ до розташуван�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
+msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
+msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -7789,7 +7778,7 @@ msgstr "Гід з розваг"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "Весь чат"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7892,8 +7881,7 @@ msgstr "Поясніть прийняту відповідь простими с
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
+msgstr "Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -7959,13 +7947,13 @@ msgstr "Відверті тексти"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Познайомтеся з Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "Познайомтеся з Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8072,7 +8060,7 @@ msgstr "Безкоштовно"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "БЕЗКОШТОВНО ТА НЕОБОВ’ЯЗКОВО"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -8235,8 +8223,7 @@ msgstr "Відфільтровує створені ШІ зображення з
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
+msgstr "Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8273,8 +8260,7 @@ msgstr "Фінансовий радник"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
+msgstr "Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8286,8 +8272,7 @@ msgstr "Знайдіть <b>%1$s</b> у папці завантажень"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
+msgstr "Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8496,7 +8481,7 @@ msgstr "Звільнити місце"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "Безкоштовно та завжди конфіденційно"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8754,22 +8739,19 @@ msgstr "Загальне призначення"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення з вбудованою високою модерацією"
+msgstr "Штучний інтелект загального призначення з вбудованою високою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення з вбудованою низькою модерацією"
+msgstr "Штучний інтелект загального призначення з вбудованою низькою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення із вбудованою середньою модерацією"
+msgstr "Штучний інтелект загального призначення із вбудованою середньою модерацією"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -8830,8 +8812,7 @@ msgstr "Згенероване зображення"
 #. Title text shown for an assistant response that contains a generated image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Generated image. Cost %s (internal only)"
-msgstr ""
-"Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr "Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Aria label for the carousel (list of generated images) in the image generation mode.
@@ -9022,7 +9003,7 @@ msgstr "Отримати комп'ютерну допомогу"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "Отримайте вищі ліміти використання з підпискою на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9065,13 +9046,15 @@ msgstr "Отримати останню версію"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "Отримати застосунок"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
+"Завантажуйте безплатний браузер DuckDuckGo %1$sдля блокування реклами на "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9099,7 +9082,7 @@ msgstr "Залучайте ваших друзів та допомагайте �
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "Контрольний список для початку роботи"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -9792,7 +9775,7 @@ msgstr "Приховати підказки"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "Приховати навчання"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -10115,8 +10098,7 @@ msgctxt "Full sentence for preparing for a conversation"
 msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
-msgstr ""
-"Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
+msgstr "Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10985,8 +10967,7 @@ msgstr "Приєднуйтесь до нашої команди!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr ""
-"Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
+msgstr "Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11425,6 +11406,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
+"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11500,7 +11483,7 @@ msgstr "Виграні коридори"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "Термін дії посилання закінчується через 7 днів."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11619,8 +11602,7 @@ msgstr "Завантаження..."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more image and video results when scrolling"
-msgstr ""
-"Завантаження інших результатів для зображень та відео при прокручуванні"
+msgstr "Завантаження інших результатів для зображень та відео при прокручуванні"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -12609,7 +12591,7 @@ msgstr "Понад 20 хвилин"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "Більше порад"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -13102,7 +13084,7 @@ msgstr "Ні, дякую"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "Ні, дякую"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13770,7 +13752,7 @@ msgstr "Увімкнено без номерів"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "Реєстрацію завершено"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13884,8 +13866,7 @@ msgstr "Відкрити вебсайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
+msgstr "Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -13989,7 +13970,7 @@ msgstr "Відкрити пропозиції щодо створення та �
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "Відкрити контрольний список для початку роботи"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -14054,8 +14035,7 @@ msgstr "Відкрити панель «Як працює Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
+msgstr "Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14434,8 +14414,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу IP-"
-"адресу, відбиток браузера чи інші дані з файлом."
+"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу "
+"IP-адресу, відбиток браузера чи інші дані з файлом."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14743,7 +14723,7 @@ msgstr "Закріплене"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "Закріпити чат"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14755,7 +14735,7 @@ msgstr "Закріпити чати тут із %1$s %2$s"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "Закріпи мене"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14778,7 +14758,7 @@ msgstr "Закріплено"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "Закріплені чати з'являтимуться на початку ваших останніх чатів."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14819,8 +14799,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
+msgstr "Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -14828,8 +14807,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
+msgstr "Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -14843,8 +14821,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
+msgstr "Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15104,6 +15081,8 @@ msgstr "Погане форматування"
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
+"Доступні популярні моделі ШІ. Обліковий запис не потрібен. Чати, які ми "
+"зробили анонімними."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15317,7 +15296,7 @@ msgstr "Попередні вкладки"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "Попередні поради"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15863,13 +15842,15 @@ msgstr "Міркуючий ШІ з вбудованою модерацією с�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "Обґрунтування може надавати кращі відповіді на складні запитання."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
+"Обґрунтування є більш ретельним, але використовує ліміти у 2–5 разів швидше. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15910,7 +15891,7 @@ msgstr "Налаштування сховища останніх чатів мо
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "Останні чати"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -16070,7 +16051,7 @@ msgstr "Зменшити використання"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "Зменште використання завдяки ефективнішій моделі"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16231,8 +16212,7 @@ msgstr "Запам'ятати вибір"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
+msgstr "Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -16452,7 +16432,7 @@ msgstr "Скинути всі налаштування"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "Скинути навчання"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16470,7 +16450,7 @@ msgstr "Розширення"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "Відповідь"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -17151,8 +17131,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
+msgstr "Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17180,7 +17159,7 @@ msgstr "Шукати «%1$s», щоб знайти результати побл
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "Перемикач «Пошук та Duck.ai»"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -17498,8 +17477,7 @@ msgstr "Друга думка"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
+msgstr "Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17566,7 +17544,7 @@ msgstr ""
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "Безпечно зберігається на нашому зашифрованому сервері."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17717,21 +17695,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
+msgstr "Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
+msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
+msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -17942,8 +17917,7 @@ msgstr "Вибраний текст із %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
+msgstr "Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18089,7 +18063,7 @@ msgstr "Встановити як домашню сторінку"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "Встанови тон і стиль відповідей Duck.ai."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -18162,13 +18136,13 @@ msgstr "Сейшельські острови"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "Поділитися"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "Поділитися"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -18179,8 +18153,7 @@ msgstr "Поділитися"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
+msgstr "Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18216,7 +18189,7 @@ msgstr ""
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "Поділитися чатом"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -18280,7 +18253,7 @@ msgstr "Надіслати позитивний відгук"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "Обсяг поширення"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18421,7 +18394,7 @@ msgstr "Показати подробиці"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "Показати навчальний посібник Duck.ai"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18576,7 +18549,7 @@ msgstr "Показати більше"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "Показати більше моделей"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18617,7 +18590,7 @@ msgstr "Показати бічну панель"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "Показувати покрокові поради, щоб отримати максимум від Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18710,14 +18683,12 @@ msgstr "Показує найпопулярніші посилання у нов
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
+msgstr "Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
+msgstr "Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18761,8 +18732,7 @@ msgstr "Показує привітальне повідомлення вгор�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
+msgstr "Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -18984,8 +18954,7 @@ msgstr "Щось пішло не так при збереженні на сер�
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
+msgstr "Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -18997,7 +18966,7 @@ msgstr "Щось пішло не так, будь ласка, спробуйте
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Сталася помилка. Повторіть спробу."
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -19089,8 +19058,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
+msgstr "На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19298,7 +19266,7 @@ msgstr "Почати використовувати тижневий ліміт"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "Почати новий чат"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19890,7 +19858,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "Перейти до цієї другої думки"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -20053,7 +20021,7 @@ msgstr "Синхронізація та резервне копіювання т
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "Синхронізувати чати на пристроях"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -20149,6 +20117,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
+"Беріть Duck.ai з собою всюди. Вбудуйте його в наш безкоштовний додаток для "
+"швидшого доступу, де б ви не були."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20157,6 +20127,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
+"Беріть Duck.ai з собою всюди. Вбудуйте його в наш безкоштовний браузер для "
+"швидшого доступу, де б ви не переглядали веб-сторінки."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20598,8 +20570,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
+msgstr "Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20627,7 +20598,7 @@ msgstr "Цього місяця"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "Ця відповідь"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20639,7 +20610,7 @@ msgstr "Цього тижня"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "Цей чат залишається в Duck.ai і є приватним для вас."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20756,16 +20727,14 @@ msgstr "Це зображення не вдалося створити."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
+msgstr "Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
+msgstr "Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -20779,6 +20748,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
+"Це лише зразок чату. Відкрийте його меню (три крапки), а потім виберіть "
+"«Закріпити», щоб розмістити його у верхній частині ваших чатів!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20787,6 +20758,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
+"Це лише зразок чату. Його можна видалити за допомогою кнопки «Fire Button» у "
+"бічному меню!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20834,8 +20807,7 @@ msgstr "Для роботи цієї сторінки необхідний Javas
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
+msgstr "Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -20910,8 +20882,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
+msgstr "Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -20951,8 +20922,7 @@ msgstr "Це зітре усі налаштування. Продовжити?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
+msgstr "Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21130,6 +21100,8 @@ msgstr "Сьогодні"
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
+"Перемикніть, щоб спробувати приватний чат зі ШІ, або %1$sвимкніть його в "
+"%2$sменю.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21548,7 +21520,7 @@ msgstr "Спробуйте їх"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "Спробуйте іншу модель"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21559,7 +21531,7 @@ msgstr "Спробуйте виконати пошук!"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "Спробуйте пропозицію"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21609,8 +21581,7 @@ msgstr "Спробуйте увімкнути анонімне розташув�
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
+msgstr "Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -21630,7 +21601,7 @@ msgstr "Спробуйте безкоштовно"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "Спробуйте безкоштовно"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21652,7 +21623,7 @@ msgstr ""
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "Спробуйте безкоштовно протягом 7 днів"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21679,14 +21650,13 @@ msgstr "Спробуйте наш браузер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
+msgstr "Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "Спробуйте обґрунтування"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21709,8 +21679,7 @@ msgstr "Спробуйте налаштувати ваше розташуван�
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
+msgstr "Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -21931,8 +21900,7 @@ msgstr "Вимкнути:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
+msgstr "Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -21943,7 +21911,7 @@ msgstr "Увімкніть Duck Player, щоб дивитися YouTube без �
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "Увімкніть перемикач Duck.ai"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -22163,8 +22131,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
+msgstr "В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22174,8 +22141,7 @@ msgstr "В %1$sНалаштуваннях пошуку%2$s оберіть %3$sDu
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
+msgstr "В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22195,8 +22161,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
+msgstr "Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -22321,7 +22286,7 @@ msgstr "Відкрийте доступ до передових можливос
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "Розблокуйте розширені моделі"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22335,8 +22300,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
+msgstr "Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to unmute the microphone.
@@ -22549,8 +22513,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
+msgstr "Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -22690,7 +22653,7 @@ msgstr "Використовуйте в Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "Використовуйте кнопку «Fire Button», щоб видалити чат з історії."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22853,8 +22816,7 @@ msgstr "Переглянути ціни на проживання"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
+msgstr "Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -22961,8 +22923,8 @@ msgid ""
 msgstr ""
 "Відвідайте сайт Duck.ai в іншому браузері або в додатку DuckDuckGo та "
 "відкрийте налаштування Duck.ai. Виберіть «Увімкнути» у розділі «Sync & "
-"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте QR-"
-"код у PDF-файлі для відновлення."
+"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте "
+"QR-код у PDF-файлі для відновлення."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23240,8 +23202,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
+msgstr "Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23306,8 +23267,7 @@ msgstr "Ми ніколи не стежимо за вами."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
+msgstr "Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23438,8 +23398,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
+msgstr "Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23856,8 +23815,7 @@ msgstr "Які страви тут варто скуштувати?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Які години роботи, місцезнаходження та контактна інформація цього місця?"
+msgstr "Які години роботи, місцезнаходження та контактна інформація цього місця?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -23887,7 +23845,7 @@ msgstr "Що привело вас сюди сьогодні?"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "Що ти вмієш?"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -24008,8 +23966,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Що таке збережена в хмарі закладка і чим вона відрізняється від URL-"
-"параметрів?"
+"Що таке збережена в хмарі закладка і чим вона відрізняється від "
+"URL-параметрів?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24084,8 +24042,7 @@ msgstr "Про що б ви хотіли залишити відгук?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
+msgstr "Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24315,6 +24272,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
+"З Duck.ai ваші чати є анонімними і ніколи не використовуються для навчання "
+"ШІ. Увімкніть або вимкніть його будь-коли в меню «%1$s»."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24749,7 +24708,7 @@ msgstr "Передбачено додавання лише %1$s зображен
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "За раз можна додати лише %1$s вкладки(-ок)."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24881,8 +24840,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
+msgstr "Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -24898,7 +24856,7 @@ msgstr ""
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "Усе готово!"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24952,7 +24910,7 @@ msgstr "Ви заблокували 1 сайт"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "Ви опанували основи Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -25152,8 +25110,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
+msgstr "Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -25213,8 +25170,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
+msgstr "Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25358,6 +25314,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
+"Ваші налаштування збережено, але видалення файлів cookie призведе до їх "
+"скидання. Увімкніть розширення %1$sDuckDuckGo No AI%2$s, щоб зробити його "
+"постійним."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25955,4 +25914,4 @@ msgstr "рік"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/ur_PK/LC_MESSAGES/duckduckgo.po
+++ b/locales/ur_PK/LC_MESSAGES/duckduckgo.po
@@ -109,6 +109,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr ""
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -290,6 +295,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -482,6 +492,11 @@ msgstr ""
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
 msgid "1 day ago"
+msgstr ""
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
 msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1222,6 +1237,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1845,6 +1867,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3079,6 +3106,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3675,6 +3707,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3710,6 +3747,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4017,6 +4059,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4071,6 +4118,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr ""
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4108,6 +4160,11 @@ msgstr ""
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4204,6 +4261,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4238,6 +4300,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4363,6 +4432,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4599,9 +4673,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4629,6 +4713,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4882,6 +4971,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5048,6 +5142,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5223,6 +5322,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5330,6 +5434,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5818,6 +5927,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6057,6 +6171,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6190,6 +6309,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6271,6 +6400,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6602,6 +6736,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7023,6 +7162,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7052,6 +7196,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7068,6 +7222,11 @@ msgstr "اس گانے کو حاصل کری"
 
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
+msgstr ""
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
 msgstr ""
 
 msgid "Ghana"
@@ -7619,6 +7778,11 @@ msgstr ""
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8922,6 +9086,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr ""
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -8977,6 +9147,11 @@ msgstr ""
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9873,6 +10048,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr ""
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #  Marked fuzzy because of translated trademark
 #. e.g. More ways to add DuckDuckGo to Firefox
 #, fuzzy
@@ -10269,6 +10449,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10817,6 +11002,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "شروع لیکن کوئی تعداد"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -10985,6 +11175,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11581,9 +11776,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11598,6 +11803,11 @@ msgstr ""
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11854,6 +12064,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12023,6 +12238,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12465,6 +12685,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12492,6 +12722,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12614,6 +12849,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12916,6 +13156,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "تمام ترتیبات کو دوبارہ ترتیب دیں"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12924,6 +13169,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13481,6 +13731,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr ""
 
@@ -13763,6 +14018,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14160,6 +14420,11 @@ msgstr "پہلے سے طے شدہ تلاش انجن کے طور پر مقرر"
 msgid "Set as Homepage"
 msgstr "مرکزی صفحہ کےطور پر مقرر کریں"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14212,6 +14477,16 @@ msgstr ""
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14241,6 +14516,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14289,6 +14570,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14400,6 +14686,11 @@ msgstr "دکھائیں پڑھیں اور ترتیبات ڈیٹا"
 #. Button that shows more details.
 msgctxt "mobile expanded map"
 msgid "Show Detail"
+msgstr ""
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
 msgstr ""
 
 msgctxt "settings"
@@ -14524,6 +14815,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14552,6 +14848,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14850,6 +15151,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15082,6 +15388,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15560,6 +15871,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr ""
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15672,6 +15990,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15741,6 +16064,20 @@ msgstr ""
 
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
 msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
@@ -16110,9 +16447,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16213,6 +16560,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16469,6 +16830,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16806,9 +17172,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr " تلاش کوشش کرو!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16862,6 +17238,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16872,6 +17253,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16894,6 +17280,11 @@ msgstr ""
 
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
+msgstr ""
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
 msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
@@ -17094,6 +17485,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17378,6 +17774,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17674,6 +18075,11 @@ msgstr ""
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "سفاری میں استعمال کرتے ہیں"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18586,6 +18992,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr ""
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -18925,6 +19336,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19271,6 +19689,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19379,6 +19803,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19413,6 +19842,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19712,6 +20146,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20184,6 +20625,11 @@ msgstr ""
 #. An abbreviated form of "year" that can be displayed in a small space e.g. "1yr"
 msgctxt "published date for videos"
 msgid "yr"
+msgstr ""
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
 msgstr ""
 
 #~ msgid "Develop"

--- a/locales/vi_VN/LC_MESSAGES/duckduckgo.po
+++ b/locales/vi_VN/LC_MESSAGES/duckduckgo.po
@@ -110,6 +110,11 @@ msgctxt "translations_module"
 msgid "%s detected"
 msgstr "%s được phát hiện"
 
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -291,6 +296,11 @@ msgstr ""
 #. Usage amount shown in the Usage section of Duck.ai settings. %s is the formatted percentage used, including the percent sign, e.g., '76%'.
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
+msgstr ""
+
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
 
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -485,6 +495,11 @@ msgstr ""
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 ngày trước"
+
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
 msgctxt "published dates for organic results"
@@ -1226,6 +1241,13 @@ msgctxt ""
 msgid "Advanced Models"
 msgstr ""
 
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr ""
@@ -1851,6 +1873,11 @@ msgstr ""
 
 #. Placeholder text used in chat input for user’s messages.
 msgctxt "Placeholder text user’s chat input"
+msgid "Ask privately"
+msgstr ""
+
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
 msgid "Ask privately"
 msgstr ""
 
@@ -3099,6 +3126,11 @@ msgctxt "Tooltip text in duckbar tab"
 msgid "Chat privately with AI"
 msgstr ""
 
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3707,6 +3739,11 @@ msgstr "Clip nghệ thuật"
 msgid "Close"
 msgstr ""
 
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -3742,6 +3779,11 @@ msgstr ""
 msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
+msgstr ""
+
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
 msgstr ""
 
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4049,6 +4091,11 @@ msgstr ""
 msgid "Continue Blocking Ads"
 msgstr ""
 
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4103,6 +4150,11 @@ msgctxt "settings"
 msgid "Cookie data:"
 msgstr "Dữ liệu cookie:"
 
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4140,6 +4192,11 @@ msgstr "Sao chép &amp; dán %sabout:preferences#search%s vào thanh địa ch�
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
+msgstr ""
+
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
 msgstr ""
 
 #. Label for the copy button on the Scan QR tab.
@@ -4236,6 +4293,11 @@ msgctxt "Promotional CTA for new image generation mode"
 msgid "Create Image"
 msgstr ""
 
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -4270,6 +4332,13 @@ msgstr ""
 #. Text that indicates the creator of an AI Model, such as 'Created by OpenAI'.
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
+msgstr ""
+
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
 msgstr ""
 
 #. Label below a video that's available under the Creative Commons license.
@@ -4395,6 +4464,11 @@ msgstr ""
 
 #. Label for the button that opens a modal that allows users to customize the AI assistant conversation context, e.g. tone and length of responses, the role and name of AI assistant, etc.
 msgctxt "Label for customizing Duck.ai"
+msgid "Customize responses"
+msgstr ""
+
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
 msgstr ""
 
@@ -4631,9 +4705,19 @@ msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Delete Server Data?"
 msgstr ""
 
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
+msgstr ""
+
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
 msgstr ""
 
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -4661,6 +4745,11 @@ msgstr ""
 #. Modal title asking users to confirm deletion of a generated image.
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
 msgstr ""
 
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -4914,6 +5003,11 @@ msgctxt "Sidemenu subscription promo"
 msgid "Dismiss promotion"
 msgstr ""
 
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -5080,6 +5174,11 @@ msgstr ""
 
 #. Text of a button that will install the DuckDuckGo browser when clicked
 msgctxt "Browser Promo Popover"
+msgid "Download DuckDuckGo"
+msgstr ""
+
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
 msgstr ""
 
@@ -5255,6 +5354,11 @@ msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr ""
 
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
@@ -5362,6 +5466,11 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
 msgstr ""
 
 #. Title shown when native app needs to reload for service update.
@@ -5861,6 +5970,11 @@ msgctxt "new tab page"
 msgid "Enable Most-Visited Sites"
 msgstr ""
 
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -6105,6 +6219,11 @@ msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr ""
 
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
+
 msgid "Equatorial Guinea"
 msgstr ""
 
@@ -6238,6 +6357,16 @@ msgctxt "Feedback prompt"
 msgid "Explicit lyrics"
 msgstr ""
 
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -6319,6 +6448,11 @@ msgstr ""
 #. Text for the badge displayed to indicate that the user does not have a subscription to DuckDuckGo. Free here refers to price (as in free of charge).
 msgctxt "Text for the free badge"
 msgid "FREE"
+msgstr ""
+
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
 msgstr ""
 
 #. Full-time (match has ended) indicator in a soccer match
@@ -6649,6 +6783,11 @@ msgstr ""
 #. Opens the file storage limit modal so the user can delete older chats.
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
+msgstr ""
+
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
 msgstr ""
 
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -7070,6 +7209,11 @@ msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr ""
 
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
+
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
@@ -7099,6 +7243,16 @@ msgctxt "Update browser banner"
 msgid "Get the Latest Version"
 msgstr ""
 
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -7116,6 +7270,11 @@ msgstr "Tìm bài hát này trên:"
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "Thuyết phục bạn bè thay đổi và giúp chúng tôi phát triển!"
+
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 msgid "Ghana"
 msgstr ""
@@ -7666,6 +7825,11 @@ msgstr "Ẩn bước đi"
 #. Button text that allows the user to hide promotional tips displayed in the screen.
 msgctxt "Button to hide promotional tips"
 msgid "Hide Tips"
+msgstr ""
+
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
 msgstr ""
 
 #. Label for the button to enable the site exclusion feature
@@ -8981,6 +9145,12 @@ msgctxt "welcome message"
 msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "Cho phép bạn tìm kiếm ẩn danh với DuckDuckGo"
 
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
 msgid "Liberia"
 msgstr ""
 
@@ -9036,6 +9206,11 @@ msgstr "Tranh vẽ nét"
 #. Rugby match stats
 msgctxt "Sports module"
 msgid "Lineouts Won"
+msgstr ""
+
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -9932,6 +10107,11 @@ msgctxt "video-duration"
 msgid "More than 20 minutes"
 msgstr "Dài hơn 20 phút"
 
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -10326,6 +10506,11 @@ msgstr ""
 
 #. Button to decline web search for the current conversation, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat web search permission prompt for encrypted models"
+msgid "No Thanks"
+msgstr ""
+
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
 msgid "No Thanks"
 msgstr ""
 
@@ -10876,6 +11061,11 @@ msgctxt "setting"
 msgid "On but no numbers"
 msgstr "Bật nhưng không có số"
 
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
+
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
 msgctxt "voice chat"
 msgid "One moment please..."
@@ -11047,6 +11237,11 @@ msgstr ""
 #. Accessible name for the pill tab that opens the panel listing suggested image-generation prompts.
 msgctxt "Aria label for the create and edit images pill tab"
 msgid "Open create and edit images suggestions"
+msgstr ""
+
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
 msgstr ""
 
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -11653,9 +11848,19 @@ msgctxt "Button for pinning a chat"
 msgid "Pin"
 msgstr ""
 
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
+msgstr ""
+
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
 msgstr ""
 
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -11670,6 +11875,11 @@ msgstr "Hồng"
 #. Title for the pinned chats section. In this section, users can pin chats that are not deleted when clearing all chats. The section is shown above the recent chats section.
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
+msgstr ""
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
 msgstr ""
 
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11926,6 +12136,11 @@ msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr ""
 
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -12095,6 +12310,11 @@ msgstr ""
 #. Accessibility label for the button that scrolls the rich caption tab row left to reveal earlier tabs.
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
+msgstr ""
+
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
 msgstr ""
 
 #. Label that's displayed next to a price below a web search result.
@@ -12537,6 +12757,16 @@ msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
 msgstr ""
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -12564,6 +12794,11 @@ msgstr ""
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
+msgstr ""
+
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
 msgstr ""
 
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -12686,6 +12921,11 @@ msgstr ""
 #. Button text in the Duck.ai usage limit banner that opens a menu of lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
+msgstr ""
+
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
 msgstr ""
 
 msgctxt "settings"
@@ -12988,6 +13228,11 @@ msgctxt "settings"
 msgid "Reset All Settings"
 msgstr "Thiết lập lại các cài đặt"
 
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -12996,6 +13241,11 @@ msgstr ""
 #. List item indicating that a layout filter (e.g. tall) is currently active for the search
 msgctxt "noresults"
 msgid "Resolution"
+msgstr ""
+
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
 msgstr ""
 
 #. Feedback option when AI response is helpful
@@ -13557,6 +13807,11 @@ msgstr ""
 msgid "Search %s to find results closer to you?"
 msgstr ""
 
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
 msgid "Search Anonymously"
 msgstr "Tìm kiếm ẩn danh"
 
@@ -13842,6 +14097,11 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
+msgstr ""
+
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
 msgstr ""
 
 msgctxt "Feedback prompt"
@@ -14245,6 +14505,11 @@ msgstr "Cài làm công cụ tìm kiếm mặc định"
 msgid "Set as Homepage"
 msgstr "Đặt làm trang chủ"
 
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -14297,6 +14562,16 @@ msgstr "Đã cập nhật cài đặt"
 msgid "Seychelles"
 msgstr ""
 
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -14327,6 +14602,12 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
+msgstr ""
+
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
 msgstr ""
 
 #. Menu option to share feedback about a result
@@ -14375,6 +14656,11 @@ msgstr ""
 
 msgctxt "feedback form"
 msgid "Share positive feedback"
+msgstr ""
+
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
 msgstr ""
 
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -14487,6 +14773,11 @@ msgstr "Hiển thị đánh dấu và dữ liệu cài đặt"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "Hiện chi tiết"
+
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 msgctxt "settings"
 msgid "Show DuckAssist <sup>BETA</sup>"
@@ -14610,6 +14901,11 @@ msgctxt "Expands content in a message"
 msgid "Show more"
 msgstr ""
 
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -14638,6 +14934,11 @@ msgctxt ""
 "Tooltip label for the desktop sidebar collapse button, when the sidebar is "
 "collapsed"
 msgid "Show sidebar"
+msgstr ""
+
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
 
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -14936,6 +15237,11 @@ msgctxt "voice chat error"
 msgid "Something went wrong, please try again later."
 msgstr ""
 
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -15168,6 +15474,11 @@ msgstr ""
 #. Button label shown with a daily Duck.ai usage limit error. Clicking it opts in to continue chatting against the weekly limit.
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
+msgstr ""
+
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
 msgstr ""
 
 #. A prompt to start a new web search.
@@ -15651,6 +15962,13 @@ msgstr ""
 msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "Chuyển sang công cụ tìm kiếm không theo dõi bạn. Không bao giờ."
 
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -15763,6 +16081,11 @@ msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr ""
 
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
+
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
 msgctxt "Title for the generic pairing-failure error screen"
 msgid "Sync failed."
@@ -15833,6 +16156,20 @@ msgstr ""
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "Giành lại quyền riêng tư của bạn!"
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 #. Primary button/link text to open the user survey (desktop only)
 msgctxt "User survey popup"
@@ -16209,9 +16546,19 @@ msgctxt "Duck.ai settings usage section"
 msgid "This Month"
 msgstr ""
 
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
+msgstr ""
+
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
 msgstr ""
 
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -16312,6 +16659,20 @@ msgstr ""
 
 #. Given as an option to select when providing feedback
 msgid "This information isn’t useful"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
 msgstr ""
 
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -16570,6 +16931,11 @@ msgstr ""
 #. Label for the section of recent chats that were edited today.
 msgctxt "Title for the period of chats from today"
 msgid "Today"
+msgstr ""
+
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
 
 msgid "Togo"
@@ -16907,9 +17273,19 @@ msgctxt "Promotional CTA for advanced AI models for subscribed Duck.ai users"
 msgid "Try Them Out"
 msgstr ""
 
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "Hãy thử tìm kiếm!"
+
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 #. Message prompting users to add more information to their search term.
 msgctxt "directions"
@@ -16963,6 +17339,11 @@ msgctxt ""
 msgid "Try for free"
 msgstr ""
 
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -16973,6 +17354,11 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
+msgstr ""
+
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
 msgstr ""
 
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -16998,6 +17384,11 @@ msgid "Try our homepage that never shows these messages:"
 msgstr ""
 "Hãy thử trang chủ của chúng tôi, không bao giờ xuất hiện những thông điệp "
 "này đâu:"
+
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 #. A prompt asking users to try searching with different words to get more results.
 msgctxt "noresults"
@@ -17197,6 +17588,11 @@ msgstr ""
 
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
+msgstr ""
+
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
 msgstr ""
 
 #. Tells users which setting to change to enable location service.
@@ -17485,6 +17881,11 @@ msgstr ""
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
+msgstr ""
+
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
 msgstr ""
 
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -17781,6 +18182,11 @@ msgstr "Sử dụng trên Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "Sử dụng trên Safari"
+
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
 msgctxt "Description for the joiner-device success screen"
@@ -18709,6 +19115,11 @@ msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "Điều gì đã khiến bạn quay lại?"
 
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
+
 #. Question on a feedback form.
 msgctxt "feedback form"
 msgid "What could be better?"
@@ -19050,6 +19461,13 @@ msgstr ""
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
 msgctxt "Weather IA"
 msgid "Wintry Mix"
+msgstr ""
+
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
 msgstr ""
 
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -19398,6 +19816,12 @@ msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr ""
 
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -19507,6 +19931,11 @@ msgid ""
 "version."
 msgstr ""
 
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
@@ -19543,6 +19972,11 @@ msgstr ""
 #. Label for a single site being blocked
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
+msgstr ""
+
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
 msgstr ""
 
 #. Title shown when a user has reached their image generation limit.
@@ -19850,6 +20284,13 @@ msgstr ""
 
 #. An item in the ads tooltip that explains that your searches can’t be tied back to you.
 msgid "Your searches can’t be tied back to you"
+msgstr ""
+
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20324,6 +20765,11 @@ msgstr ""
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "năm"
+
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""
 
 #~ msgctxt "SERP footer content"
 #~ msgid "%s Billion Searches"

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr "检测到 %1$s"
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -175,7 +181,9 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
+msgstr ""
+"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
+"者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -184,7 +192,9 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
+msgstr ""
+"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
+"者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -199,7 +209,9 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，或切换到免费模式。"
+msgstr ""
+"%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，"
+"或切换到免费模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -297,7 +309,9 @@ msgid ""
 "%s runs in a Trusted Execution Environment. This means not even the model "
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
-msgstr "%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的响应，也不会在其服务器上保存此聊天记录。"
+msgstr ""
+"%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的"
+"响应，也不会在其服务器上保存此聊天记录。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -339,6 +353,12 @@ msgstr "已阻止 %1$s 次跟踪尝试"
 msgctxt "Duck.ai settings usage section"
 msgid "%s used"
 msgstr "已使用 %1$s"
+
+# smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -405,7 +425,8 @@ msgstr "%1$s点击%2$s添加%3$s勾选%4$s允许%5$s，然后点击%6$s确定%7$
 #. Instructions on what buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr ""
+"%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -414,7 +435,9 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr "%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr ""
+"%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确"
+"定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -572,6 +595,12 @@ msgstr "过去 24 小时内被 DuckDuckGo 阻止了 1 次企图"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1 天前"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -852,7 +881,8 @@ msgstr "客场"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
+msgstr ""
+"网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -910,8 +940,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 DuckDuckGo Search 中的 AI Chat "
-"功能。关闭此设置后，仍可以通过访问 %1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
+"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 "
+"DuckDuckGo Search 中的 AI Chat 功能。关闭此设置后，仍可以通过访问 "
+"%1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -972,8 +1003,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s "
-"并通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 OpenAI 和 Anthropic 等公司的聊天模型。"
+"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s 并"
+"通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 "
+"OpenAI 和 Anthropic 等公司的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1464,6 +1496,14 @@ msgid "Advanced Models"
 msgstr "高级模型"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "在搜索时投放广告"
@@ -1638,7 +1678,9 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr "DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用你的对话来训练聊天模型"
+msgstr ""
+"DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用"
+"你的对话来训练聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1747,8 +1789,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给数据留存期有限的搜索引擎。%2$s "
-"的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
+"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给"
+"数据留存期有限的搜索引擎。%2$s 的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1913,7 +1955,8 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
+msgstr ""
+"根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2123,7 +2166,9 @@ msgstr "截至"
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保护隐私。"
+msgstr ""
+"根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保"
+"护隐私。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2221,6 +2266,12 @@ msgid "Ask privately"
 msgstr "以私密方式提问"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2253,9 +2304,11 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可以选择显示 Assist 的频率：从不（从搜索结果中完全移除 "
-"Assist "
-"用户界面)、按需（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案目前仅供美国（英语）地区使用。"
+"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可"
+"以选择显示 Assist 的频率：从不（从搜索结果中完全移除 Assist 用户界面)、按需"
+"（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人"
+"工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案"
+"目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2267,8 +2320,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist "
-"是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"Assist 是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答"
+"案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，"
+"根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并"
+"通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2430,7 +2485,9 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。Assist 目前仅供英语地区使用。"
+msgstr ""
+"为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。"
+"Assist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2438,7 +2495,9 @@ msgid ""
 "Automatically shows DuckAssist for relevant searches. DuckAssist can "
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
-msgstr "为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。DuckAssist 目前仅供英语地区使用。"
+msgstr ""
+"为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些"
+"搜索。DuckAssist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2643,7 +2702,9 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr "在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身份信息，对你的对话进行匿名化处理。"
+msgstr ""
+"在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身"
+"份信息，对你的对话进行匿名化处理。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3023,20 +3084,26 @@ msgstr "浏览文件"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，"
+"还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏"
+"蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即可匿名搜索、屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即"
+"可匿名搜索、屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3143,15 +3210,18 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 Cloud Save "
-"功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令也只有浏览器知道。"
+"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 "
+"Cloud Save 功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令"
+"也只有浏览器知道。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
+msgstr ""
+"启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用"
+"之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3159,7 +3229,9 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
+msgstr ""
+"启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始"
+"使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3643,9 +3715,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿名对话，该功能支持 OpenAI、Anthropic "
-"等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
-"%1$shttps://duck.ai%2$s 来使用聊天功能。 "
+"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿"
+"名对话，该功能支持 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
+"DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过"
+"访问 %1$shttps://duck.ai%2$s 来使用聊天功能。 "
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3722,6 +3795,12 @@ msgid "Chat privately with AI"
 msgstr "与人工智能私聊"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3769,7 +3848,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历史记录会删除已置顶的聊天记录。"
+msgstr ""
+"聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历"
+"史记录会删除已置顶的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3781,8 +3862,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
-"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
+"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删"
+"除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3804,7 +3886,9 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr "与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
+msgstr ""
+"与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审"
+"核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4155,7 +4239,9 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr "清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者在超过 7 天未使用 AI Chat 后自动将其删除。"
+msgstr ""
+"清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者"
+"在超过 7 天未使用 AI Chat 后自动将其删除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4164,7 +4250,9 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr "清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
+msgstr ""
+"清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近"
+"期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4181,8 +4269,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密人工智能聊天服务支持 OpenAI、Anthropic "
-"等聊天模型。"
+"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密"
+"人工智能聊天服务支持 OpenAI、Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4223,7 +4311,9 @@ msgstr "在弹出的菜单中点击 %1$s更改搜索设置%2$s"
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选项%4$s"
+msgstr ""
+"Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选"
+"项%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4253,7 +4343,9 @@ msgstr "在左侧的列表中点击 %1$s隐私和服务%2$s。"
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图标%4$s）"
+msgstr ""
+"在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图"
+"标%4$s）"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4343,7 +4435,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
+msgstr ""
+"点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻"
+"触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4353,7 +4447,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
+msgstr ""
+"点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设"
+"置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4421,7 +4517,9 @@ msgstr "点击搜索栏中的下拉菜单"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 "
+"%3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4471,6 +4569,12 @@ msgid "Close"
 msgstr "关闭"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4513,6 +4617,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "关闭搜索"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4884,6 +4994,12 @@ msgid "Continue Blocking Ads"
 msgstr "继续屏蔽广告"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4949,6 +5065,12 @@ msgid "Cookie data:"
 msgstr "Cookie 数据："
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -4994,6 +5116,12 @@ msgstr "将 %1$sabout:preferences#search%2$s 复制并粘贴到地址栏中"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "复制代码"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5109,6 +5237,12 @@ msgid "Create Image"
 msgstr "创建图像"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5150,6 +5284,14 @@ msgstr "创作者："
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "由 %1$s 创建"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5303,6 +5445,12 @@ msgstr "自定义回复"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "自定义回复"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5587,10 +5735,22 @@ msgid "Delete Server Data?"
 msgstr "删除服务器数据？"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "删除记录"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5623,6 +5783,12 @@ msgstr "删除图片"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "删除图像？"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5765,7 +5931,8 @@ msgstr "暂时无法使用听写功能"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
+msgstr ""
+"听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -5929,6 +6096,12 @@ msgid "Dismiss promotion"
 msgstr "关闭促销信息"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6070,7 +6243,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr "不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 AI 生成的图像。 %3$s了解详情%4$s"
+msgstr ""
+"不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 "
+"AI 生成的图像。 %3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6079,8 +6254,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤掉 AI "
-"生成的图像。%3$s了解详情%4$s"
+"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤"
+"掉 AI 生成的图像。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6135,6 +6310,12 @@ msgstr "下载完成"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "下载 DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6344,13 +6525,21 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai 是由 DuckDuckGo 提供的免费人工智能私聊工具。"
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr "Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非你选择在设置中自动附加页面。"
+msgstr ""
+"Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非"
+"你选择在设置中自动附加页面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6359,7 +6548,9 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程序再试一次。"
+msgstr ""
+"Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程"
+"序再试一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6382,7 +6573,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何希望重新掌控自己个人信息的人。"
+msgstr ""
+"Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何"
+"希望重新掌控自己个人信息的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6396,7 +6589,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页：https://duck.ai"
+msgstr ""
+"Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页："
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6410,7 +6605,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
+msgstr ""
+"暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6430,7 +6627,9 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr "Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
+msgstr ""
+"Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链"
+"接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6441,9 +6640,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
-"DuckDuckGo Search 中的 Duck.ai 按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
-"%1$shttps://duck.ai%2$s 来使用 Duck.ai。"
+"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、"
+"Anthropic 等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 中的 Duck.ai 按钮"
+"和链接。不过，即使关闭该设置，仍然可以直接通过访问 %1$shttps://duck.ai%2$s 来"
+"使用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6473,6 +6673,12 @@ msgid ""
 msgstr "Duck.ai 的回复并非基于特定资料来源，也未核实其准确性。"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6498,8 +6704,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需注册的 AI "
-"聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 AI、无需账户的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需"
+"注册的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 "
+"AI、无需账户的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6527,10 +6734,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示频率：从不（从搜索结果中完全移除 "
-"DuckAssist "
-"用户界面)、按需（仅在点击“协助”按钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显示）。DuckAssist "
-"目前仅供美国（英语）地区使用。"
+"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示"
+"频率：从不（从搜索结果中完全移除 DuckAssist 用户界面)、按需（仅在点击“协助”按"
+"钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显"
+"示）。DuckAssist 目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6539,8 +6746,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI "
-"Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI Chat%2$s，这"
+"是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天"
+"模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6549,8 +6757,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持 "
-"OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这"
+"是一种人工智能驱动的私密聊天服务，支持 OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6562,10 +6770,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist "
-""
-"是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生成这些信息的摘要。 "
-"请注意，其回复目前基于维基百科和相关内容，其准确性未经核实。"
+"DuckAssist 是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该"
+"功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生"
+"成这些信息的摘要。 请注意，其回复目前基于维基百科和相关内容，其准确性未经核"
+"实。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6579,10 +6787,11 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist "
-""
-"是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。DuckAssist "
-"的回复始终直接链接到一个或两个资料来源，并注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"DuckAssist 是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，"
+"该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的"
+"相关信息生成简短的答案。DuckAssist 的回复始终直接链接到一个或两个资料来源，并"
+"注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资"
+"料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6605,7 +6814,9 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
+"和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6613,7 +6824,9 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
+"和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6629,7 +6842,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
+msgstr ""
+"暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 "
+"%1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6761,14 +6976,18 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息来对这些报告进行匿名化。"
+msgstr ""
+"DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息"
+"来对这些报告进行匿名化。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 %2$s。"
+msgstr ""
+"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 "
+"%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6776,7 +6995,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
+msgstr ""
+"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -6784,7 +7004,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟踪程序，这些公司经常试图在其他网站上跟踪你。"
+msgstr ""
+"DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟"
+"踪程序，这些公司经常试图在其他网站上跟踪你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6796,8 +7018,9 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo "
-"的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
+"DuckDuckGo 的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时"
+"会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名"
+"性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6816,7 +7039,8 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
+msgstr ""
+"DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6902,8 +7126,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 "
-"个字符。"
+"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，"
+"并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 个字符。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7070,6 +7294,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "展示经常浏览的网站"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7146,7 +7376,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置信息。"
+msgstr ""
+"启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置"
+"信息。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7332,7 +7564,8 @@ msgstr "输入文本"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
+msgstr ""
+"输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7357,6 +7590,12 @@ msgstr "输入口令即可读取设置。"
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "娱乐指南"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7520,6 +7759,18 @@ msgid "Explicit lyrics"
 msgstr "露骨的歌词"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7621,6 +7872,12 @@ msgid "FREE"
 msgstr "免费"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7684,7 +7941,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问题。"
+msgstr ""
+"类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问"
+"题。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8023,6 +8282,12 @@ msgid "Free Up Storage"
 msgstr "释放存储空间"
 
 # smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us"
@@ -8143,8 +8408,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; “<strong>Check for "
-"Updates...</strong>”（查看更新……），然后选择“<strong>Install Update</strong>”（安装更新）。"
+"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; "
+"“<strong>Check for Updates...</strong>”（查看更新……），然后选"
+"择“<strong>Install Update</strong>”（安装更新）。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8494,7 +8760,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和其他高级隐私保护功能。"
+msgstr ""
+"订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和"
+"其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8504,7 +8772,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和其他高级隐私保护功能。"
+msgstr ""
+"通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和"
+"其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8528,6 +8798,12 @@ msgstr "在 DuckDuckGo Help 中获取答案。"
 msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr "获取电脑帮助"
+
+# smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8565,6 +8841,18 @@ msgid "Get the Latest Version"
 msgstr "获取最新版本"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8585,6 +8873,12 @@ msgstr "从以下平台获取此歌曲："
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "引荐给你的朋友们，帮助我们成长吧！"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8615,8 +8909,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊天 › Sync & Backup › "
-"与其他设备同步 › 复制文本二维码%4$s"
+"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊"
+"天 › Sync & Backup › 与其他设备同步 › 复制文本二维码%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8625,8 +8919,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
-"与其他设备同步%4$s"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
+"天 › Sync & Backup › 与其他设备同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8636,8 +8930,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊天 › Sync & Backup › "
-"与其他设备同步%4$s并扫描此二维码："
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊"
+"天 › Sync & Backup › 与其他设备同步%4$s并扫描此二维码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8647,8 +8941,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
-"与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
+"天 › Sync & Backup › 与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8670,7 +8964,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 "
+"%3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9263,6 +9559,12 @@ msgid "Hide Tips"
 msgstr "隐藏提示"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9372,7 +9674,9 @@ msgstr "历史"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr "按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s设为默认搜索引擎%6$s"
+msgstr ""
+"按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s"
+"设为默认搜索引擎%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9385,7 +9689,9 @@ msgstr "白苗语"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保护。"
+msgstr ""
+"稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保"
+"护。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -9730,7 +10036,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
+msgstr ""
+"如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与"
+"隐私”%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9740,8 +10048,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站设置” > “位置”%2$s，并确认已允许 "
-"DuckDuckGo 使用定位信息。"
+"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站"
+"设置” > “位置”%2$s，并确认已允许 DuckDuckGo 使用定位信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9755,7 +10063,8 @@ msgstr "如果你继续看到此错误，请联系 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
+msgstr ""
+"如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9763,7 +10072,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 %2$s 支持页面。"
+msgstr ""
+"如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 "
+"%2$s 支持页面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9771,7 +10082,9 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码以文本文件的形式保存到设备中。"
+msgstr ""
+"如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码"
+"以文本文件的形式保存到设备中。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -9786,7 +10099,9 @@ msgstr "如果你仍愿支持我们，可%1$s协助推广 DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版本。"
+msgstr ""
+"如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版"
+"本。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -9933,7 +10248,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄露搜索内容。%1$s了解详情%2$s。"
+msgstr ""
+"如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄"
+"露搜索内容。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9943,7 +10260,8 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
+msgstr ""
+"在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -9957,7 +10275,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具体都存了什么。"
+msgstr ""
+"本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具"
+"体都存了什么。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10362,8 +10682,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向商户页面，与广告不同，DuckDuckGo "
-"不会通过这些搜索结果获得收益。"
+"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向"
+"商户页面，与广告不同，DuckDuckGo 不会通过这些搜索结果获得收益。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10838,6 +11158,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "使用 DuckDuckGo 匿名搜索"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "利比里亚"
 
@@ -10906,6 +11233,12 @@ msgstr "线条图"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "争边球获胜次数"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11998,6 +12331,12 @@ msgid "More than 20 minutes"
 msgstr "20 分钟以上"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12318,8 +12657,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
-"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互"
+"联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和"
+"回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12481,6 +12821,12 @@ msgstr "不用了，谢谢"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "不用了，谢谢"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13134,13 +13480,21 @@ msgstr "按需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设置%5$s"
+msgstr ""
+"Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设"
+"置%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "开启但不显示页码"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13349,6 +13703,12 @@ msgid "Open create and edit images suggestions"
 msgstr "打开“创建和编辑图像”建议"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13511,7 +13871,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简单。"
+msgstr ""
+"即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简"
+"单。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13530,7 +13892,9 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。现已支持 %1$siOS 和 Android%2$s。"
+msgstr ""
+"我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。"
+"现已支持 %1$siOS 和 Android%2$s。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13782,7 +14146,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口令。"
+msgstr ""
+"我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口"
+"令。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13981,7 +14347,9 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr "以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
+msgstr ""
+"以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获"
+"得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13990,8 +14358,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答案。 如需调整此功能的工作方式或将其关闭，请访问 "
-"%1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答"
+"案。 如需调整此功能的工作方式或将其关闭，请访问 %1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14001,8 +14369,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答案。若要将其关闭并隐藏“协助”按钮，请访问 "
-"%1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答"
+"案。若要将其关闭并隐藏“协助”按钮，请访问 %1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14042,7 +14410,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
+msgstr ""
+"选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14071,10 +14440,22 @@ msgid "Pin"
 msgstr "别针"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "从%1$s%2$s将聊天记录置顶于此处"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14092,6 +14473,12 @@ msgstr "粉红"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "已固定"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14180,7 +14567,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害或非法。"
+msgstr ""
+"请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害"
+"或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14188,7 +14577,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法或有害。"
+msgstr ""
+"请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法"
+"或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14399,6 +14790,12 @@ msgid "Poor formatting"
 msgstr "格式不佳"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14605,6 +15002,12 @@ msgstr "上一张图片"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "上一个标签页"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15143,6 +15546,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "内置中节制度的人工智能推理功能"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15178,12 +15593,19 @@ msgid "Recent chat storage can be adjusted in %s."
 msgstr "可以在%1$s中调整近期聊天记录。"
 
 # smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
 msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr ""
+"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15191,7 +15613,8 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr ""
+"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15200,7 +15623,9 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
+msgstr ""
+"最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
+"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15323,6 +15748,12 @@ msgstr "重新搜索，不包含此网站"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "减少使用量"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15469,7 +15900,9 @@ msgstr "重新加载 Duck.ai"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重新加载）按钮。"
+msgstr ""
+"请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重"
+"新加载）按钮。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15558,14 +15991,18 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
+msgstr ""
+"移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的"
+"答案。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
+msgstr ""
+"移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示"
+"缓存的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -15622,14 +16059,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提供给 %1$s，以便共同提高服务质量。"
+msgstr ""
+"你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提"
+"供给 %1$s，以便共同提高服务质量。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr ""
+"发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信"
+"息。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15637,7 +16078,9 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr ""
+"发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是"
+"匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15684,6 +16127,12 @@ msgid "Reset All Settings"
 msgstr "恢复初始设置"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -15694,6 +16143,12 @@ msgstr "%1$s 后重置"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "分辨率"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -15716,7 +16171,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助的答案受我们的%1$s服务条款%2$s约束。"
+msgstr ""
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助"
+"的答案受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15724,7 +16181,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受我们的%1$s服务条款%2$s约束。"
+msgstr ""
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受"
+"我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15734,8 +16193,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内容生成，可能包含不准确的信息。Search Assist "
-"受我们的%1$s服务条款%2$s约束。"
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内"
+"容生成，可能包含不准确的信息。Search Assist 受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16159,7 +16618,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记录。"
+msgstr ""
+"在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记"
+"录。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16319,7 +16780,9 @@ msgstr "向下滚动并点击 %1$s查看高级设置%2$s。"
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s添加搜索引擎%6$s）"
+msgstr ""
+"向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s"
+"添加搜索引擎%6$s）"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16327,7 +16790,9 @@ msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr "向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 %5$s添加搜索引擎%6$s）。"
+msgstr ""
+"向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 "
+"%5$s添加搜索引擎%6$s）。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16376,6 +16841,12 @@ msgid "Search %s to find results closer to you?"
 msgstr "需要搜索 %1$s，查找离你更近的搜索结果吗？"
 
 # smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Search Anonymously"
 msgstr "匿名搜索"
 
@@ -16399,10 +16870,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist "
-""
-"匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显示）。Search "
-"Assist 目前仅供部分英语地区使用。"
+"Search Assist 匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，"
+"然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点"
+"击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显"
+"示）。Search Assist 目前仅供部分英语地区使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16418,8 +16889,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist "
-"是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
+"Search Assist 是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s"
+"扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16539,7 +17010,8 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
+msgstr ""
+"使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16557,7 +17029,9 @@ msgstr "匿名搜索并屏蔽跟踪程序"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 %1$sduckduckgo.com%2$s 发起搜索。"
+msgstr ""
+"通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 "
+"%1$sduckduckgo.com%2$s 发起搜索。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16576,8 +17050,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud Save "
-"将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，且你的口令仅限在你的浏览器中使用。"
+"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud "
+"Save 将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，"
+"且你的口令仅限在你的浏览器中使用。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16679,7 +17154,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
+"访问。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -16687,7 +17164,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
+"访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16695,7 +17174,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同步的设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同"
+"步的设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16703,7 +17184,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相关内容。"
+msgstr ""
+"利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相"
+"关内容。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16717,7 +17200,15 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
+msgstr ""
+"采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看"
+"到你的数据，甚至我们也不行。"
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16925,14 +17416,16 @@ msgstr "在弹出的菜单中点击 %1$s管理加载项%2$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
+msgstr ""
+"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
+msgstr ""
+"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17117,7 +17610,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后的所有对话。"
+msgstr ""
+"向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后"
+"的所有对话。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17215,6 +17710,12 @@ msgid "Set as Homepage"
 msgstr "设为主页"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17278,6 +17779,18 @@ msgid "Seychelles"
 msgstr "塞舌尔"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17312,7 +17825,16 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智能模型透露你的精确位置。"
+msgstr ""
+"与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智"
+"能模型透露你的精确位置。"
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17373,6 +17895,12 @@ msgid "Share positive feedback"
 msgstr "分享正面反馈"
 
 # smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
@@ -17394,7 +17922,8 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
+msgstr ""
+"将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -17504,6 +18033,12 @@ msgstr "显示设置链接和数据"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "显示详情"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17653,6 +18188,12 @@ msgid "Show more"
 msgstr "展开"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -17686,6 +18227,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "显示边栏"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -17739,14 +18286,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不会影响搜索隐私。"
+msgstr ""
+"提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不"
+"会影响搜索隐私。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不会影响搜索保护。"
+msgstr ""
+"提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不"
+"会影响搜索保护。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18050,6 +18601,12 @@ msgid "Something went wrong, please try again later."
 msgstr "出了点问题，请稍后再试。"
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18332,6 +18889,12 @@ msgstr "开始使用每月限额"
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "开始使用每周限额"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -18908,6 +19471,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "改用这款永不跟踪你的搜索引擎。"
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19021,7 +19592,8 @@ msgid ""
 msgstr ""
 "同步恢复代码\n"
 "\n"
-"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无法访问某个设备时恢复已同步的数据。\n"
+"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无"
+"法访问某个设备时恢复已同步的数据。\n"
 "\n"
 "请妥善保管此信息。\n"
 "任何可访问此代码的人都可以访问你的同步数据。\n"
@@ -19033,7 +19605,8 @@ msgstr ""
 "2. 选择“开启 Sync & Backup”，然后选择“恢复同步数据”\n"
 " 3. 复制上方的恢复代码，并将其粘贴到“在此处粘贴代码”处\n"
 "\n"
-"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据将从服务器中删除且无法恢复。"
+"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据"
+"将从服务器中删除且无法恢复。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19052,6 +19625,12 @@ msgstr "与其他设备同步"
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "同步和备份暂时不可用"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19139,6 +19718,22 @@ msgstr "塔吉克斯坦"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "夺回你的隐私！"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19375,7 +19970,9 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银行账号。"
+msgstr ""
+"这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银"
+"行账号。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19491,7 +20088,8 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
+msgstr ""
+"在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19523,7 +20121,9 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设为默认搜索引擎，从而保护你的隐私。"
+msgstr ""
+"所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设"
+"为默认搜索引擎，从而保护你的隐私。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19583,10 +20183,22 @@ msgid "This Month"
 msgstr "本月"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "本周"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19594,7 +20206,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr "此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+msgstr ""
+"此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不"
+"准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19603,7 +20217,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%2$s）。"
+msgstr ""
+"此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或"
+"令人反感的信息（详情请参阅%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19611,7 +20227,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感的信息。（详情请参见 %2$s）。"
+msgstr ""
+"这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感"
+"的信息。（详情请参见 %2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19621,8 +20239,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s "
-"模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可"
+"能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19708,6 +20326,22 @@ msgid "This information isn’t useful"
 msgstr "这些信息没有用"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -19725,7 +20359,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据保留模式。"
+msgstr ""
+"该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据"
+"保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19733,7 +20369,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据保留模式。"
+msgstr ""
+"该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据"
+"保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19769,7 +20407,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，之后可以通过任何浏览器访问这些记录。"
+msgstr ""
+"这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，"
+"之后可以通过任何浏览器访问这些记录。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19777,7 +20417,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI 辅助的答案。"
+msgstr ""
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
+"么你可能会再次看到 AI 辅助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19787,8 +20429,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI "
-"辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显示 AI 辅助答案。"
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
+"么你可能会再次看到 AI 辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显"
+"示 AI 辅助答案。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19827,8 +20470,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你仍然可以在连接到 Sync & Backup "
-"的其他浏览器中浏览你的聊天记录。"
+"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你"
+"仍然可以在连接到 Sync & Backup 的其他浏览器中浏览你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19973,7 +20616,8 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
+msgstr ""
+"打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19982,7 +20626,9 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格式保存到最初用于设置同步的设备上。"
+msgstr ""
+"需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格"
+"式保存到最初用于设置同步的设备上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19990,7 +20636,9 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再试一次。"
+msgstr ""
+"如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再"
+"试一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20014,6 +20662,12 @@ msgstr "今天"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "今天"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20186,7 +20840,8 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
+msgstr ""
+"此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -20421,9 +21076,21 @@ msgid "Try Them Out"
 msgstr "试试它们"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "尝试搜索！"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -20488,6 +21155,12 @@ msgid "Try for free"
 msgstr "免费试用"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -20500,6 +21173,12 @@ msgstr "免费试用"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "立即免费试用！安全的 VPN、先进的私密人工智能技术，以及更多功能。"
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20527,6 +21206,12 @@ msgstr "立即试用我们的浏览器"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "试试我们的纯净版主页："
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20640,7 +21325,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
+msgstr ""
+"想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设"
+"置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20648,7 +21335,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
+msgstr ""
+"想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的"
+"设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20770,6 +21459,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "打开 Duck Player，观看没有定向广告的 YouTube"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -20830,7 +21525,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间出现短暂的延迟。"
+msgstr ""
+"在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间"
+"出现短暂的延迟。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20959,14 +21656,16 @@ msgstr "了解优点和缺点"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
+msgstr ""
+"在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
+msgstr ""
+"在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21081,7 +21780,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍的使用限额。"
+msgstr ""
+"升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍"
+"的使用限额。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21122,6 +21823,12 @@ msgstr "通过 DuckDuckGo 订阅解锁高级 AI 模型"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "订阅即可解锁高级人工智能功能！"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -21439,7 +22146,9 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公司的侵害。确保信息保密。免费。无需账户。"
+msgstr ""
+"私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公"
+"司的侵害。确保信息保密。免费。无需账户。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21474,6 +22183,12 @@ msgstr "在 Firefox 中使用"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "在 Safari 中使用"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -21645,7 +22360,8 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
+msgstr ""
+"DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21687,8 +22403,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & Backup%4$s > "
-"%5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
+"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21698,8 +22414,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup "
-"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup 栏下选择“开"
+"启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21709,8 +22425,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设置%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同步%8$s”。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设"
+"置%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同"
+"步%8$s”。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21720,8 +22437,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。在 Sync & Backup "
-"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。"
+"在 Sync & Backup 栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF "
+"中的二维码。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21916,7 +22634,9 @@ msgstr "在 Duck Player 中观看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 YouTube 推荐。"
+msgstr ""
+"在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 "
+"YouTube 推荐。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21936,8 +22656,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube "
-"没有任何关系。"
+"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。"
+"DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube 没有任何关系。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21960,7 +22680,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 DuckDuckGo，这样我们才能调查并处理这个问题。"
+msgstr ""
+"我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 "
+"DuckDuckGo，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21971,7 +22693,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回复，这样我们才能调查并处理这个问题。"
+msgstr ""
+"我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回"
+"复，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22024,7 +22748,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
+msgstr ""
+"我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟"
+"踪："
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22032,7 +22758,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
+msgstr ""
+"我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们"
+"跟踪："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22128,7 +22856,8 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
+msgstr ""
+"匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22154,7 +22883,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更正可能需要一段时间。"
+msgstr ""
+"你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更"
+"正可能需要一段时间。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22167,7 +22898,8 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
+msgstr ""
+"我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22175,7 +22907,8 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
+msgstr ""
+"我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -22318,7 +23051,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用"
+"于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22326,7 +23061,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处"
+"理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22336,8 +23073,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天内容均为私密，DuckDuckGo "
-"绝不会存储或用于训练 AI 模型。"
+"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天"
+"内容均为私密，DuckDuckGo 绝不会存储或用于训练 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22463,8 +23200,9 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官方 DuckDuckGo "
-"来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
+"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官"
+"方 DuckDuckGo 来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。"
+"保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22574,6 +23312,12 @@ msgstr "您最不满意的地方是什么？"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "什么吸引了你，让你再回到这里呢？"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -22988,6 +23732,14 @@ msgid "Wintry Mix"
 msgstr "冬季雨加雪"
 
 # smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -23266,7 +24018,8 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
+msgstr ""
+"可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -23310,7 +24063,8 @@ msgstr "您最多可以附加 %1$s 个文本选中内容。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
+msgstr ""
+"可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23398,6 +24152,13 @@ msgid "You can only attach %s images per conversation."
 msgstr "每个对话最多只能附加 %1$s 张图像。"
 
 # smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach 1 image at a time"
@@ -23471,7 +24232,9 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限额。"
+msgstr ""
+"你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限"
+"额。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23479,7 +24242,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 DuckDuckGo 订阅保护功能。"
+msgstr ""
+"现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 "
+"DuckDuckGo 订阅保护功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23500,7 +24265,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr ""
+"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
+"存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23509,7 +24276,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr ""
+"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
+"存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23525,12 +24294,20 @@ msgid ""
 msgstr "安装最新版本后，你将自动收到 DuckDuckGo 应用程序更新。"
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装的 App 上网还能进一步保护隐私，它可以："
+msgstr ""
+"现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装"
+"的 App 上网还能进一步保护隐私，它可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23566,6 +24343,12 @@ msgstr "你已屏蔽 %1$s 个网站"
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "你已屏蔽 1 个网站"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -23612,8 +24395,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 %1$s "
-"条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
+"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 "
+"%1$s 条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23623,8 +24406,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s "
-"条包含附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
+"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s 条包含"
+"附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23637,7 +24420,9 @@ msgstr "你已用尽存储空间"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 Google 与 YouTube 跟踪。"
+msgstr ""
+"Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 "
+"Google 与 YouTube 跟踪。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23680,7 +24465,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
+msgstr ""
+"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
+"览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23689,7 +24476,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 100 条聊天记录将保存在本地存储中："
+msgstr ""
+"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
+"览器中，你最近的 100 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23728,7 +24517,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
+msgstr ""
+"你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -23753,14 +24543,16 @@ msgstr "你的聊天内容均为私密，绝不会用于训练人工智能模型
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23788,7 +24580,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请按照以下步骤保留聊天记录。"
+msgstr ""
+"聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请"
+"按照以下步骤保留聊天记录。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -23827,7 +24621,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample message%3$s]"
+msgstr ""
+"我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample "
+"message%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -23870,8 +24666,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 512 "
-"位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
+"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 "
+"512 位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密"
+"钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23885,7 +24682,9 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商无法将对话内容与你本人关联起来。"
+msgstr ""
+"你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商"
+"无法将对话内容与你本人关联起来。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23924,14 +24723,22 @@ msgid "Your searches can’t be tied back to you"
 msgstr "你的搜索记录无法追溯到你本人"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No AI%2$s "
-"扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
+"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No "
+"AI%2$s 扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -23950,7 +24757,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更多保护。已安装该浏览器并可以："
+msgstr ""
+"你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更"
+"多保护。已安装该浏览器并可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24501,3 +25310,9 @@ msgstr "年"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "年"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "检测到 %1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "已使用 %1$s 个文件"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -181,9 +181,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
-"者切换到 Plus 或免费模型。"
+msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -192,9 +190,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
-"者切换到 Plus 或免费模型。"
+msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -209,9 +205,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，"
-"或切换到免费模式。"
+msgstr "%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，或切换到免费模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -309,9 +303,7 @@ msgid ""
 "%s runs in a Trusted Execution Environment. This means not even the model "
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
-msgstr ""
-"%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的"
-"响应，也不会在其服务器上保存此聊天记录。"
+msgstr "%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的响应，也不会在其服务器上保存此聊天记录。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -358,7 +350,7 @@ msgstr "已使用 %1$s"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s 使用额度的速度可达基础模型的 2-5 倍%2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -425,8 +417,7 @@ msgstr "%1$s点击%2$s添加%3$s勾选%4$s允许%5$s，然后点击%6$s确定%7$
 #. Instructions on what buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr "%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -435,9 +426,7 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr ""
-"%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确"
-"定%9$s"
+msgstr "%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -600,7 +589,7 @@ msgstr "1 天前"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "已使用 1 个文件"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -881,8 +870,7 @@ msgstr "客场"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
+msgstr "网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -940,9 +928,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 "
-"DuckDuckGo Search 中的 AI Chat 功能。关闭此设置后，仍可以通过访问 "
-"%1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
+"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 DuckDuckGo Search 中的 AI Chat "
+"功能。关闭此设置后，仍可以通过访问 %1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1003,9 +990,8 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s 并"
-"通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 "
-"OpenAI 和 Anthropic 等公司的聊天模型。"
+"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s "
+"并通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 OpenAI 和 Anthropic 等公司的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1501,7 +1487,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
+msgstr "高级模型使用额度的速度比其他模型快 2-5 倍。%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1678,9 +1664,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用"
-"你的对话来训练聊天模型"
+msgstr "DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用你的对话来训练聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1789,8 +1773,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给"
-"数据留存期有限的搜索引擎。%2$s 的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
+"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给数据留存期有限的搜索引擎。%2$s "
+"的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1955,8 +1939,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
+msgstr "根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2166,9 +2149,7 @@ msgstr "截至"
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保"
-"护隐私。"
+msgstr "根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保护隐私。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2269,7 +2250,7 @@ msgstr "以私密方式提问"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "以私密方式提问"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2304,11 +2285,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可"
-"以选择显示 Assist 的频率：从不（从搜索结果中完全移除 Assist 用户界面)、按需"
-"（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人"
-"工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案"
-"目前仅供美国（英语）地区使用。"
+"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可以选择显示 Assist 的频率：从不（从搜索结果中完全移除 "
+"Assist "
+"用户界面)、按需（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2320,10 +2299,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答"
-"案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，"
-"根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并"
-"通过%1$s爬取网络内容%2$s自动生成。"
+"Assist "
+"是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2485,9 +2462,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。"
-"Assist 目前仅供英语地区使用。"
+msgstr "为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。Assist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2495,9 +2470,7 @@ msgid ""
 "Automatically shows DuckAssist for relevant searches. DuckAssist can "
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
-msgstr ""
-"为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些"
-"搜索。DuckAssist 目前仅供英语地区使用。"
+msgstr "为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。DuckAssist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2702,9 +2675,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身"
-"份信息，对你的对话进行匿名化处理。"
+msgstr "在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身份信息，对你的对话进行匿名化处理。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3084,26 +3055,20 @@ msgstr "浏览文件"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，"
-"还能屏蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏"
-"蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即"
-"可匿名搜索、屏蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即可匿名搜索、屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3210,18 +3175,15 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 "
-"Cloud Save 功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令"
-"也只有浏览器知道。"
+"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 Cloud Save "
+"功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令也只有浏览器知道。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用"
-"之前，请参阅我们的%1$s。"
+msgstr "启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3229,9 +3191,7 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始"
-"使用之前，请参阅我们的%1$s。"
+msgstr "启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3715,10 +3675,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿"
-"名对话，该功能支持 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
-"DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过"
-"访问 %1$shttps://duck.ai%2$s 来使用聊天功能。 "
+"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿名对话，该功能支持 OpenAI、Anthropic "
+"等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
+"%1$shttps://duck.ai%2$s 来使用聊天功能。 "
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3798,7 +3757,7 @@ msgstr "与人工智能私聊"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "与热门 AI 私聊"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3848,9 +3807,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历"
-"史记录会删除已置顶的聊天记录。"
+msgstr "聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历史记录会删除已置顶的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3862,9 +3819,8 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
-"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删"
-"除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
+"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3886,9 +3842,7 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审"
-"核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
+msgstr "与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4239,9 +4193,7 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr ""
-"清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者"
-"在超过 7 天未使用 AI Chat 后自动将其删除。"
+msgstr "清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者在超过 7 天未使用 AI Chat 后自动将其删除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4250,9 +4202,7 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr ""
-"清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近"
-"期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
+msgstr "清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4269,8 +4219,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密"
-"人工智能聊天服务支持 OpenAI、Anthropic 等聊天模型。"
+"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密人工智能聊天服务支持 OpenAI、Anthropic "
+"等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4311,9 +4261,7 @@ msgstr "在弹出的菜单中点击 %1$s更改搜索设置%2$s"
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选"
-"项%4$s"
+msgstr "Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选项%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4343,9 +4291,7 @@ msgstr "在左侧的列表中点击 %1$s隐私和服务%2$s。"
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图"
-"标%4$s）"
+msgstr "在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图标%4$s）"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4435,9 +4381,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻"
-"触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
+msgstr "点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4447,9 +4391,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设"
-"置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
+msgstr "点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4517,9 +4459,7 @@ msgstr "点击搜索栏中的下拉菜单"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 "
-"%3$sDuckDuckGo%4$s。"
+msgstr "点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4572,7 +4512,7 @@ msgstr "关闭"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "关闭"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4622,7 +4562,7 @@ msgstr "关闭搜索"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "关闭第二意见"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4997,7 +4937,7 @@ msgstr "继续屏蔽广告"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "在此处继续查看近期聊天记录。或者使用 Fire Button 将其删除。"
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5068,7 +5008,7 @@ msgstr "Cookie 数据："
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "已复制"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5121,7 +5061,7 @@ msgstr "复制代码"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "复制链接"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5240,7 +5180,7 @@ msgstr "创建图像"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "创建分享链接"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5291,7 +5231,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
+msgstr "创建链接会生成聊天记录的副本，任何打开链接的人都可以查看。"
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5450,7 +5390,7 @@ msgstr "自定义回复"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "自定义回复"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5738,7 +5678,7 @@ msgstr "删除服务器数据？"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "删除分享链接"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5750,7 +5690,7 @@ msgstr "删除记录"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "删除一条聊天记录"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5788,7 +5728,7 @@ msgstr "删除图像？"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "删除我"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5931,8 +5871,7 @@ msgstr "暂时无法使用听写功能"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
+msgstr "听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6099,7 +6038,7 @@ msgstr "关闭促销信息"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "关闭导览"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6243,9 +6182,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 "
-"AI 生成的图像。 %3$s了解详情%4$s"
+msgstr "不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 AI 生成的图像。 %3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6254,8 +6191,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤"
-"掉 AI 生成的图像。%3$s了解详情%4$s"
+"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤掉 AI "
+"生成的图像。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6315,7 +6252,7 @@ msgstr "下载 DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "下载 DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6528,7 +6465,7 @@ msgstr "Duck.ai 是由 DuckDuckGo 提供的免费人工智能私聊工具。"
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai 现在可以分析 PDF 文件。试试看！"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6537,9 +6474,7 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr ""
-"Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非"
-"你选择在设置中自动附加页面。"
+msgstr "Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非你选择在设置中自动附加页面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6548,9 +6483,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程"
-"序再试一次。"
+msgstr "Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程序再试一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6573,9 +6506,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何"
-"希望重新掌控自己个人信息的人。"
+msgstr "Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何希望重新掌控自己个人信息的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6589,9 +6520,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页："
-"https://duck.ai"
+msgstr "Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页：https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6605,9 +6534,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 "
-"%2$s"
+msgstr "暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6627,9 +6554,7 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr ""
-"Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链"
-"接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
+msgstr "Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6640,10 +6565,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、"
-"Anthropic 等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 中的 Duck.ai 按钮"
-"和链接。不过，即使关闭该设置，仍然可以直接通过访问 %1$shttps://duck.ai%2$s 来"
-"使用 Duck.ai。"
+"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
+"DuckDuckGo Search 中的 Duck.ai 按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
+"%1$shttps://duck.ai%2$s 来使用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6676,7 +6600,7 @@ msgstr "Duck.ai 的回复并非基于特定资料来源，也未核实其准确�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai 支持来自 Anthropic、OpenAI 和其他公司的模型。"
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6704,9 +6628,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需"
-"注册的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 "
-"AI、无需账户的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需注册的 AI "
+"聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 AI、无需账户的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6734,10 +6657,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示"
-"频率：从不（从搜索结果中完全移除 DuckAssist 用户界面)、按需（仅在点击“协助”按"
-"钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显"
-"示）。DuckAssist 目前仅供美国（英语）地区使用。"
+"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示频率：从不（从搜索结果中完全移除 "
+"DuckAssist "
+"用户界面)、按需（仅在点击“协助”按钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显示）。DuckAssist "
+"目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6746,9 +6669,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI Chat%2$s，这"
-"是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天"
-"模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI "
+"Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6757,8 +6679,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这"
-"是一种人工智能驱动的私密聊天服务，支持 OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持 "
+"OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6770,10 +6692,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该"
-"功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生"
-"成这些信息的摘要。 请注意，其回复目前基于维基百科和相关内容，其准确性未经核"
-"实。"
+"DuckAssist "
+""
+"是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生成这些信息的摘要。 "
+"请注意，其回复目前基于维基百科和相关内容，其准确性未经核实。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6787,11 +6709,10 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist 是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，"
-"该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的"
-"相关信息生成简短的答案。DuckAssist 的回复始终直接链接到一个或两个资料来源，并"
-"注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资"
-"料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"DuckAssist "
+""
+"是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。DuckAssist "
+"的回复始终直接链接到一个或两个资料来源，并注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6814,9 +6735,7 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
-"和 %3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6824,9 +6743,7 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
-"和 %3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6842,9 +6759,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 "
-"%1$s 发送到 %2$s"
+msgstr "暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6976,18 +6891,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息"
-"来对这些报告进行匿名化。"
+msgstr "DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息来对这些报告进行匿名化。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 "
-"%2$s。"
+msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 %2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6995,8 +6906,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
+msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7004,9 +6914,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟"
-"踪程序，这些公司经常试图在其他网站上跟踪你。"
+msgstr "DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟踪程序，这些公司经常试图在其他网站上跟踪你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7018,9 +6926,8 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo 的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时"
-"会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名"
-"性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
+"DuckDuckGo "
+"的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7039,8 +6946,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
+msgstr "DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7126,8 +7032,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，"
-"并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 个字符。"
+"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 "
+"个字符。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7297,7 +7203,7 @@ msgstr "展示经常浏览的网站"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "立即启用"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7376,9 +7282,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置"
-"信息。"
+msgstr "启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置信息。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7564,8 +7468,7 @@ msgstr "输入文本"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
+msgstr "输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7595,7 +7498,7 @@ msgstr "娱乐指南"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "完整聊天记录"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7762,13 +7665,13 @@ msgstr "露骨的歌词"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "探索 Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "探索 Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7875,7 +7778,7 @@ msgstr "免费"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "免费且可选"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -7941,9 +7844,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问"
-"题。"
+msgstr "类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问题。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8285,7 +8186,7 @@ msgstr "释放存储空间"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "免费使用，保障隐私"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8408,9 +8309,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; "
-"“<strong>Check for Updates...</strong>”（查看更新……），然后选"
-"择“<strong>Install Update</strong>”（安装更新）。"
+"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; “<strong>Check for "
+"Updates...</strong>”（查看更新……），然后选择“<strong>Install Update</strong>”（安装更新）。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8760,9 +8660,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和"
-"其他高级隐私保护功能。"
+msgstr "订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8772,9 +8670,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和"
-"其他高级隐私保护功能。"
+msgstr "通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8803,7 +8699,7 @@ msgstr "获取电脑帮助"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "通过 DuckDuckGo 订阅获取更高的使用限额。"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8844,13 +8740,13 @@ msgstr "获取最新版本"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "下载应用"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
+msgstr "获取免费的 DuckDuckGo 浏览器 %1$s，即可屏蔽 YouTube 上的广告。%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -8878,7 +8774,7 @@ msgstr "引荐给你的朋友们，帮助我们成长吧！"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "开始使用清单"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8909,8 +8805,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊"
-"天 › Sync & Backup › 与其他设备同步 › 复制文本二维码%4$s"
+"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊天 › Sync & Backup › "
+"与其他设备同步 › 复制文本二维码%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8919,8 +8815,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8930,8 +8826,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s并扫描此二维码："
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s并扫描此二维码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8941,8 +8837,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8964,9 +8860,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 "
-"%3$sDuckDuckGo%4$s。"
+msgstr "转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9562,7 +9456,7 @@ msgstr "隐藏提示"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "隐藏教程"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9674,9 +9568,7 @@ msgstr "历史"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr ""
-"按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s"
-"设为默认搜索引擎%6$s"
+msgstr "按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s设为默认搜索引擎%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9689,9 +9581,7 @@ msgstr "白苗语"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保"
-"护。"
+msgstr "稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保护。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10036,9 +9926,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与"
-"隐私”%2$s。"
+msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10048,8 +9936,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站"
-"设置” > “位置”%2$s，并确认已允许 DuckDuckGo 使用定位信息。"
+"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站设置” > “位置”%2$s，并确认已允许 "
+"DuckDuckGo 使用定位信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10063,8 +9951,7 @@ msgstr "如果你继续看到此错误，请联系 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
+msgstr "如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10072,9 +9959,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 "
-"%2$s 支持页面。"
+msgstr "如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 %2$s 支持页面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10082,9 +9967,7 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码"
-"以文本文件的形式保存到设备中。"
+msgstr "如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码以文本文件的形式保存到设备中。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10099,9 +9982,7 @@ msgstr "如果你仍愿支持我们，可%1$s协助推广 DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版"
-"本。"
+msgstr "如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版本。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10248,9 +10129,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄"
-"露搜索内容。%1$s了解详情%2$s。"
+msgstr "如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄露搜索内容。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10260,8 +10139,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
+msgstr "在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10275,9 +10153,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具"
-"体都存了什么。"
+msgstr "本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具体都存了什么。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10682,8 +10558,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向"
-"商户页面，与广告不同，DuckDuckGo 不会通过这些搜索结果获得收益。"
+"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向商户页面，与广告不同，DuckDuckGo "
+"不会通过这些搜索结果获得收益。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11162,7 +11038,7 @@ msgstr "使用 DuckDuckGo 匿名搜索"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "允许你在向 Duck.ai 提交搜索查询和提示之间切换"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11238,7 +11114,7 @@ msgstr "争边球获胜次数"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "链接将在 7 天后失效。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12334,7 +12210,7 @@ msgstr "20 分钟以上"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "更多提示"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12657,9 +12533,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互"
-"联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和"
-"回复的临时存储功能。"
+"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
+"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12826,7 +12701,7 @@ msgstr "不用了，谢谢"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "不用了，谢谢"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13480,9 +13355,7 @@ msgstr "按需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设"
-"置%5$s"
+msgstr "Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设置%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13494,7 +13367,7 @@ msgstr "开启但不显示页码"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "新手引导已完成"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13706,7 +13579,7 @@ msgstr "打开“创建和编辑图像”建议"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "打开开始使用清单"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -13871,9 +13744,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简"
-"单。"
+msgstr "即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简单。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13892,9 +13763,7 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。"
-"现已支持 %1$siOS 和 Android%2$s。"
+msgstr "我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。现已支持 %1$siOS 和 Android%2$s。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14146,9 +14015,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口"
-"令。"
+msgstr "我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口令。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14347,9 +14214,7 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获"
-"得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
+msgstr "以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14358,8 +14223,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答"
-"案。 如需调整此功能的工作方式或将其关闭，请访问 %1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答案。 如需调整此功能的工作方式或将其关闭，请访问 "
+"%1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14369,8 +14234,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答"
-"案。若要将其关闭并隐藏“协助”按钮，请访问 %1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答案。若要将其关闭并隐藏“协助”按钮，请访问 "
+"%1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14410,8 +14275,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
+msgstr "选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14443,7 +14307,7 @@ msgstr "别针"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "置顶聊天"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14455,7 +14319,7 @@ msgstr "从%1$s%2$s将聊天记录置顶于此处"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "置顶我"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14478,7 +14342,7 @@ msgstr "已固定"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "已置顶的聊天记录会显示在最近的聊天记录顶部。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14567,9 +14431,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害"
-"或非法。"
+msgstr "请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14577,9 +14439,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法"
-"或有害。"
+msgstr "请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14793,7 +14653,7 @@ msgstr "格式不佳"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
+msgstr "可使用热门 AI 模型。无需账户。已由我们进行匿名化处理的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15007,7 +14867,7 @@ msgstr "上一个标签页"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "上一条提示"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15549,13 +15409,13 @@ msgstr "内置中节制度的人工智能推理功能"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "推理能为复杂问题提供更好的回答。"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "推理能力更强，但使用额度的速度快 2–5 倍。%1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15596,7 +15456,7 @@ msgstr "可以在%1$s中调整近期聊天记录。"
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "近期聊天记录"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15604,8 +15464,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15613,8 +15472,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15623,9 +15481,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
-"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
+msgstr "最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15753,7 +15609,7 @@ msgstr "减少使用量"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "使用更高效的模型以减少使用量"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15900,9 +15756,7 @@ msgstr "重新加载 Duck.ai"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重"
-"新加载）按钮。"
+msgstr "请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重新加载）按钮。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15991,18 +15845,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的"
-"答案。"
+msgstr "移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示"
-"缓存的答案。"
+msgstr "移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16059,18 +15909,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提"
-"供给 %1$s，以便共同提高服务质量。"
+msgstr "你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提供给 %1$s，以便共同提高服务质量。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信"
-"息。"
+msgstr "发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16078,9 +15924,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是"
-"匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr "发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16130,7 +15974,7 @@ msgstr "恢复初始设置"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "重置教程"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16148,7 +15992,7 @@ msgstr "分辨率"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "回复"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16171,9 +16015,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助"
-"的答案受我们的%1$s服务条款%2$s约束。"
+msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助的答案受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16181,9 +16023,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受"
-"我们的%1$s服务条款%2$s约束。"
+msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16193,8 +16033,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内"
-"容生成，可能包含不准确的信息。Search Assist 受我们的%1$s服务条款%2$s约束。"
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内容生成，可能包含不准确的信息。Search Assist "
+"受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16618,9 +16458,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记"
-"录。"
+msgstr "在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记录。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16780,9 +16618,7 @@ msgstr "向下滚动并点击 %1$s查看高级设置%2$s。"
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s"
-"添加搜索引擎%6$s）"
+msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s添加搜索引擎%6$s）"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -16790,9 +16626,7 @@ msgstr ""
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr ""
-"向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 "
-"%5$s添加搜索引擎%6$s）。"
+msgstr "向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 %5$s添加搜索引擎%6$s）。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -16844,7 +16678,7 @@ msgstr "需要搜索 %1$s，查找离你更近的搜索结果吗？"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "搜索和 Duck.ai 切换开关"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16870,10 +16704,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，"
-"然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点"
-"击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显"
-"示）。Search Assist 目前仅供部分英语地区使用。"
+"Search Assist "
+""
+"匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显示）。Search "
+"Assist 目前仅供部分英语地区使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -16889,8 +16723,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s"
-"扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
+"Search Assist "
+"是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17010,8 +16844,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
+msgstr "使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17029,9 +16862,7 @@ msgstr "匿名搜索并屏蔽跟踪程序"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 "
-"%1$sduckduckgo.com%2$s 发起搜索。"
+msgstr "通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 %1$sduckduckgo.com%2$s 发起搜索。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17050,9 +16881,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud "
-"Save 将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，"
-"且你的口令仅限在你的浏览器中使用。"
+"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud Save "
+"将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，且你的口令仅限在你的浏览器中使用。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17154,9 +16984,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
-"访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17164,9 +16992,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
-"访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17174,9 +17000,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同"
-"步的设备访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同步的设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17184,9 +17008,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相"
-"关内容。"
+msgstr "利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相关内容。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17200,15 +17022,13 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看"
-"到你的数据，甚至我们也不行。"
+msgstr "采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "安全存储在我们的加密服务器上。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17416,16 +17236,14 @@ msgstr "在弹出的菜单中点击 %1$s管理加载项%2$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
+msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
+msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -17610,9 +17428,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后"
-"的所有对话。"
+msgstr "向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后的所有对话。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17713,7 +17529,7 @@ msgstr "设为主页"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "设置 Duck.ai 回复的语气和风格。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -17782,13 +17598,13 @@ msgstr "塞舌尔"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "分享"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "分享"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -17825,16 +17641,14 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智"
-"能模型透露你的精确位置。"
+msgstr "与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智能模型透露你的精确位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "分享聊天"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17898,7 +17712,7 @@ msgstr "分享正面反馈"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "分享范围"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17922,8 +17736,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
+msgstr "将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18038,7 +17851,7 @@ msgstr "显示详情"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "显示 Duck.ai 教程"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18191,7 +18004,7 @@ msgstr "展开"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "显示更多模型"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18232,7 +18045,7 @@ msgstr "显示边栏"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "显示分步提示，助你充分利用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18286,18 +18099,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不"
-"会影响搜索隐私。"
+msgstr "提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不会影响搜索隐私。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不"
-"会影响搜索保护。"
+msgstr "提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不会影响搜索保护。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18604,7 +18413,7 @@ msgstr "出了点问题，请稍后再试。"
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "出了点问题。请重试。"
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18894,7 +18703,7 @@ msgstr "开始使用每周限额"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "开始新聊天"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19476,7 +19285,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "切换到此第二种意见"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19592,8 +19401,7 @@ msgid ""
 msgstr ""
 "同步恢复代码\n"
 "\n"
-"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无"
-"法访问某个设备时恢复已同步的数据。\n"
+"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无法访问某个设备时恢复已同步的数据。\n"
 "\n"
 "请妥善保管此信息。\n"
 "任何可访问此代码的人都可以访问你的同步数据。\n"
@@ -19605,8 +19413,7 @@ msgstr ""
 "2. 选择“开启 Sync & Backup”，然后选择“恢复同步数据”\n"
 " 3. 复制上方的恢复代码，并将其粘贴到“在此处粘贴代码”处\n"
 "\n"
-"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据"
-"将从服务器中删除且无法恢复。"
+"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据将从服务器中删除且无法恢复。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19630,7 +19437,7 @@ msgstr "同步和备份暂时不可用"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "跨设备同步聊天记录"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19725,7 +19532,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
+msgstr "随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调用。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -19733,7 +19540,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
+msgstr "随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能快速调用。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19970,9 +19777,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银"
-"行账号。"
+msgstr "这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银行账号。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20088,8 +19893,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
+msgstr "在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20121,9 +19925,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设"
-"为默认搜索引擎，从而保护你的隐私。"
+msgstr "所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设为默认搜索引擎，从而保护你的隐私。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20186,7 +19988,7 @@ msgstr "本月"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "此回复"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20198,7 +20000,7 @@ msgstr "本周"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "此聊天记录将保留在 Duck.ai 中，仅对你本人可见。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20206,9 +20008,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr ""
-"此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不"
-"准确或令人反感的信息（详情请参阅%4$s）。"
+msgstr "此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20217,9 +20017,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或"
-"令人反感的信息（详情请参阅%2$s）。"
+msgstr "此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20227,9 +20025,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感"
-"的信息。（详情请参见 %2$s）。"
+msgstr "这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感的信息。（详情请参见 %2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20239,8 +20035,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可"
-"能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s "
+"模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20331,7 +20127,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
+msgstr "这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记录顶部！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20339,7 +20135,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
+msgstr "这只是一个示例聊天记录。使用侧边菜单中的 Fire Button 将其删除！"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20359,9 +20155,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据"
-"保留模式。"
+msgstr "该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20369,9 +20163,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据"
-"保留模式。"
+msgstr "该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20407,9 +20199,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，"
-"之后可以通过任何浏览器访问这些记录。"
+msgstr "这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，之后可以通过任何浏览器访问这些记录。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20417,9 +20207,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
-"么你可能会再次看到 AI 辅助的答案。"
+msgstr "此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI 辅助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20429,9 +20217,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
-"么你可能会再次看到 AI 辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显"
-"示 AI 辅助答案。"
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI "
+"辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显示 AI 辅助答案。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20470,8 +20257,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你"
-"仍然可以在连接到 Sync & Backup 的其他浏览器中浏览你的聊天记录。"
+"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你仍然可以在连接到 Sync & Backup "
+"的其他浏览器中浏览你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20616,8 +20403,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
+msgstr "打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20626,9 +20412,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格"
-"式保存到最初用于设置同步的设备上。"
+msgstr "需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格式保存到最初用于设置同步的设备上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20636,9 +20420,7 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再"
-"试一次。"
+msgstr "如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20667,7 +20449,7 @@ msgstr "今天"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
+msgstr "切换以试用私密 AI 聊天，或%1$s在 %2$s 菜单中将其禁用。%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20840,8 +20622,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
+msgstr "此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21079,7 +20860,7 @@ msgstr "试试它们"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "尝试其他模型"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21090,7 +20871,7 @@ msgstr "尝试搜索！"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "试试这条建议"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21158,7 +20939,7 @@ msgstr "免费试用"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "免费试用"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21178,7 +20959,7 @@ msgstr "立即免费试用！安全的 VPN、先进的私密人工智能技术�
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "免费试用 7 天"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21211,7 +20992,7 @@ msgstr "试试我们的纯净版主页："
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "尝试推理"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21325,9 +21106,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设"
-"置。%3$s了解详情%4$s"
+msgstr "想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21335,9 +21114,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的"
-"设置。%3$s了解详情%4$s"
+msgstr "想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21462,7 +21239,7 @@ msgstr "打开 Duck Player，观看没有定向广告的 YouTube"
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "开启 Duck.ai 切换开关"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21525,9 +21302,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间"
-"出现短暂的延迟。"
+msgstr "在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间出现短暂的延迟。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21656,16 +21431,14 @@ msgstr "了解优点和缺点"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
+msgstr "在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
+msgstr "在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -21780,9 +21553,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍"
-"的使用限额。"
+msgstr "升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍的使用限额。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21828,7 +21599,7 @@ msgstr "订阅即可解锁高级人工智能功能！"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "解锁高级模型"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22146,9 +21917,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公"
-"司的侵害。确保信息保密。免费。无需账户。"
+msgstr "私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公司的侵害。确保信息保密。免费。无需账户。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22188,7 +21957,7 @@ msgstr "在 Safari 中使用"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "使用 Fire Button 从历史记录中删除聊天。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22360,8 +22129,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
+msgstr "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22403,8 +22171,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
+"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & Backup%4$s > "
+"%5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22414,8 +22182,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup 栏下选择“开"
-"启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup "
+"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22425,9 +22193,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设"
-"置%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同"
-"步%8$s”。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设置%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同步%8$s”。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22437,9 +22204,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。"
-"在 Sync & Backup 栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF "
-"中的二维码。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。在 Sync & Backup "
+"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22634,9 +22400,7 @@ msgstr "在 Duck Player 中观看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 "
-"YouTube 推荐。"
+msgstr "在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 YouTube 推荐。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22656,8 +22420,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。"
-"DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube 没有任何关系。"
+"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube "
+"没有任何关系。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22680,9 +22444,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 "
-"DuckDuckGo，这样我们才能调查并处理这个问题。"
+msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 DuckDuckGo，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22693,9 +22455,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回"
-"复，这样我们才能调查并处理这个问题。"
+msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回复，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22748,9 +22508,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟"
-"踪："
+msgstr "我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -22758,9 +22516,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们"
-"跟踪："
+msgstr "我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22856,8 +22612,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
+msgstr "匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22883,9 +22638,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更"
-"正可能需要一段时间。"
+msgstr "你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更正可能需要一段时间。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22898,8 +22651,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
+msgstr "我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -22907,8 +22659,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
+msgstr "我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23051,9 +22802,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用"
-"于训练人工智能模型。"
+msgstr "欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23061,9 +22810,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处"
-"理，不会用于训练人工智能模型。"
+msgstr "欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23073,8 +22820,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天"
-"内容均为私密，DuckDuckGo 绝不会存储或用于训练 AI 模型。"
+"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天内容均为私密，DuckDuckGo "
+"绝不会存储或用于训练 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23200,9 +22947,8 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官"
-"方 DuckDuckGo 来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。"
-"保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
+"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官方 DuckDuckGo "
+"来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23317,7 +23063,7 @@ msgstr "什么吸引了你，让你再回到这里呢？"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "你能做什么？"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23737,7 +23483,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
+msgstr "使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时在“%1$s”菜单中开启或关闭。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24018,8 +23764,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
+msgstr "可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24063,8 +23808,7 @@ msgstr "您最多可以附加 %1$s 个文本选中内容。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
+msgstr "可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24156,7 +23900,7 @@ msgstr "每个对话最多只能附加 %1$s 张图像。"
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "你一次只能附加 %1$s 个标签页。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24232,9 +23976,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限"
-"额。"
+msgstr "你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限额。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24242,9 +23984,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 "
-"DuckDuckGo 订阅保护功能。"
+msgstr "现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 DuckDuckGo 订阅保护功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24265,9 +24005,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
-"存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24276,9 +24014,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
-"存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24297,7 +24033,7 @@ msgstr "安装最新版本后，你将自动收到 DuckDuckGo 应用程序更新
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "一切准备就绪！"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24305,9 +24041,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装"
-"的 App 上网还能进一步保护隐私，它可以："
+msgstr "现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装的 App 上网还能进一步保护隐私，它可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24348,7 +24082,7 @@ msgstr "你已屏蔽 1 个网站"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "你已掌握 Duck.ai 的基础知识"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24395,8 +24129,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 "
-"%1$s 条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
+"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 %1$s "
+"条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24406,8 +24140,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s 条包含"
-"附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
+"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s "
+"条包含附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24420,9 +24154,7 @@ msgstr "你已用尽存储空间"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 "
-"Google 与 YouTube 跟踪。"
+msgstr "Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 Google 与 YouTube 跟踪。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24465,9 +24197,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
-"览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24476,9 +24206,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
-"览器中，你最近的 100 条聊天记录将保存在本地存储中："
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 100 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24517,8 +24245,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
+msgstr "你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -24543,16 +24270,14 @@ msgstr "你的聊天内容均为私密，绝不会用于训练人工智能模型
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24580,9 +24305,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请"
-"按照以下步骤保留聊天记录。"
+msgstr "聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请按照以下步骤保留聊天记录。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24621,9 +24344,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample "
-"message%3$s]"
+msgstr "我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample message%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24666,9 +24387,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 "
-"512 位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密"
-"钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
+"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 512 "
+"位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24682,9 +24402,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商"
-"无法将对话内容与你本人关联起来。"
+msgstr "你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商无法将对话内容与你本人关联起来。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24728,7 +24446,7 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr ""
+msgstr "已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No AI%2$s 扩展插件，以便永久保存你的设置。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -24737,8 +24455,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No "
-"AI%2$s 扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
+"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No AI%2$s "
+"扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -24757,9 +24475,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更"
-"多保护。已安装该浏览器并可以："
+msgstr "你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更多保护。已安装该浏览器并可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25315,4 +25031,4 @@ msgstr "年"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -127,7 +127,7 @@ msgstr "偵測到%1$s"
 #. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
 msgctxt "Caption under a shared user prompt with multiple hidden attachments"
 msgid "%s files used"
-msgstr ""
+msgstr "%1$s 個檔案已使用"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
@@ -181,9 +181,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換"
-"至 Plus 或免費模式。"
+msgstr "%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -192,9 +190,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切"
-"換至 Plus 或免費模式。"
+msgstr "%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -209,9 +205,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或"
-"切換至免費模式。"
+msgstr "%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或切換至免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -310,8 +304,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s 運行於受信任執行環境（Trusted Execution Environment）。這表示即使是模型"
-"提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
+"%1$s 運行於受信任執行環境（Trusted Execution "
+"Environment）。這表示即使是模型提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -358,7 +352,7 @@ msgstr "%1$s 已使用"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
+msgstr "%1$s 消耗使用額度的速度比基本模型快多達 2—5 倍 %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -396,8 +390,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
+msgstr "%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -407,8 +400,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
+msgstr "%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -436,8 +428,7 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr ""
-"%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
+msgstr "%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -600,7 +591,7 @@ msgstr "1天前"
 #. Shown under a shared user message when exactly one uploaded file was omitted from the share.
 msgctxt "Caption under a shared user prompt with one hidden attachment"
 msgid "1 file used"
-msgstr ""
+msgstr "已使用 1 個檔案"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -881,8 +872,7 @@ msgstr "客場戰績"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
+msgstr "網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -940,9 +930,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo "
-"Search 上的 AI Chat 功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/"
-"aichat%2$s 使用 AI Chat 功能。"
+"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo Search 上的 AI Chat "
+"功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/aichat%2$s 使用 AI Chat 功能。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1003,9 +992,8 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck."
-"ai%2$s 以回答後續問題，這是我們的私密 AI 驅動的聊天服務，支援來自 OpenAI、"
-"Anthropic 等的聊天模型。"
+"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck.ai%2$s 以回答後續問題，這是我們的私密 AI "
+"驅動的聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1501,7 +1489,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
+msgstr "進階模型消耗使用額度的速度可能比其他模型快 2—5 倍。%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1678,9 +1666,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型"
-"供應商用於訓練聊天模型"
+msgstr "所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型供應商用於訓練聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1726,9 +1712,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會"
-"被移除。"
+msgstr "在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會被移除。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1791,8 +1775,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期"
-"限有限的搜尋引擎。%2$s 的提示和回應仍具有%3$s零提供者可見度%4$s。"
+"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期限有限的搜尋引擎。%2$s "
+"的提示和回應仍具有%3$s零提供者可見度%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1957,8 +1941,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
+msgstr "根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2131,9 +2114,7 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr ""
-"你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天"
-"記錄一併刪除。"
+msgstr "你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天記錄一併刪除。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2170,9 +2151,7 @@ msgstr "更新時間："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業"
-"皆於你的裝置上進行。"
+msgstr "根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業皆於你的裝置上進行。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2273,7 +2252,7 @@ msgstr "私下詢問"
 #. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
 msgctxt "new tab page"
 msgid "Ask privately"
-msgstr ""
+msgstr "私下詢問"
 
 # smartling.placeholder_format=C
 #. The name of the Assamese language
@@ -2308,10 +2287,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想"
-"要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 Assist 使用介面)、隨選 (僅在"
-"點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更"
-"頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
+"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 "
+"Assist 使用介面)、隨選 (僅在點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 "
+"(在更廣泛的搜尋中更頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2323,10 +2301,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI 協助的搜尋查詢答案。"
-"為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言"
-"技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並"
-"根據%1$s搜耙網路%2$s自動產生的。"
+"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI "
+"協助的搜尋查詢答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2488,9 +2464,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜"
-"尋結果。目前，Assist 僅供英語地區使用。"
+msgstr "自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，Assist 僅供英語地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2499,8 +2473,8 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應"
-"某些搜尋結果。目前，DuckAssist 僅供說英文的地區使用。"
+"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，DuckAssist "
+"僅供說英文的地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2705,9 +2679,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身"
-"份資訊，將你的對話匿名化。"
+msgstr "在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身份資訊，將你的對話匿名化。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3087,26 +3059,20 @@ msgstr "瀏覽檔案"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組"
-"合為一項%1$s%2$s延伸模組%3$s。"
+msgstr "享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執"
-"行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr "你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽"
-"器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
+msgstr "你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3213,18 +3179,15 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使"
-"用匿名的 Could Save 以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別"
-"的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
+"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使用匿名的 Could Save "
+"以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始"
-"之前，請先查看我們的%1$s。"
+msgstr "啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3232,9 +3195,7 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開"
-"始之前，請先查看我們的%1$s。"
+msgstr "啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3718,10 +3679,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 "
-"OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo Search 上的聊天按鈕和連"
-"結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 直接使用聊天功"
-"能。"
+"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 "
+"DuckDuckGo Search 上的聊天按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s "
+"直接使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3801,7 +3761,7 @@ msgstr "與 AI 私密聊天"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Chat privately with Popular AIs"
-msgstr ""
+msgstr "與熱門 AI 私密聊天"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
@@ -3851,9 +3811,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用"
-"聊天記錄將刪除置頂的聊天。"
+msgstr "聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用聊天記錄將刪除置頂的聊天。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3865,9 +3823,8 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 "
-"DuckDuckGo 伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置"
-"頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
+"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3889,9 +3846,7 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴"
-"供應商匿名審核，以用於 %2$s。"
+msgstr "與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴供應商匿名審核，以用於 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4242,9 +4197,7 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr ""
-"清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近"
-"的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
+msgstr "清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4254,8 +4207,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期"
-"保存，或在不使用 Duck.ai 的情況下 7 天後自動刪除，視您的瀏覽器而定。"
+"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期保存，或在不使用 Duck.ai 的情況下 7 "
+"天後自動刪除，視您的瀏覽器而定。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4272,8 +4225,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私"
-"人 AI 聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
+"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私人 AI 聊天服務，支援來自 "
+"OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4434,9 +4387,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏"
-"覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
+msgstr "按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4446,9 +4397,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的"
-"瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
+msgstr "按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4569,7 +4518,7 @@ msgstr "關閉"
 #. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
 msgctxt "Accessible label for the checklist sheet close button"
 msgid "Close"
-msgstr ""
+msgstr "關閉"
 
 # smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
@@ -4619,7 +4568,7 @@ msgstr "關閉搜尋"
 #. Removes the second-opinion card and returns to the original answer.
 msgctxt "Accessible label for a close (X) button"
 msgid "Close second opinion"
-msgstr ""
+msgstr "關閉另一種觀點"
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4723,8 +4672,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
+msgstr "Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -4995,7 +4943,7 @@ msgstr "繼續封鎖廣告"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
+msgstr "在這裡繼續最近的聊天記錄。 或是使用 Fire Button 將其刪除。"
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5066,7 +5014,7 @@ msgstr "Cookie資料："
 #. Temporary label shown on the copy button after a successful copy.
 msgctxt "Confirmation label after copying a share link"
 msgid "Copied"
-msgstr ""
+msgstr "已複製"
 
 # smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
@@ -5119,7 +5067,7 @@ msgstr "複製代碼"
 #. Title-case button label in the Duck.ai share modal that copies the generated share URL.
 msgctxt "Button to copy the share link to the clipboard"
 msgid "Copy Link"
-msgstr ""
+msgstr "複製連結"
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5238,7 +5186,7 @@ msgstr "建立圖像"
 #. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
 msgctxt "Primary button to create a share link"
 msgid "Create Share Link"
-msgstr ""
+msgstr "建立分享連結"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
@@ -5289,7 +5237,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
+msgstr "建立連結會建立對話副本，任何開啟連結的人都可以查看。"
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5448,7 +5396,7 @@ msgstr "自訂回應"
 #. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
 msgctxt "Product-tour checklist item title"
 msgid "Customize responses"
-msgstr ""
+msgstr "自訂回應"
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5736,7 +5684,7 @@ msgstr "刪除伺服器資料？"
 #. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
 msgctxt "Button to revoke a share link"
 msgid "Delete Shared Link"
-msgstr ""
+msgstr "刪除分享連結"
 
 # smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
@@ -5748,7 +5696,7 @@ msgstr "刪除逐字稿"
 #. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
 msgctxt "Product-tour checklist item title"
 msgid "Delete a chat"
-msgstr ""
+msgstr "刪除一則聊天記錄"
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5786,7 +5734,7 @@ msgstr "刪除圖片？"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Delete me"
-msgstr ""
+msgstr "刪除我"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5929,9 +5877,7 @@ msgstr "聽寫功能暫時無法使用"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 "
-"Duck.ai 中聊天。"
+msgstr "語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6098,7 +6044,7 @@ msgstr "關閉促銷廣告"
 #. Accessible label for the close (X) button that dismisses the onboarding checklist.
 msgctxt "Accessible label for the checklist dismiss button"
 msgid "Dismiss tour"
-msgstr ""
+msgstr "隱藏導覽"
 
 # smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
@@ -6242,9 +6188,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖"
-"片。 %3$s瞭解更多%4$s"
+msgstr "不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖片。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6252,9 +6196,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr ""
-"不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖"
-"片的搜尋。%3$s瞭解更多%4$s"
+msgstr "不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖片的搜尋。%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6314,7 +6256,7 @@ msgstr "下載 DuckDuckGo"
 #. Button on the onboarding completion modal that links to download the DuckDuckGo app.
 msgctxt "Product-tour completion modal button"
 msgid "Download DuckDuckGo"
-msgstr ""
+msgstr "下載 DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6527,7 +6469,7 @@ msgstr "Duck.ai 由 DuckDuckGo 提供。私人 AI 聊天。免費。"
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai can now analyze PDFs. Give it a try!"
-msgstr ""
+msgstr "Duck.ai 現在可以分析 PDF 文件。來試試看吧！"
 
 # smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
@@ -6536,9 +6478,7 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr ""
-"Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包"
-"含，除非你在設定中選擇自動附加頁面。"
+msgstr "Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包含，除非你在設定中選擇自動附加頁面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6547,9 +6487,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任"
-"何擴充套件，然後再試一次。"
+msgstr "Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任何擴充套件，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6572,9 +6510,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重"
-"新掌控個人資訊的人。"
+msgstr "Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重新掌控個人資訊的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6588,9 +6524,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁："
-"https://duck.ai"
+msgstr "Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁：https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6604,8 +6538,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr "Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6626,8 +6559,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，"
-"但你仍然可以造訪 %1$sduck.ai%2$s 直接使用。"
+"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，但你仍然可以造訪 %1$sduck.ai%2$s "
+"直接使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6638,9 +6571,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。"
-"關閉此設定將隱藏 DuckDuckGo Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定"
-"後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 Duck.ai使用聊天功能。"
+"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo "
+"Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 "
+"Duck.ai使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6673,7 +6606,7 @@ msgstr "Duck.ai 的回應不是根據特定來源，也尚未確認準確性。"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
+msgstr "Duck.ai 支援來自 Anthropic、OpenAI 等公司的模型。"
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -6701,9 +6634,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需"
-"註冊的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點"
-"的 AI、無需帳號的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需註冊的 AI "
+"聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點的 AI、無需帳號的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6731,10 +6663,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 "
-"DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 DuckAssist UI)、隨選 (僅在"
-"點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁"
-"地顯示)。目前 DuckAssist 僅供美國 (英文) 地區使用。"
+"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 "
+"DuckAssist UI)、隨選 (僅在點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁地顯示)。目前 "
+"DuckAssist 僅供美國 (英文) 地區使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6743,8 +6674,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這"
-"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 等聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
+"OpenAI 和 Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6753,8 +6684,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這"
-"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
+"OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6766,10 +6697,8 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了"
-"完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 AI 驅動的自"
-"然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，"
-"尚未確認準確性。"
+"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 "
+"AI 驅動的自然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，尚未確認準確性。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6783,11 +6712,10 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完"
-"成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，"
-"根據找到的相關資訊產生簡短的答案。DuckAssist 的回應始終直接連結至一個或兩個來"
-"源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是"
-"從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
+"DuckAssist "
+""
+"是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。DuckAssist "
+"的回應始終直接連結至一個或兩個來源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6810,9 +6738,7 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
-"%3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6820,9 +6746,7 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
-"%3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6838,9 +6762,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件"
-"傳送至%2$s"
+msgstr "DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6972,17 +6894,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資"
-"訊來匿名化這些報告。"
+msgstr "DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資訊來匿名化這些報告。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
+msgstr "DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6998,9 +6917,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤"
-"器，它們經常試圖在你造訪其他網站時追蹤你。"
+msgstr "DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤器，它們經常試圖在你造訪其他網站時追蹤你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7011,11 +6928,7 @@ msgid ""
 "use it to improve results for that search, and then we promptly throw it "
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
-msgstr ""
-"DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置"
-"上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我"
-"們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保"
-"護你的隱私%2$s。"
+msgstr "DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保護你的隱私%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7034,9 +6947,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更"
-"接近你的搜尋結果。%1$s瞭解更多%2$s。"
+msgstr "DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更接近你的搜尋結果。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7121,10 +7032,7 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr ""
-"當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我"
-"們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18"
-"至20個字元。"
+msgstr "當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18至20個字元。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7294,7 +7202,7 @@ msgstr "啟用最常造訪的網站"
 #. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
 msgctxt "settings"
 msgid "Enable Now"
-msgstr ""
+msgstr "立即啟用"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
@@ -7373,9 +7281,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保"
-"密。"
+msgstr "啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保密。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7536,9 +7442,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關"
-"密語下。"
+msgstr "輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關密語下。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7563,8 +7467,7 @@ msgstr "輸入文字"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
+msgstr "輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7594,7 +7497,7 @@ msgstr "娛樂指南"
 #. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
 msgctxt "Share scope toggle label for the full chat"
 msgid "Entire Chat"
-msgstr ""
+msgstr "完整聊天"
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7761,13 +7664,13 @@ msgstr "成人內容歌詞"
 #. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
 msgctxt "Label on the mobile product-tour entry button"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "探索 Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
 msgctxt "Product-tour checklist group title"
 msgid "Explore Duck.ai"
-msgstr ""
+msgstr "探索 Duck.ai"
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -7874,7 +7777,7 @@ msgstr "免費"
 #. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
 msgctxt "new tab page"
 msgid "FREE & OPTIONAL"
-msgstr ""
+msgstr "免費 & 可選用"
 
 # smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
@@ -7940,9 +7843,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的"
-"問題。"
+msgstr "像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的問題。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8179,8 +8080,7 @@ msgstr "多霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
+msgstr "按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8285,7 +8185,7 @@ msgstr "釋放儲存空間"
 #. Secondary text under the app-download row, emphasising the app is free and private.
 msgctxt "Subtitle under the Download the app row"
 msgid "Free and always private"
-msgstr ""
+msgstr "免費且永遠保密"
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8408,8 +8308,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> &gt;"
-"<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
+"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> "
+"&gt;<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8759,9 +8659,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
-"隱私權保護。"
+msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8771,9 +8669,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
-"隱私權保護。"
+msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8802,7 +8698,7 @@ msgstr "取得電腦協助"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
+msgstr "訂閱 DuckDuckGo 即可獲得更高的使用上限。"
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8843,13 +8739,13 @@ msgstr "取得最新版本"
 #. Row that links to downloading the DuckDuckGo app after finishing the tour.
 msgctxt "Title of the app-download row on the completion card"
 msgid "Get the app"
-msgstr ""
+msgstr "下載 App"
 
 # smartling.placeholder_format=C
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
+msgstr "取得免費的 DuckDuckGo 瀏覽器 %1$s以封鎖 YouTube 廣告。%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -8877,7 +8773,7 @@ msgstr "邀請你的朋友使用DuckDuckGo，並幫助我們成長！"
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
 msgctxt "Accessible label for the product-tour checklist"
 msgid "Getting started checklist"
-msgstr ""
+msgstr "新手入門檢查清單"
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8908,8 +8804,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 "
-"%3$s聊天記錄 › Sync & Backup › 與另一裝置同步 › 複製文字代碼%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 %3$s聊天記錄 › Sync & Backup "
+"› 與另一裝置同步 › 複製文字代碼%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8918,8 +8814,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s"
-"聊天記錄 › Sync & Backup › 與另一裝置同步%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s聊天記錄 › Sync & Backup "
+"› 與另一裝置同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8929,8 +8825,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊"
-"天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
+"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊天 › Sync & Backup › "
+"與其他裝置同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8940,8 +8836,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s"
-"聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s聊天 › Sync & Backup › "
+"與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8955,8 +8851,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr ""
-"前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
+msgstr "前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8964,8 +8859,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
+msgstr "前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9561,7 +9455,7 @@ msgstr "隱藏提示"
 #. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
 msgctxt "Product-tour checklist sheet dismiss button"
 msgid "Hide Tutorial"
-msgstr ""
+msgstr "隱藏教學"
 
 # smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
@@ -9673,9 +9567,7 @@ msgstr "最近活動"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr ""
-"在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定"
-"為預設%6$s"
+msgstr "在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定為預設%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10033,9 +9925,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與"
-"隱私」%2$s。"
+msgstr "如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與隱私」%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10045,8 +9935,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > "
-"網站設定 > 位置%2$s，確認DuckDuckGo是被允許的存取位置。"
+"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > 網站設定 > "
+"位置%2$s，確認DuckDuckGo是被允許的存取位置。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10060,8 +9950,7 @@ msgstr "如果你繼續看到此錯誤，請聯絡 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
+msgstr "如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10069,9 +9958,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 "
-"%2$s 支援頁面。"
+msgstr "若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 %2$s 支援頁面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10079,9 +9966,7 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢"
-"復碼儲存成文字檔，儲存至您的裝置。"
+msgstr "如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢復碼儲存成文字檔，儲存至您的裝置。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10243,9 +10128,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避"
-"免搜尋記錄外洩。%1$s瞭解更多%2$s。"
+msgstr "若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避免搜尋記錄外洩。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10255,9 +10138,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同"
-"步」。"
+msgstr "在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同步」。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10676,9 +10557,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad Network播送。點擊後"
-"會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收"
-"到任何報酬。"
+"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad "
+"Network播送。點擊後會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收到任何報酬。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10686,9 +10566,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安"
-"全。"
+msgstr "比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安全。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11159,7 +11037,7 @@ msgstr "讓你以DuckDuckGo匿名搜尋"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
+msgstr "讓你在提交搜尋查詢與 Duck.ai 提示之間切換"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -11235,7 +11113,7 @@ msgstr "邊線爭球成功次數"
 #. Explains the seven-day share link lifetime.
 msgctxt "Share modal info bullet about link expiry"
 msgid "Link expires in 7 days."
-msgstr ""
+msgstr "連結會在 7 天後到期。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -12331,7 +12209,7 @@ msgstr "超過20分鐘"
 #. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
 msgctxt "Accessible label for the checklist next-page button"
 msgid "More tips"
-msgstr ""
+msgstr "更多提示"
 
 # smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
@@ -12654,9 +12532,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你失去"
-"網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應"
-"的暫時儲存功能。"
+"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
+"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12823,7 +12700,7 @@ msgstr "不了，謝謝"
 #. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
 msgctxt "Product-tour success modal button"
 msgid "No Thanks"
-msgstr ""
+msgstr "不了，謝謝"
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13477,9 +13354,7 @@ msgstr "隨需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設"
-"定%5$s"
+msgstr "在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設定%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -13491,7 +13366,7 @@ msgstr "開啟但不顯示頁數"
 #. Accessible label for the card shown once the onboarding checklist is fully complete.
 msgctxt "Accessible label for the tour-completion card"
 msgid "Onboarding complete"
-msgstr ""
+msgstr "新手引導完成"
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13506,8 +13381,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
+msgstr "附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13704,7 +13578,7 @@ msgstr "開啟「建立與編輯圖片」建議"
 #. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
 msgctxt "Accessible label for the collapsed checklist trigger"
 msgid "Open getting started checklist"
-msgstr ""
+msgstr "開啟新手入門檢查清單"
 
 # smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
@@ -13869,8 +13743,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
+msgstr "即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13889,9 +13762,7 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功"
-"能。提供%1$siOS及Android%2$s版本。"
+msgstr "我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功能。提供%1$siOS及Android%2$s版本。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14143,9 +14014,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找"
-"回通關密語。"
+msgstr "我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找回通關密語。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14345,8 +14214,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常"
-"能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 %1$s搜尋設定%2$s。"
+"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 "
+"%1$s搜尋設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14355,9 +14224,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
-"顯示並且通常能得出更好的答案。 欲調整此功能的運作方式或將其關閉，請造訪 "
-"%1$sDuckAssist 設定%2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能顯示並且通常能得出更好的答案。 "
+"欲調整此功能的運作方式或將其關閉，請造訪 %1$sDuckAssist 設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14367,9 +14235,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
-"自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s "
-"DuckAssist 設定 %2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist "
+"更可能自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s DuckAssist 設定 %2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14401,8 +14268,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
+msgstr "選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14418,8 +14284,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
+msgstr "選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14443,7 +14308,7 @@ msgstr "Pin"
 #. Onboarding checklist item: points the user to pinning a chat in the sidebar.
 msgctxt "Product-tour checklist item title"
 msgid "Pin a chat"
-msgstr ""
+msgstr "釘選聊天"
 
 # smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
@@ -14455,7 +14320,7 @@ msgstr "從 %1$s %2$s 將聊天釘選在此處"
 #. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
 msgctxt "Title of a throwaway sample chat created by the product tour"
 msgid "Pin me"
-msgstr ""
+msgstr "釘選我"
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14478,7 +14343,7 @@ msgstr "已固定"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
+msgstr "置頂的聊天會顯示在你最近的聊天記錄頂端。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14567,9 +14432,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非"
-"法。"
+msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14577,9 +14440,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有"
-"害。"
+msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14793,7 +14654,7 @@ msgstr "格式不佳"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
+msgstr "提供熱門 AI 模型。 無需帳戶。 我們會將聊天內容匿名化。"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15007,7 +14868,7 @@ msgstr "先前的分頁"
 #. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
 msgctxt "Accessible label for the checklist previous-page button"
 msgid "Previous tips"
-msgstr ""
+msgstr "先前的提示"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15549,13 +15410,13 @@ msgstr "具備內建適中審查制度的推理型 AI"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
+msgstr "推理功能可以針對複雜的問題提供更好的回答。"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
+msgstr "推理過程更詳盡，但消耗使用額度的速度快 2—5 倍。%1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -15596,7 +15457,7 @@ msgstr "你可以在「%1$s」中調整「最近的聊天記錄」的設定。"
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
 msgctxt "Product-tour tooltip title"
 msgid "Recent chats"
-msgstr ""
+msgstr "最近的聊天記錄"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
@@ -15604,9 +15465,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
-"中。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15614,9 +15473,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
-"中。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15625,9 +15482,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲"
-"存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15755,7 +15610,7 @@ msgstr "減少使用量"
 #. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce usage with a more efficient model"
-msgstr ""
+msgstr "改用更有效率的模式以減少使用量"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15902,8 +15757,7 @@ msgstr "重新載入 Duck.ai。"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
+msgstr "按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16056,18 +15910,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享"
-"給%1$s來協助改善其服務。"
+msgstr "報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享給%1$s來協助改善其服務。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別"
-"身分的資訊。"
+msgstr "傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16075,9 +15925,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿"
-"名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr "傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16127,7 +15975,7 @@ msgstr "重設所有設定"
 #. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
 msgctxt "Settings button"
 msgid "Reset tutorial"
-msgstr ""
+msgstr "重設教學"
 
 # smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
@@ -16145,7 +15993,7 @@ msgstr "畫質"
 #. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
 msgctxt "Share scope toggle label for a single response"
 msgid "Response"
-msgstr ""
+msgstr "回應"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -16168,9 +16016,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回"
-"答受我們的 %1$s 服務條款%2$s約束。"
+msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回答受我們的 %1$s 服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16178,9 +16024,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist "
-"受我們的%1$s服務條款%2$s約束。"
+msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist 受我們的%1$s服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16190,8 +16034,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁"
-"內容生成，可能會有不準確之處。Search Assist 受我們的 %1$s服務條款%2$s 約束。"
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁內容生成，可能會有不準確之處。Search Assist 受我們的 "
+"%1$s服務條款%2$s 約束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16615,9 +16459,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更"
-"多內容。"
+msgstr "你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更多內容。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16837,7 +16679,7 @@ msgstr "是否要搜尋「%1$s」，找到離你較近的結果？"
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Search & Duck.ai Toggle"
-msgstr ""
+msgstr "搜尋 & Duck.ai 切換開關"
 
 # smartling.placeholder_format=C
 msgid "Search Anonymously"
@@ -16863,18 +16705,16 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相"
-"關內容，然後使用 AI 生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在"
-"點按 Assist 時)、有時 (在高度相關時)，或經常 (在廣泛的搜尋中)。目前，Search "
-"Assist 功能僅供部分英語地區使用。"
+"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相關內容，然後使用 AI "
+"生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在點按 Assist 時)、有時 (在高度相關時)，或經常 "
+"(在廣泛的搜尋中)。目前，Search Assist 功能僅供部分英語地區使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr ""
-"Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
+msgstr "Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16883,8 +16723,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網"
-"路%2$s以尋找相關內容，然後使用 AI 根據找到的資訊生成簡短的答案。"
+"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網路%2$s以尋找相關內容，然後使用 AI "
+"根據找到的資訊生成簡短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17004,9 +16844,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋"
-"「ducks」。"
+msgstr "使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋「ducks」。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17024,9 +16862,7 @@ msgstr "私密搜尋與封鎖追蹤器"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋"
-"功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
+msgstr "使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17045,9 +16881,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 "
-"Cloud Save 將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資"
-"料，且你的通關密語永遠不會離開你的瀏覽器。"
+"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 Cloud Save "
+"將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資料，且你的通關密語永遠不會離開你的瀏覽器。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17165,9 +17000,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步"
-"的裝置存取。"
+msgstr "以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17175,9 +17008,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存"
-"取。"
+msgstr "以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17191,15 +17022,13 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到"
-"你的資料，連我們也不行。"
+msgstr "採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
 msgctxt "Share modal info bullet about encryption"
 msgid "Securely stored on our encrypted server."
-msgstr ""
+msgstr "安全儲存在我們的加密伺服器上。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17599,9 +17428,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有"
-"對話。"
+msgstr "向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有對話。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17702,7 +17529,7 @@ msgstr "設為首頁"
 #. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Set the tone and style of Duck.ai's responses."
-msgstr ""
+msgstr "設定 Duck.ai 回應的語氣與風格。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
@@ -17716,8 +17543,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
+msgstr "開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17772,13 +17598,13 @@ msgstr "塞席爾"
 #. Label for the share action in the chat options menu and on assistant message actions.
 msgctxt "Button for sharing a chat or response"
 msgid "Share"
-msgstr ""
+msgstr "分享"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from an assistant response.
 msgctxt "Title for the share modal when sharing from a response action"
 msgid "Share"
-msgstr ""
+msgstr "分享"
 
 # smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
@@ -17815,16 +17641,14 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透"
-"露你的精確位置。"
+msgstr "與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透露你的精確位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
 msgctxt ""
 "Title for the share modal when sharing an entire chat from the sidebar menu"
 msgid "Share chat"
-msgstr ""
+msgstr "分享聊天"
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17888,7 +17712,7 @@ msgstr "分享正面意見回饋"
 #. ARIA label for the response vs entire chat toggle in the share modal.
 msgctxt "Accessible label for the share scope toggle group"
 msgid "Share scope"
-msgstr ""
+msgstr "分享範圍"
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -18027,7 +17851,7 @@ msgstr "顯示詳情"
 #. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row title"
 msgid "Show Duck.ai tutorial"
-msgstr ""
+msgstr "顯示 Duck.ai 教學"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18180,7 +18004,7 @@ msgstr "顯示更多"
 #. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Show more models"
-msgstr ""
+msgstr "顯示更多模型"
 
 # smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
@@ -18221,7 +18045,7 @@ msgstr "顯示側邊欄"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
+msgstr "顯示逐步提示，以充分利用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18275,18 +18099,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影"
-"響私密搜尋。"
+msgstr "提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影響私密搜尋。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影"
-"響搜尋保護。"
+msgstr "提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影響搜尋保護。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18593,7 +18413,7 @@ msgstr "發生錯誤，請稍後再試。"
 #. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
 msgctxt "Error message shown in the Duck.ai share modal"
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "發生錯誤。請再試一次。"
 
 # smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
@@ -18883,7 +18703,7 @@ msgstr "開始使用每週上限"
 #. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
 msgctxt "Product-tour checklist item title"
 msgid "Start a new chat"
-msgstr ""
+msgstr "開始新的聊天"
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -19465,7 +19285,7 @@ msgctxt ""
 "Accessible name and tooltip for the heading button on an inactive second-"
 "opinion card"
 msgid "Switch to this second opinion"
-msgstr ""
+msgstr "切換到此另一種觀點"
 
 # smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
@@ -19581,19 +19401,16 @@ msgid ""
 msgstr ""
 "同步恢復碼\n"
 "\n"
-"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在"
-"你無法存取某個裝置時恢復你的同步資料。\n"
+"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在你無法存取某個裝置時恢復你的同步資料。\n"
 "\n"
 "確保此資訊安全無虞。\n"
 "任何有權限存取此代碼的人都能存取你同步的資料。%1$s\n"
 "\n"
 "這段代碼是如何運作的？\n"
-"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & "
-"Backup」，然後選擇「恢復已同步的資料」\n"
+"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & Backup」，然後選擇「恢復已同步的資料」\n"
 "3. 複製上方的恢復代碼，並貼到顯示「將你的代碼貼在這裡」的地方\n"
 "\n"
-"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將"
-"從伺服器上刪除，且無法恢復。"
+"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將從伺服器上刪除，且無法恢復。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19617,7 +19434,7 @@ msgstr "同步和備份功能暫時無法使用"
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
 msgctxt "Product-tour checklist item title"
 msgid "Sync chats across devices"
-msgstr ""
+msgstr "跨裝置同步聊天記錄"
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19712,7 +19529,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
+msgstr "隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存取。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -19720,7 +19537,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
+msgstr "隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快速存取。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19957,9 +19774,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第"
-"三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
+msgstr "這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20075,8 +19890,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
+msgstr "在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20108,9 +19922,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設"
-"搜尋引擎，藉此為你造訪的網站新增隱私保護。"
+msgstr "這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設搜尋引擎，藉此為你造訪的網站新增隱私保護。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20173,7 +19985,7 @@ msgstr "本月"
 #. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
 msgctxt "Share scope toggle label after a link is created"
 msgid "This Response"
-msgstr ""
+msgstr "這個回應"
 
 # smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
@@ -20185,7 +19997,7 @@ msgstr "本週"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
+msgstr "此對話會留在 Duck.ai 中，且對你保持私密。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20194,8 +20006,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準"
-"確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %4$s "
+"取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20204,9 +20016,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令"
-"人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
+msgstr "此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20214,9 +20024,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感"
-"的資訊。（更多資訊請參見%2$s）。"
+msgstr "這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感的資訊。（更多資訊請參見%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20226,8 +20034,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能"
-"會顯示不準確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 "
+"(請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20318,7 +20126,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
+msgstr "這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最上方！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -20326,7 +20134,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
+msgstr "這只是一個範例聊天。 使用側邊選單中的 Fire Button 來刪除它！"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -20346,9 +20154,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留"
-"模式。"
+msgstr "此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -20356,9 +20162,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模"
-"式。"
+msgstr "此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -20394,9 +20198,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從"
-"任何瀏覽器存取。"
+msgstr "這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從任何瀏覽器存取。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20404,9 +20206,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
-"可能會再次看到 AI 輔助的答案。"
+msgstr "此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI 輔助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -20416,9 +20216,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
-"可能會再次看到 AI 輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 "
-"AI 輔助答案。"
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI "
+"輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 AI 輔助答案。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -20457,8 +20256,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然"
-"可以在連接到 Sync & Backup 的其他瀏覽器中存取您的聊天記錄。"
+"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然可以在連接到 Sync & Backup "
+"的其他瀏覽器中存取您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -20603,9 +20402,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖"
-"示。%4$s"
+msgstr "如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖示。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -20614,9 +20411,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲"
-"存在您最初用於設定同步的裝置上。"
+msgstr "若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲存在您最初用於設定同步的裝置上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -20624,9 +20419,7 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再"
-"試一次。"
+msgstr "欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再試一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20655,7 +20448,7 @@ msgstr "今天"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
+msgstr "切換開關即可試用私密 AI 聊天，或%1$s在 %2$s 功能表中停用%3$s。"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20875,8 +20668,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
+msgstr "將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20884,8 +20676,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
+msgstr "將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21068,7 +20859,7 @@ msgstr "試試看"
 #. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
 msgctxt "Product-tour checklist item title"
 msgid "Try a different model"
-msgstr ""
+msgstr "嘗試其他模型"
 
 # smartling.placeholder_format=C
 #. Alternate header text for front page
@@ -21079,7 +20870,7 @@ msgstr "試試搜尋一下！"
 #. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
 msgctxt "Product-tour highlight tooltip"
 msgid "Try a suggestion"
-msgstr ""
+msgstr "試試建議"
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -21147,7 +20938,7 @@ msgstr "免費試用"
 #. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Try for free"
-msgstr ""
+msgstr "免費試用"
 
 # smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
@@ -21167,7 +20958,7 @@ msgstr "免費試用！安全的 VPN、先進的& Private AI 等。"
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
 msgctxt "Subtitle under the Unlock advanced models row"
 msgid "Try free for 7 days"
-msgstr ""
+msgstr "免費試用 7 天"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -21200,7 +20991,7 @@ msgstr "試試我們從來不會顯示這些訊息的首頁："
 #. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
 msgctxt "Product-tour checklist item title"
 msgid "Try reasoning"
-msgstr ""
+msgstr "嘗試推理型"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -21314,9 +21105,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設"
-"定。 %3$s瞭解更多%4$s"
+msgstr "想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -21324,9 +21113,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設"
-"定。 %3$s瞭解更多%4$s"
+msgstr "想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -21451,7 +21238,7 @@ msgstr "開啟 Duck Player 即可觀看不受廣告鎖定干擾的 YouTube 影�
 #. Button that enables the Search/Duck.ai toggle.
 msgctxt "new tab page"
 msgid "Turn on Duck.ai Toggle"
-msgstr ""
+msgstr "開啟 Duck.ai 切換開關"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -21514,9 +21301,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延"
-"遲。"
+msgstr "在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延遲。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21767,9 +21552,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus "
-"方案的使用上限。"
+msgstr "透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus 方案的使用上限。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21815,7 +21598,7 @@ msgstr "訂閱後即可解鎖進階的 AI！"
 #. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
 msgctxt "Title of the row that opens the subscription modal"
 msgid "Unlock advanced models"
-msgstr ""
+msgstr "解鎖進階模型"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -22133,9 +21916,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵"
-"害。對資訊保密。免費。不需要帳戶。"
+msgstr "私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵害。對資訊保密。免費。不需要帳戶。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22175,7 +21956,7 @@ msgstr "用於Safari"
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
+msgstr "使用「Fire Button」按鈕從歷史紀錄中刪除聊天。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -22339,8 +22120,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -22348,9 +22128,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管"
-"理。"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -22392,8 +22170,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & Backup%4$s > "
+"%5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22403,8 +22181,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & Backup」下選取"
-"「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & "
+"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -22414,8 +22192,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設"
-"定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -22425,9 +22203,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在"
-"「Sync & Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 "
-"PDF 上的二維碼。"
+"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在「Sync & "
+"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -22622,9 +22399,7 @@ msgstr "在 Duck Player 中觀看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推"
-"播干擾。"
+msgstr "在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推播干擾。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -22644,8 +22419,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內"
-"容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube 沒有任何關係。"
+"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube "
+"沒有任何關係。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -22668,9 +22443,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo "
-"分享此對話，以便我們調查並處理該問題。"
+msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo 分享此對話，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -22681,9 +22454,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的"
-"提示詞與回覆內容，以便我們調查並處理該問題。"
+msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的提示詞與回覆內容，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22723,8 +22494,7 @@ msgstr "我們不會儲存你的個人資訊。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr ""
-"我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
+msgstr "我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22745,8 +22515,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
+msgstr "本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22785,9 +22554,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr ""
-"我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告"
-"商。"
+msgstr "我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告商。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22812,9 +22579,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智"
-"慧。"
+msgstr "我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智慧。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22846,9 +22611,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主"
-"意。"
+msgstr "我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主意。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22874,9 +22637,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立"
-"刻出現。"
+msgstr "我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立刻出現。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23040,9 +22801,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會"
-"用來訓練人工智慧模型。"
+msgstr "歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23050,9 +22809,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名"
-"化，且不會用來訓練人工智慧模型。"
+msgstr "歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23062,8 +22819,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這"
-"裡的所有聊天內容都是私密的，且永遠不會被 DuckDuckGo 儲存或用來訓練 AI 模型。"
+"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這裡的所有聊天內容都是私密的，且永遠不會被 "
+"DuckDuckGo 儲存或用來訓練 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23189,9 +22946,8 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 "
-"DuckDuckGo 來源。將回應分成清晰的部分，並以 Duck.ai 整合和隱私保護為重點。對"
-"於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
+"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 DuckDuckGo 來源。將回應分成清晰的部分，並以 "
+"Duck.ai 整合和隱私保護為重點。對於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -23306,7 +23062,7 @@ msgstr "你今天為何又回來了？"
 #. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
 msgctxt "Sample user message inside the throwaway product-tour chat"
 msgid "What can you do?"
-msgstr ""
+msgstr "你可以做什麼？"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -23726,7 +23482,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
+msgstr "使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時在「%1$s」選單中將其開啟或關閉。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24051,8 +23807,7 @@ msgstr "你最多可以附加 %1$s 個文字選擇。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
+msgstr "你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24072,8 +23827,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
+msgstr "你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24145,7 +23899,7 @@ msgstr "每次對話只能附加 %1$s 張圖片"
 msgctxt ""
 "Error message when the number of attached browser tabs exceeds the limit"
 msgid "You can only attach %s tabs at a time."
-msgstr ""
+msgstr "你一次只能附加 %1$s 個分頁。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -24221,9 +23975,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高"
-"出 2 倍的使用上限。"
+msgstr "您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高出 2 倍的使用上限。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -24231,9 +23983,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 "
-"DuckDuckGo 訂閱保護功能。"
+msgstr "你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 DuckDuckGo 訂閱保護功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -24254,9 +24004,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
-"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -24265,9 +24013,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
-"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -24286,7 +24032,7 @@ msgstr "一旦您擁有最新版本，您將收到自動 DuckDuckGo 應用程式
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
 msgctxt "Heading shown while the completion celebration (confetti) plays"
 msgid "You're all set!"
-msgstr ""
+msgstr "一切就緒！"
 
 # smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
@@ -24294,9 +24040,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏"
-"覽。應用程式已經安裝完畢，而且可以："
+msgstr "你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏覽。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -24337,7 +24081,7 @@ msgstr "您已封鎖 1 個網站"
 #. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
 msgctxt "Product-tour success modal title"
 msgid "You've mastered the basics of Duck.ai"
-msgstr ""
+msgstr "你已掌握 Duck.ai 的基礎"
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -24383,9 +24127,7 @@ msgctxt "Sync file storage limit modal description"
 msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
-msgstr ""
-"您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的"
-"聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr "您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -24394,9 +24136,7 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats. Delete the %s "
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
-msgstr ""
-"您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件"
-"聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr "您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -24409,9 +24149,7 @@ msgstr "你的儲存空間已用完"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/"
-"Google追蹤。"
+msgstr "YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/Google追蹤。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -24454,9 +24192,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
-"中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -24465,9 +24201,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
-"中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -24531,16 +24265,14 @@ msgstr "您的聊天內容是私密的，且絕不會用於訓練 AI 模型"
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -24568,9 +24300,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些"
-"步驟保留您的聊天記錄。"
+msgstr "您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些步驟保留您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -24609,8 +24339,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
+msgstr "你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -24652,10 +24381,7 @@ msgid ""
 "known as %sSHA-2%s. Only the key and associated settings file leave your "
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
-msgstr ""
-"我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。"
-"只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔"
-"案。DuckDuckGo不會知道你的通關密語。"
+msgstr "我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔案。DuckDuckGo不會知道你的通關密語。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24669,9 +24395,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者"
-"無法將你的對話與你連結起來。"
+msgstr "你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者無法將你的對話與你連結起來。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -24715,7 +24439,7 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr ""
+msgstr "你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -24724,8 +24448,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No "
-"AI%2$s 擴充套件以使其永久生效。 %3$s瞭解更多%4$s"
+"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。 "
+"%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -24744,9 +24468,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得"
-"更全面的保護。應用程式已經安裝完畢，而且可以："
+msgstr "你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得更全面的保護。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -24762,8 +24484,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
+msgstr "您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25303,4 +25024,4 @@ msgstr "年"
 #. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
 msgctxt "Product-tour tooltip action"
 msgid "→"
-msgstr ""
+msgstr "→"

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -124,6 +124,12 @@ msgid "%s detected"
 msgstr "偵測到%1$s"
 
 # smartling.placeholder_format=C
+#. Shown under a shared user message when multiple uploaded files were omitted from the share. %s is the file count (always 2 or more).
+msgctxt "Caption under a shared user prompt with multiple hidden attachments"
+msgid "%s files used"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a follower count below a web search result.
 msgctxt "Rich Facts label"
 msgid "%s followers"
@@ -175,7 +181,9 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
+msgstr ""
+"%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換"
+"至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -184,7 +192,9 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
+msgstr ""
+"%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切"
+"換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -199,7 +209,9 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或切換至免費模式。"
+msgstr ""
+"%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或"
+"切換至免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -298,8 +310,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s 運行於受信任執行環境（Trusted Execution "
-"Environment）。這表示即使是模型提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
+"%1$s 運行於受信任執行環境（Trusted Execution Environment）。這表示即使是模型"
+"提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -343,6 +355,12 @@ msgid "%s used"
 msgstr "%1$s 已使用"
 
 # smartling.placeholder_format=C
+#. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
+msgctxt "Dismissible new-chat banner when Opus is selected"
+msgid "%s uses limits up to 2-5x faster than basic models %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
 msgid "%s view"
 msgstr "%1$s 檢視"
@@ -378,7 +396,8 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
+msgstr ""
+"%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -388,7 +407,8 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
+msgstr ""
+"%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -416,7 +436,8 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr "%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
+msgstr ""
+"%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -574,6 +595,12 @@ msgstr "在過去 24 小時內，有 1 次嘗試被 DuckDuckGo 封鎖"
 msgctxt "published dates for organic results"
 msgid "1 day ago"
 msgstr "1天前"
+
+# smartling.placeholder_format=C
+#. Shown under a shared user message when exactly one uploaded file was omitted from the share.
+msgctxt "Caption under a shared user prompt with one hidden attachment"
+msgid "1 file used"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -854,7 +881,8 @@ msgstr "客場戰績"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
+msgstr ""
+"網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -912,8 +940,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo Search 上的 AI Chat "
-"功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/aichat%2$s 使用 AI Chat 功能。"
+"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo "
+"Search 上的 AI Chat 功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/"
+"aichat%2$s 使用 AI Chat 功能。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -974,8 +1003,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck.ai%2$s 以回答後續問題，這是我們的私密 AI "
-"驅動的聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
+"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck."
+"ai%2$s 以回答後續問題，這是我們的私密 AI 驅動的聊天服務，支援來自 OpenAI、"
+"Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1466,6 +1496,14 @@ msgid "Advanced Models"
 msgstr "進階模型"
 
 # smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
+msgctxt ""
+"Always-visible warning banner shown above the recommended models in the "
+"model picker dropdown"
+msgid "Advanced models can use limits 2-5x faster than other models. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
 msgid "Advertise on Search"
 msgstr "刊登搜尋廣告"
@@ -1640,7 +1678,9 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr "所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型供應商用於訓練聊天模型"
+msgstr ""
+"所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型"
+"供應商用於訓練聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1686,7 +1726,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會被移除。"
+msgstr ""
+"在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會"
+"被移除。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1749,8 +1791,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期限有限的搜尋引擎。%2$s "
-"的提示和回應仍具有%3$s零提供者可見度%4$s。"
+"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期"
+"限有限的搜尋引擎。%2$s 的提示和回應仍具有%3$s零提供者可見度%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1915,7 +1957,8 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
+msgstr ""
+"根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2088,7 +2131,9 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr "你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天記錄一併刪除。"
+msgstr ""
+"你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天"
+"記錄一併刪除。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2125,7 +2170,9 @@ msgstr "更新時間："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業皆於你的裝置上進行。"
+msgstr ""
+"根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業"
+"皆於你的裝置上進行。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2223,6 +2270,12 @@ msgid "Ask privately"
 msgstr "私下詢問"
 
 # smartling.placeholder_format=C
+#. Placeholder text for the Duck.ai prompt input on the Chrome New Tab Page, shown when the Search/Duck.ai toggle is set to Duck.ai.
+msgctxt "new tab page"
+msgid "Ask privately"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. The name of the Assamese language
 msgctxt "language_name"
 msgid "Assamese"
@@ -2255,9 +2308,10 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 "
-"Assist 使用介面)、隨選 (僅在點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 "
-"(在更廣泛的搜尋中更頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
+"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想"
+"要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 Assist 使用介面)、隨選 (僅在"
+"點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更"
+"頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2269,8 +2323,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI "
-"協助的搜尋查詢答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的。"
+"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI 協助的搜尋查詢答案。"
+"為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言"
+"技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並"
+"根據%1$s搜耙網路%2$s自動產生的。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2432,7 +2488,9 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，Assist 僅供英語地區使用。"
+msgstr ""
+"自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜"
+"尋結果。目前，Assist 僅供英語地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2441,8 +2499,8 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，DuckAssist "
-"僅供說英文的地區使用。"
+"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應"
+"某些搜尋結果。目前，DuckAssist 僅供說英文的地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2647,7 +2705,9 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr "在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身份資訊，將你的對話匿名化。"
+msgstr ""
+"在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身"
+"份資訊，將你的對話匿名化。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3027,20 +3087,26 @@ msgstr "瀏覽檔案"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr ""
+"享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組"
+"合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr ""
+"你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執"
+"行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
+msgstr ""
+"你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽"
+"器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3147,15 +3213,18 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使用匿名的 Could Save "
-"以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
+"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使"
+"用匿名的 Could Save 以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別"
+"的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
+msgstr ""
+"啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始"
+"之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3163,7 +3232,9 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
+msgstr ""
+"啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開"
+"始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3647,9 +3718,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 "
-"DuckDuckGo Search 上的聊天按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s "
-"直接使用聊天功能。"
+"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 "
+"OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo Search 上的聊天按鈕和連"
+"結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 直接使用聊天功"
+"能。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3726,6 +3798,12 @@ msgid "Chat privately with AI"
 msgstr "與 AI 私密聊天"
 
 # smartling.placeholder_format=C
+#. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
+msgctxt "new tab page"
+msgid "Chat privately with Popular AIs"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Option for feedback when the chat response is below expectations.
 msgctxt "Feedback option for chat response below expectations"
 msgid "Chat response is below expectations"
@@ -3773,7 +3851,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用聊天記錄將刪除置頂的聊天。"
+msgstr ""
+"聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用"
+"聊天記錄將刪除置頂的聊天。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -3785,8 +3865,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
-"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 "
+"DuckDuckGo 伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置"
+"頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -3808,7 +3889,9 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr "與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴供應商匿名審核，以用於 %2$s。"
+msgstr ""
+"與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴"
+"供應商匿名審核，以用於 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4159,7 +4242,9 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr "清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
+msgstr ""
+"清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近"
+"的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4169,8 +4254,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期保存，或在不使用 Duck.ai 的情況下 7 "
-"天後自動刪除，視您的瀏覽器而定。"
+"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期"
+"保存，或在不使用 Duck.ai 的情況下 7 天後自動刪除，視您的瀏覽器而定。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4187,8 +4272,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私人 AI 聊天服務，支援來自 "
-"OpenAI、Anthropic 等的聊天模型。"
+"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私"
+"人 AI 聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4349,7 +4434,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
+msgstr ""
+"按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏"
+"覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4359,7 +4446,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
+msgstr ""
+"按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的"
+"瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4477,6 +4566,12 @@ msgid "Close"
 msgstr "關閉"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button in the header of the mobile onboarding-checklist bottom sheet. This only closes the sheet and keeps the tour available; the separate 'Hide Tutorial' action dismisses the tour entirely and can be re-enabled in settings.
+msgctxt "Accessible label for the checklist sheet close button"
+msgid "Close"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Aria label for the close button in the image lightbox.
 msgctxt "Aria label for image lightbox close button"
 msgid "Close"
@@ -4519,6 +4614,12 @@ msgctxt ""
 "Accessibility label for the button that exits chat search mode in Duck.ai"
 msgid "Close search"
 msgstr "關閉搜尋"
+
+# smartling.placeholder_format=C
+#. Removes the second-opinion card and returns to the original answer.
+msgctxt "Accessible label for a close (X) button"
+msgid "Close second opinion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Accessibility label for closing the batch actions toolbar. The Batch Action toolbar is used to perform actions on multiple chats in the chat history list.
@@ -4622,7 +4723,8 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
+msgstr ""
+"Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -4890,6 +4992,12 @@ msgid "Continue Blocking Ads"
 msgstr "繼續封鎖廣告"
 
 # smartling.placeholder_format=C
+#. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
+msgctxt "Product-tour tooltip description"
+msgid "Continue recent chats here. Or delete them with the fire button."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
 msgctxt "AI Chat - Tooltip for selecting a response in chat action"
 msgid "Continue with this model"
@@ -4955,6 +5063,12 @@ msgid "Cookie data:"
 msgstr "Cookie資料："
 
 # smartling.placeholder_format=C
+#. Temporary label shown on the copy button after a successful copy.
+msgctxt "Confirmation label after copying a share link"
+msgid "Copied"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short confirmation announcement shown to the user after copying the recovery code.
 msgctxt "Confirmation label after the recovery code has been copied"
 msgid "Copied"
@@ -5000,6 +5114,12 @@ msgstr "複製%1$sabout:preferences#search%2$s並在網址列貼上"
 msgctxt "Text for a button for copying preformatted code block content"
 msgid "Copy Code"
 msgstr "複製代碼"
+
+# smartling.placeholder_format=C
+#. Title-case button label in the Duck.ai share modal that copies the generated share URL.
+msgctxt "Button to copy the share link to the clipboard"
+msgid "Copy Link"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for the copy button on the Scan QR tab.
@@ -5115,6 +5235,12 @@ msgid "Create Image"
 msgstr "建立圖像"
 
 # smartling.placeholder_format=C
+#. Title-case primary button label in the Duck.ai share modal that creates an encrypted share link.
+msgctxt "Primary button to create a share link"
+msgid "Create Share Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
@@ -5156,6 +5282,14 @@ msgstr "建立者"
 msgctxt "Label copy indicating the creator of an AI Model"
 msgid "Created by %s"
 msgstr "建立者 %1$s"
+
+# smartling.placeholder_format=C
+#. Explains that anyone with the link can view the shared copy.
+msgctxt "Share modal info bullet about public access"
+msgid ""
+"Creating a link makes a copy of the chat that can be viewed by anyone who "
+"opens it."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5309,6 +5443,12 @@ msgstr "自訂回應"
 msgctxt "Label for customizing Duck.ai"
 msgid "Customize responses"
 msgstr "自訂回應"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the customize-responses modal so the user can tailor how Duck.ai replies.
+msgctxt "Product-tour checklist item title"
+msgid "Customize responses"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. The help text shown to users to indicate that there's a menu that can be used to customize the layout of the page
@@ -5593,10 +5733,22 @@ msgid "Delete Server Data?"
 msgstr "刪除伺服器資料？"
 
 # smartling.placeholder_format=C
+#. Title-case destructive button label in the Duck.ai share modal that deletes the shared link.
+msgctxt "Button to revoke a share link"
+msgid "Delete Shared Link"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button text to delete a voice chat transcript.
 msgctxt "voice chat transcript"
 msgid "Delete Transcript"
 msgstr "刪除逐字稿"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: completed when the user deletes a chat using the Fire Button.
+msgctxt "Product-tour checklist item title"
+msgid "Delete a chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip text that appears when hovering over the delete chat button in the chat history list.
@@ -5629,6 +5781,12 @@ msgstr "刪除圖片"
 msgctxt "Title for delete image confirmation modal"
 msgid "Delete image?"
 msgstr "刪除圖片？"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Delete a chat' tour step creates so the user can practice deleting without removing a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Delete me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the file storage sync quota (5GB).
@@ -5771,7 +5929,9 @@ msgstr "聽寫功能暫時無法使用"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 Duck.ai 中聊天。"
+msgstr ""
+"語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 "
+"Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -5935,6 +6095,12 @@ msgid "Dismiss promotion"
 msgstr "關閉促銷廣告"
 
 # smartling.placeholder_format=C
+#. Accessible label for the close (X) button that dismisses the onboarding checklist.
+msgctxt "Accessible label for the checklist dismiss button"
+msgid "Dismiss tour"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessible label for the close button in the Duck.ai usage limit banner.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Dismiss usage limit warning"
@@ -6076,7 +6242,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr "不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖片。 %3$s瞭解更多%4$s"
+msgstr ""
+"不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖"
+"片。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6084,7 +6252,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr "不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖片的搜尋。%3$s瞭解更多%4$s"
+msgstr ""
+"不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖"
+"片的搜尋。%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6139,6 +6309,12 @@ msgstr "下載完成"
 msgctxt "Browser Promo Popover"
 msgid "Download DuckDuckGo"
 msgstr "下載 DuckDuckGo"
+
+# smartling.placeholder_format=C
+#. Button on the onboarding completion modal that links to download the DuckDuckGo app.
+msgctxt "Product-tour completion modal button"
+msgid "Download DuckDuckGo"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo browser when clicked
@@ -6348,13 +6524,21 @@ msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
 msgstr "Duck.ai 由 DuckDuckGo 提供。私人 AI 聊天。免費。"
 
 # smartling.placeholder_format=C
+#. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
+msgctxt "Promotional text for PDF upload feature"
+msgid "Duck.ai can now analyze PDFs. Give it a try!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Description explaining how the page context feature works in Duck.ai sidebar.
 msgctxt "Description text for the page context onboarding modal"
 msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr "Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包含，除非你在設定中選擇自動附加頁面。"
+msgstr ""
+"Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包"
+"含，除非你在設定中選擇自動附加頁面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6363,7 +6547,9 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任何擴充套件，然後再試一次。"
+msgstr ""
+"Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任"
+"何擴充套件，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6386,7 +6572,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重新掌控個人資訊的人。"
+msgstr ""
+"Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重"
+"新掌控個人資訊的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6400,7 +6588,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁：https://duck.ai"
+msgstr ""
+"Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁："
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6414,7 +6604,8 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr ""
+"Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6435,8 +6626,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，但你仍然可以造訪 %1$sduck.ai%2$s "
-"直接使用。"
+"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，"
+"但你仍然可以造訪 %1$sduck.ai%2$s 直接使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6447,9 +6638,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo "
-"Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 "
-"Duck.ai使用聊天功能。"
+"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。"
+"關閉此設定將隱藏 DuckDuckGo Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定"
+"後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 Duck.ai使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6479,6 +6670,12 @@ msgid ""
 msgstr "Duck.ai 的回應不是根據特定來源，也尚未確認準確性。"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
 msgctxt "duckai_migration"
 msgid "Duck.ai update"
@@ -6504,8 +6701,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需註冊的 AI "
-"聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點的 AI、無需帳號的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需"
+"註冊的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點"
+"的 AI、無需帳號的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6533,9 +6731,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 "
-"DuckAssist UI)、隨選 (僅在點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁地顯示)。目前 "
-"DuckAssist 僅供美國 (英文) 地區使用。"
+"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 "
+"DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 DuckAssist UI)、隨選 (僅在"
+"點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁"
+"地顯示)。目前 DuckAssist 僅供美國 (英文) 地區使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6544,8 +6743,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
-"OpenAI 和 Anthropic 等聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這"
+"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6554,8 +6753,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
-"OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這"
+"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6567,8 +6766,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 "
-"AI 驅動的自然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，尚未確認準確性。"
+"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了"
+"完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 AI 驅動的自"
+"然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，"
+"尚未確認準確性。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -6582,10 +6783,11 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist "
-""
-"是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。DuckAssist "
-"的回應始終直接連結至一個或兩個來源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
+"DuckAssist 是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完"
+"成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，"
+"根據找到的相關資訊產生簡短的答案。DuckAssist 的回應始終直接連結至一個或兩個來"
+"源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是"
+"從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -6608,7 +6810,9 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
+"%3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -6616,7 +6820,9 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
+"%3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -6632,7 +6838,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr ""
+"DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件"
+"傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6764,14 +6972,17 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資訊來匿名化這些報告。"
+msgstr ""
+"DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資"
+"訊來匿名化這些報告。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
+msgstr ""
+"DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -6787,7 +6998,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤器，它們經常試圖在你造訪其他網站時追蹤你。"
+msgstr ""
+"DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤"
+"器，它們經常試圖在你造訪其他網站時追蹤你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -6798,7 +7011,11 @@ msgid ""
 "use it to improve results for that search, and then we promptly throw it "
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
-msgstr "DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保護你的隱私%2$s。"
+msgstr ""
+"DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置"
+"上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我"
+"們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保"
+"護你的隱私%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -6817,7 +7034,9 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更接近你的搜尋結果。%1$s瞭解更多%2$s。"
+msgstr ""
+"DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更"
+"接近你的搜尋結果。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -6902,7 +7121,10 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr "當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18至20個字元。"
+msgstr ""
+"當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我"
+"們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18"
+"至20個字元。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7069,6 +7291,12 @@ msgid "Enable Most-Visited Sites"
 msgstr "啟用最常造訪的網站"
 
 # smartling.placeholder_format=C
+#. Button text in the modal that links Firefox users to the DuckDuckGo extension add-on page so they can enable the installed No AI extension.
+msgctxt "settings"
+msgid "Enable Now"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Recent Chats feature, a feature that stores the user's most recent chats.
 msgctxt "Label for enabling recent chats feature"
 msgid "Enable Recent Chats"
@@ -7145,7 +7373,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保密。"
+msgstr ""
+"啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保"
+"密。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7306,7 +7536,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關密語下。"
+msgstr ""
+"輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關"
+"密語下。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7331,7 +7563,8 @@ msgstr "輸入文字"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
+msgstr ""
+"輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -7356,6 +7589,12 @@ msgstr "輸入通關密語以載入你的設定。"
 msgctxt "Assistant role option label for Entertainment guide"
 msgid "Entertainment guide"
 msgstr "娛樂指南"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share the full conversation in the Duck.ai share modal.
+msgctxt "Share scope toggle label for the full chat"
+msgid "Entire Chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Equatorial Guinea"
@@ -7519,6 +7758,18 @@ msgid "Explicit lyrics"
 msgstr "成人內容歌詞"
 
 # smartling.placeholder_format=C
+#. Text shown next to the Duck.ai duck icon on the mobile onboarding-checklist entry pill. Names the getting-started tour the button opens; 'Duck.ai' is the product name and should not be translated.
+msgctxt "Label on the mobile product-tour entry button"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Shared title across every page of the Duck.ai sidebar/mobile getting-started checklist ('Explore Duck.ai').
+msgctxt "Product-tour checklist group title"
+msgid "Explore Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
@@ -7620,6 +7871,12 @@ msgid "FREE"
 msgstr "免費"
 
 # smartling.placeholder_format=C
+#. Pill badge on the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. All caps by design; adapt casing to what suits your language.
+msgctxt "new tab page"
+msgid "FREE & OPTIONAL"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Full-time (match has ended) indicator in a soccer match
 msgctxt "Sports module"
 msgid "FT"
@@ -7683,7 +7940,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的問題。"
+msgstr ""
+"像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的"
+"問題。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -7920,7 +8179,8 @@ msgstr "多霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
+msgstr ""
+"按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8020,6 +8280,12 @@ msgstr "免費方案"
 msgctxt "Sync file storage inline disclaimer primary button"
 msgid "Free Up Storage"
 msgstr "釋放儲存空間"
+
+# smartling.placeholder_format=C
+#. Secondary text under the app-download row, emphasising the app is free and private.
+msgctxt "Subtitle under the Download the app row"
+msgid "Free and always private"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
@@ -8142,8 +8408,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> "
-"&gt;<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
+"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> &gt;"
+"<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -8493,7 +8759,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
+msgstr ""
+"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
+"隱私權保護。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -8503,7 +8771,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
+msgstr ""
+"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
+"隱私權保護。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -8527,6 +8797,12 @@ msgstr "在 DuckDuckGo 說明中取得解答。"
 msgctxt "Brief for getting computer help"
 msgid "Get computer help"
 msgstr "取得電腦協助"
+
+# smartling.placeholder_format=C
+#. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Get higher usage limits with a DuckDuckGo subscription."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -8564,6 +8840,18 @@ msgid "Get the Latest Version"
 msgstr "取得最新版本"
 
 # smartling.placeholder_format=C
+#. Row that links to downloading the DuckDuckGo app after finishing the tour.
+msgctxt "Title of the app-download row on the completion card"
+msgid "Get the app"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
+msgctxt "Browser Promo Popover"
+msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
 msgctxt "Covid 19 module"
 msgid "Get the latest information:"
@@ -8584,6 +8872,12 @@ msgstr "在這兒取得歌曲："
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
 msgstr "邀請你的朋友使用DuckDuckGo，並幫助我們成長！"
+
+# smartling.placeholder_format=C
+#. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
+msgctxt "Accessible label for the product-tour checklist"
+msgid "Getting started checklist"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Ghana"
@@ -8614,8 +8908,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 %3$s聊天記錄 › Sync & Backup "
-"› 與另一裝置同步 › 複製文字代碼%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 "
+"%3$s聊天記錄 › Sync & Backup › 與另一裝置同步 › 複製文字代碼%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -8624,8 +8918,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s聊天記錄 › Sync & Backup "
-"› 與另一裝置同步%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s"
+"聊天記錄 › Sync & Backup › 與另一裝置同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -8635,8 +8929,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊天 › Sync & Backup › "
-"與其他裝置同步%4$s，然後掃描此代碼："
+"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊"
+"天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -8646,8 +8940,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s聊天 › Sync & Backup › "
-"與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s"
+"聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8661,7 +8955,8 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr "前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
+msgstr ""
+"前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8669,7 +8964,8 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9262,6 +9558,12 @@ msgid "Hide Tips"
 msgstr "隱藏提示"
 
 # smartling.placeholder_format=C
+#. Button at the foot of the onboarding component that dismisses the tour entirely; the user can re-enable it from settings.
+msgctxt "Product-tour checklist sheet dismiss button"
+msgid "Hide Tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the button to enable the site exclusion feature
 msgctxt "Exclusion message re-enable button"
 msgid "Hide blocked sites from results"
@@ -9371,7 +9673,9 @@ msgstr "最近活動"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr "在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定為預設%6$s"
+msgstr ""
+"在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定"
+"為預設%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -9729,7 +10033,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與隱私」%2$s。"
+msgstr ""
+"如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與"
+"隱私」%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -9739,8 +10045,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > 網站設定 > "
-"位置%2$s，確認DuckDuckGo是被允許的存取位置。"
+"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > "
+"網站設定 > 位置%2$s，確認DuckDuckGo是被允許的存取位置。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -9754,7 +10060,8 @@ msgstr "如果你繼續看到此錯誤，請聯絡 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
+msgstr ""
+"如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -9762,7 +10069,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 %2$s 支援頁面。"
+msgstr ""
+"若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 "
+"%2$s 支援頁面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -9770,7 +10079,9 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢復碼儲存成文字檔，儲存至您的裝置。"
+msgstr ""
+"如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢"
+"復碼儲存成文字檔，儲存至您的裝置。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -9932,7 +10243,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避免搜尋記錄外洩。%1$s瞭解更多%2$s。"
+msgstr ""
+"若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避"
+"免搜尋記錄外洩。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -9942,7 +10255,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同步」。"
+msgstr ""
+"在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同"
+"步」。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10361,8 +10676,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad "
-"Network播送。點擊後會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收到任何報酬。"
+"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad Network播送。點擊後"
+"會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收"
+"到任何報酬。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -10370,7 +10686,9 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安全。"
+msgstr ""
+"比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安"
+"全。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -10837,6 +11155,13 @@ msgid "Lets you search anonymously with DuckDuckGo"
 msgstr "讓你以DuckDuckGo匿名搜尋"
 
 # smartling.placeholder_format=C
+#. Description shown under the 'Search & Duck.ai Toggle' entry in the 'Customize New Tab Page' menu, explaining what the toggle does.
+msgctxt "new tab page"
+msgid ""
+"Lets you switch between submitting search queries and prompts to Duck.ai"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Liberia"
 msgstr "賴比瑞亞"
 
@@ -10905,6 +11230,12 @@ msgstr "線圖"
 msgctxt "Sports module"
 msgid "Lineouts Won"
 msgstr "邊線爭球成功次數"
+
+# smartling.placeholder_format=C
+#. Explains the seven-day share link lifetime.
+msgctxt "Share modal info bullet about link expiry"
+msgid "Link expires in 7 days."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -11997,6 +12328,12 @@ msgid "More than 20 minutes"
 msgstr "超過20分鐘"
 
 # smartling.placeholder_format=C
+#. Accessible label for the right chevron button that navigates the onboarding checklist card to the next page of tips.
+msgctxt "Accessible label for the checklist next-page button"
+msgid "More tips"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. e.g. More ways to add DuckDuckGo to Firefox
 msgctxt "frontpage"
 msgid "More ways to add DuckDuckGo to %s"
@@ -12317,8 +12654,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
-"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你失去"
+"網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應"
+"的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -12480,6 +12818,12 @@ msgstr "不了，謝謝"
 msgctxt "DuckChat web search permission prompt for encrypted models"
 msgid "No Thanks"
 msgstr "不了，謝謝"
+
+# smartling.placeholder_format=C
+#. Button that closes the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal button"
+msgid "No Thanks"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Text describing how DuckDuckGo doesn't track its users.
@@ -13133,13 +13477,21 @@ msgstr "隨需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設定%5$s"
+msgstr ""
+"在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設"
+"定%5$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
 msgctxt "setting"
 msgid "On but no numbers"
 msgstr "開啟但不顯示頁數"
+
+# smartling.placeholder_format=C
+#. Accessible label for the card shown once the onboarding checklist is fully complete.
+msgctxt "Accessible label for the tour-completion card"
+msgid "Onboarding complete"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message shown to the user while they are waiting for a connection to a new voice chat session to be established.
@@ -13154,7 +13506,8 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
+msgstr ""
+"附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -13348,6 +13701,12 @@ msgid "Open create and edit images suggestions"
 msgstr "開啟「建立與編輯圖片」建議"
 
 # smartling.placeholder_format=C
+#. Accessible label for the icon button that opens the onboarding checklist when the sidebar is collapsed.
+msgctxt "Accessible label for the collapsed checklist trigger"
+msgid "Open getting started checklist"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Button that opens a third party app. Placeholder is the name of the app. For example: 'Open in TripAdvisor'
 msgctxt "open_in_third_party_app"
 msgid "Open in %s"
@@ -13510,7 +13869,8 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
+msgstr ""
+"即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -13529,7 +13889,9 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功能。提供%1$siOS及Android%2$s版本。"
+msgstr ""
+"我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功"
+"能。提供%1$siOS及Android%2$s版本。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -13781,7 +14143,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找回通關密語。"
+msgstr ""
+"我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找"
+"回通關密語。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -13981,8 +14345,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 "
-"%1$s搜尋設定%2$s。"
+"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常"
+"能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 %1$s搜尋設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -13991,8 +14355,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能顯示並且通常能得出更好的答案。 "
-"欲調整此功能的運作方式或將其關閉，請造訪 %1$sDuckAssist 設定%2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
+"顯示並且通常能得出更好的答案。 欲調整此功能的運作方式或將其關閉，請造訪 "
+"%1$sDuckAssist 設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14002,8 +14367,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist "
-"更可能自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s DuckAssist 設定 %2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
+"自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s "
+"DuckAssist 設定 %2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14035,7 +14401,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
+msgstr ""
+"選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14051,7 +14418,8 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
+msgstr ""
+"選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -14072,10 +14440,22 @@ msgid "Pin"
 msgstr "Pin"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to pinning a chat in the sidebar.
+msgctxt "Product-tour checklist item title"
+msgid "Pin a chat"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining how to pin chats, placeholders are for an icon and the word 'menu' wrapped in <strong> tags. Example: 'Pin chats here from the [three-dots-icon] <strong>menu</strong>'
 msgctxt "Pinned chats education row in Duck.ai"
 msgid "Pin chats here from the %s %s"
 msgstr "從 %1$s %2$s 將聊天釘選在此處"
+
+# smartling.placeholder_format=C
+#. Title shown in the chat-history sidebar for the disposable sample chat the 'Pin a chat' tour step creates so the user can practice pinning without affecting a real conversation.
+msgctxt "Title of a throwaway sample chat created by the product tour"
+msgid "Pin me"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used for various color settings  query parameters values captions into <a =href="https://duckduckgo.com/params.html">query parameters documentation page</a>.
@@ -14093,6 +14473,12 @@ msgstr "粉紅色"
 msgctxt "Title for the pinned chats section"
 msgid "Pinned"
 msgstr "已固定"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Pinned chats will appear at the top of your recent chats."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -14181,7 +14567,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非法。"
+msgstr ""
+"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非"
+"法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -14189,7 +14577,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有害。"
+msgstr ""
+"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有"
+"害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -14400,6 +14790,12 @@ msgid "Poor formatting"
 msgstr "格式不佳"
 
 # smartling.placeholder_format=C
+#. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
+msgctxt "new tab page"
+msgid "Popular AI models available. No account needed. Chats anonymized by us."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
 msgctxt "Onboarding welcome screen feature"
 msgid "Popular AI models from:"
@@ -14606,6 +15002,12 @@ msgstr "前一張圖片"
 msgctxt "Rich caption tabbed snippet, horizontal tab scroll"
 msgid "Previous tabs"
 msgstr "先前的分頁"
+
+# smartling.placeholder_format=C
+#. Accessible label for the left chevron button that navigates the onboarding checklist card to the previous page of tips.
+msgctxt "Accessible label for the checklist previous-page button"
+msgid "Previous tips"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a price below a web search result.
@@ -15144,6 +15546,18 @@ msgid "Reasoning AI with medium built-in moderation"
 msgstr "具備內建適中審查制度的推理型 AI"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Reasoning can give better responses to complex questions."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
+msgctxt "Usage warning in the reasoning mode dropdown"
+msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
 msgctxt "Aria label for the reasoning mode dropdown in Duck.ai"
 msgid "Reasoning mode"
@@ -15179,12 +15593,20 @@ msgid "Recent chat storage can be adjusted in %s."
 msgstr "你可以在「%1$s」中調整「最近的聊天記錄」的設定。"
 
 # smartling.placeholder_format=C
+#. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
+msgctxt "Product-tour tooltip title"
+msgid "Recent chats"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Text explaining that the Recent Chats feature stores the user's most recent chats locally to their device, and not in other remote servers.
 msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
+"中。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -15192,7 +15614,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
+"中。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -15201,7 +15625,9 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲"
+"存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -15324,6 +15750,12 @@ msgstr "重新搜尋不包含此網站"
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Reduce Usage"
 msgstr "減少使用量"
+
+# smartling.placeholder_format=C
+#. Subtitle shown under the title in the Duck.ai usage limit banner, prompting the user to switch to a lower-cost model to reduce their usage.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Reduce usage with a more efficient model"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -15470,7 +15902,8 @@ msgstr "重新載入 Duck.ai。"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
+msgstr ""
+"按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -15623,14 +16056,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享給%1$s來協助改善其服務。"
+msgstr ""
+"報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享"
+"給%1$s來協助改善其服務。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr ""
+"傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別"
+"身分的資訊。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -15638,7 +16075,9 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr ""
+"傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿"
+"名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -15685,6 +16124,12 @@ msgid "Reset All Settings"
 msgstr "重設所有設定"
 
 # smartling.placeholder_format=C
+#. Button in settings that resets the Duck.ai onboarding tips so they show again from the beginning.
+msgctxt "Settings button"
+msgid "Reset tutorial"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Displayed in the Duck.ai usage limit banner for subscribers. %s is a compact duration until the active usage limit window resets, e.g., '2d' or '5h'.
 msgctxt "Usage limit banner in Duck.ai."
 msgid "Resets in %s"
@@ -15695,6 +16140,12 @@ msgstr "重設於 %1$s"
 msgctxt "noresults"
 msgid "Resolution"
 msgstr "畫質"
+
+# smartling.placeholder_format=C
+#. Title-case label on the share-scope card to share only the selected assistant response in the Duck.ai share modal.
+msgctxt "Share scope toggle label for a single response"
+msgid "Response"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is helpful
@@ -15717,7 +16168,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回答受我們的 %1$s 服務條款%2$s約束。"
+msgstr ""
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回"
+"答受我們的 %1$s 服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15725,7 +16178,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist 受我們的%1$s服務條款%2$s約束。"
+msgstr ""
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist "
+"受我們的%1$s服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15735,8 +16190,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁內容生成，可能會有不準確之處。Search Assist 受我們的 "
-"%1$s服務條款%2$s 約束。"
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁"
+"內容生成，可能會有不準確之處。Search Assist 受我們的 %1$s服務條款%2$s 約束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -16160,7 +16615,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更多內容。"
+msgstr ""
+"你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更"
+"多內容。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -16377,6 +16834,12 @@ msgid "Search %s to find results closer to you?"
 msgstr "是否要搜尋「%1$s」，找到離你較近的結果？"
 
 # smartling.placeholder_format=C
+#. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
+msgctxt "new tab page"
+msgid "Search & Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgid "Search Anonymously"
 msgstr "匿名搜尋"
 
@@ -16400,16 +16863,18 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相關內容，然後使用 AI "
-"生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在點按 Assist 時)、有時 (在高度相關時)，或經常 "
-"(在廣泛的搜尋中)。目前，Search Assist 功能僅供部分英語地區使用。"
+"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相"
+"關內容，然後使用 AI 生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在"
+"點按 Assist 時)、有時 (在高度相關時)，或經常 (在廣泛的搜尋中)。目前，Search "
+"Assist 功能僅供部分英語地區使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr "Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
+msgstr ""
+"Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -16418,8 +16883,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網路%2$s以尋找相關內容，然後使用 AI "
-"根據找到的資訊生成簡短的答案。"
+"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網"
+"路%2$s以尋找相關內容，然後使用 AI 根據找到的資訊生成簡短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -16539,7 +17004,9 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋「ducks」。"
+msgstr ""
+"使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋"
+"「ducks」。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -16557,7 +17024,9 @@ msgstr "私密搜尋與封鎖追蹤器"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
+msgstr ""
+"使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋"
+"功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -16576,8 +17045,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 Cloud Save "
-"將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資料，且你的通關密語永遠不會離開你的瀏覽器。"
+"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 "
+"Cloud Save 將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資"
+"料，且你的通關密語永遠不會離開你的瀏覽器。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -16695,7 +17165,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步的裝置存取。"
+msgstr ""
+"以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步"
+"的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -16703,7 +17175,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存取。"
+msgstr ""
+"以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存"
+"取。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -16717,7 +17191,15 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
+msgstr ""
+"採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到"
+"你的資料，連我們也不行。"
+
+# smartling.placeholder_format=C
+#. Explains that the shared copy is stored encrypted on the server.
+msgctxt "Share modal info bullet about encryption"
+msgid "Securely stored on our encrypted server."
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17117,7 +17599,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有對話。"
+msgstr ""
+"向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有"
+"對話。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -17215,6 +17699,12 @@ msgid "Set as Homepage"
 msgstr "設為首頁"
 
 # smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Customize responses' item title when the user activates that onboarding step.
+msgctxt "Product-tour tooltip description"
+msgid "Set the tone and style of Duck.ai's responses."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Short description shown below the 'Customize responses' label in the Tools dropdown. May be overridden dynamically when customizations are saved.
 msgctxt "Subtitle for the Customize Responses entry in the Tools dropdown menu"
 msgid "Set tone, length and behavior"
@@ -17226,7 +17716,8 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
+msgstr ""
+"開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -17278,6 +17769,18 @@ msgid "Seychelles"
 msgstr "塞席爾"
 
 # smartling.placeholder_format=C
+#. Label for the share action in the chat options menu and on assistant message actions.
+msgctxt "Button for sharing a chat or response"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from an assistant response.
+msgctxt "Title for the share modal when sharing from a response action"
+msgid "Share"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the 'Share' item in the Search Assist overflow menu. Opens the OS-native share sheet to share a link to the answer.
 msgctxt "duckassist"
 msgid "Share"
@@ -17312,7 +17815,16 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透露你的精確位置。"
+msgstr ""
+"與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透"
+"露你的精確位置。"
+
+# smartling.placeholder_format=C
+#. Modal header when the user opens share from the chat history options menu.
+msgctxt ""
+"Title for the share modal when sharing an entire chat from the sidebar menu"
+msgid "Share chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Menu option to share feedback about a result
@@ -17371,6 +17883,12 @@ msgstr "分享頁面網址"
 msgctxt "feedback form"
 msgid "Share positive feedback"
 msgstr "分享正面意見回饋"
+
+# smartling.placeholder_format=C
+#. ARIA label for the response vs entire chat toggle in the share modal.
+msgctxt "Accessible label for the share scope toggle group"
+msgid "Share scope"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label for a toggle; when enabled, the user agrees to include this conversation with feedback sent to DuckDuckGo.
@@ -17504,6 +18022,12 @@ msgstr "顯示書籤小工具以及設定資料"
 msgctxt "mobile expanded map"
 msgid "Show Detail"
 msgstr "顯示詳情"
+
+# smartling.placeholder_format=C
+#. Title of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row title"
+msgid "Show Duck.ai tutorial"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17653,6 +18177,12 @@ msgid "Show more"
 msgstr "顯示更多"
 
 # smartling.placeholder_format=C
+#. Accessible label for the dropdown toggle button next to the instant model-switch button in the Duck.ai usage limit banner. Opens a menu listing more lower-cost AI models.
+msgctxt "Usage limit banner in Duck.ai."
+msgid "Show more models"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Screen-reader label for the right chevron button that navigates to the next page of suggested chat prompts.
 msgctxt ""
 "Accessible label for the next-page chevron button in the chat suggestions "
@@ -17686,6 +18216,12 @@ msgctxt ""
 "collapsed"
 msgid "Show sidebar"
 msgstr "顯示側邊欄"
+
+# smartling.placeholder_format=C
+#. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
+msgctxt "Settings row description"
+msgid "Show step-by-step tips for getting the most out of Duck.ai."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -17739,14 +18275,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影響私密搜尋。"
+msgstr ""
+"提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影"
+"響私密搜尋。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影響搜尋保護。"
+msgstr ""
+"提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影"
+"響搜尋保護。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18050,6 +18590,12 @@ msgid "Something went wrong, please try again later."
 msgstr "發生錯誤，請稍後再試。"
 
 # smartling.placeholder_format=C
+#. Error callout in the Duck.ai share modal when create/copy/delete fails, or when the selected assistant response cannot be previewed/shared (e.g. superseded by regeneration).
+msgctxt "Error message shown in the Duck.ai share modal"
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Error message shown when the user tries to activate their subscription but the process fails.
 msgctxt "Error message when subscription activation fails"
 msgid "Something went wrong. Please try again."
@@ -18332,6 +18878,12 @@ msgstr "開始使用每月上限"
 msgctxt "Action button for fixed-window Duck.ai usage limit"
 msgid "Start Using Weekly Limit"
 msgstr "開始使用每週上限"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item, the tour's opening step: highlights the Suggestions pill so the user sends their first prompt. Completed when a message is sent.
+msgctxt "Product-tour checklist item title"
+msgid "Start a new chat"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt to start a new web search.
@@ -18908,6 +19460,14 @@ msgid "Switch to the search engine that doesn't track you. Ever."
 msgstr "切換到永遠不會追蹤你的搜尋引擎。"
 
 # smartling.placeholder_format=C
+#. Re-activates a stacked second opinion, making it the current answer again.
+msgctxt ""
+"Accessible name and tooltip for the heading button on an inactive second-"
+"opinion card"
+msgid "Switch to this second opinion"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Shown in the second-opinion card after the user switches to its model. %s is the model name.
 msgctxt "Confirmation label"
 msgid "Switched to %s"
@@ -19021,16 +19581,19 @@ msgid ""
 msgstr ""
 "同步恢復碼\n"
 "\n"
-"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在你無法存取某個裝置時恢復你的同步資料。\n"
+"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在"
+"你無法存取某個裝置時恢復你的同步資料。\n"
 "\n"
 "確保此資訊安全無虞。\n"
 "任何有權限存取此代碼的人都能存取你同步的資料。%1$s\n"
 "\n"
 "這段代碼是如何運作的？\n"
-"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & Backup」，然後選擇「恢復已同步的資料」\n"
+"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & "
+"Backup」，然後選擇「恢復已同步的資料」\n"
 "3. 複製上方的恢復代碼，並貼到顯示「將你的代碼貼在這裡」的地方\n"
 "\n"
-"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將從伺服器上刪除，且無法恢復。"
+"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將"
+"從伺服器上刪除，且無法恢復。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -19049,6 +19612,12 @@ msgstr "與另一裝置同步"
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
 msgstr "同步和備份功能暫時無法使用"
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
+msgctxt "Product-tour checklist item title"
+msgid "Sync chats across devices"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Catch-all shown when pairing fails for a runtime reason (network, timeout, dropped channel, denied/aborted, protocol error). Paired with DUCKCHAT_SYNC_PAIRING_FAILED_BODY and a retry button.
@@ -19136,6 +19705,22 @@ msgstr "塔吉克"
 #. Header on a page prompting users to switch to the DuckDuckGo private search engine.
 msgid "Take Back Your Privacy!"
 msgstr "奪回你的隱私！"
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist. Mobile variant.
+msgctxt "Product-tour success modal body - mobile variant"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free app for quicker "
+"access, wherever you are."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Body of the success modal shown when the user finishes the entire onboarding checklist.
+msgctxt "Product-tour success modal body"
+msgid ""
+"Take Duck.ai with you everywhere. Get it built into our free browser for "
+"quicker access, wherever you're browsing."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -19372,7 +19957,9 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
+msgstr ""
+"這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第"
+"三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -19488,7 +20075,8 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
+msgstr ""
+"在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -19520,7 +20108,9 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設搜尋引擎，藉此為你造訪的網站新增隱私保護。"
+msgstr ""
+"這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設"
+"搜尋引擎，藉此為你造訪的網站新增隱私保護。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -19580,10 +20170,22 @@ msgid "This Month"
 msgstr "本月"
 
 # smartling.placeholder_format=C
+#. Title-case label on the share-scope card after a link is created; replaces the shorter 'Response' label. Shown in the Duck.ai share modal.
+msgctxt "Share scope toggle label after a link is created"
+msgid "This Response"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label for the weekly usage row in the Usage section of Duck.ai settings.
 msgctxt "Duck.ai settings usage section"
 msgid "This Week"
 msgstr "本週"
+
+# smartling.placeholder_format=C
+#. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
+msgctxt "Share modal info bullet about private original chat"
+msgid "This chat stays in Duck.ai and remains private to you."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19592,8 +20194,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %4$s "
-"取得更多資訊)。"
+"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準"
+"確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19602,7 +20204,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
+msgstr ""
+"此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令"
+"人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -19610,7 +20214,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感的資訊。（更多資訊請參見%2$s）。"
+msgstr ""
+"這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感"
+"的資訊。（更多資訊請參見%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -19620,8 +20226,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 "
-"(請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能"
+"會顯示不準確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -19707,6 +20313,22 @@ msgid "This information isn’t useful"
 msgstr "這些資訊沒有用"
 
 # smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Pin a chat' tour step. Tells the user to open the chat row's 3-dot menu and choose Pin.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Open its menu (the three dots), then choose Pin "
+"to keep it at the top of your chats!"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
+msgctxt "Sample assistant reply inside the throwaway product-tour chat"
+msgid ""
+"This is just a sample chat. Use the Fire Button in the side menu to delete "
+"it!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
 msgctxt "Title for the wrong code error screen"
 msgid "This is not a valid Sync code."
@@ -19724,7 +20346,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留模式。"
+msgstr ""
+"此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留"
+"模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -19732,7 +20356,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模式。"
+msgstr ""
+"此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模"
+"式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -19768,7 +20394,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從任何瀏覽器存取。"
+msgstr ""
+"這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從"
+"任何瀏覽器存取。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19776,7 +20404,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI 輔助的答案。"
+msgstr ""
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
+"可能會再次看到 AI 輔助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -19786,8 +20416,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI "
-"輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 AI 輔助答案。"
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
+"可能會再次看到 AI 輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 "
+"AI 輔助答案。"
 
 # smartling.placeholder_format=C
 #. User feedback indicating that a translation is helpful
@@ -19826,8 +20457,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然可以在連接到 Sync & Backup "
-"的其他瀏覽器中存取您的聊天記錄。"
+"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然"
+"可以在連接到 Sync & Backup 的其他瀏覽器中存取您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -19972,7 +20603,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖示。%4$s"
+msgstr ""
+"如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖"
+"示。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -19981,7 +20614,9 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲存在您最初用於設定同步的裝置上。"
+msgstr ""
+"若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲"
+"存在您最初用於設定同步的裝置上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -19989,7 +20624,9 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再試一次。"
+msgstr ""
+"欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再"
+"試一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -20013,6 +20650,12 @@ msgstr "今天"
 msgctxt "Title for the period of chats from today"
 msgid "Today"
 msgstr "今天"
+
+# smartling.placeholder_format=C
+#. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
+msgctxt "new tab page"
+msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -20232,7 +20875,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
+msgstr ""
+"將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -20240,7 +20884,8 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
+msgstr ""
+"將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20420,9 +21065,21 @@ msgid "Try Them Out"
 msgstr "試試看"
 
 # smartling.placeholder_format=C
+#. Onboarding checklist item: opens the model selector so the user can pick a different AI model.
+msgctxt "Product-tour checklist item title"
+msgid "Try a different model"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Alternate header text for front page
 msgid "Try a search!"
 msgstr "試試搜尋一下！"
+
+# smartling.placeholder_format=C
+#. Tooltip on the Suggestions pill when the user activates the 'Start a new chat' onboarding step. Invites them to open the suggested prompts instead of composing from scratch.
+msgctxt "Product-tour highlight tooltip"
+msgid "Try a suggestion"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Message prompting users to add more information to their search term.
@@ -20487,6 +21144,12 @@ msgid "Try for free"
 msgstr "免費試用"
 
 # smartling.placeholder_format=C
+#. Link-style call to action shown when a subscription-eligible free user has reached a Duck.ai usage limit. Opens the DuckDuckGo subscription modal.
+msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
+msgid "Try for free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link-style CTA shown on the right of the Subscriber exclusive section header; clicking starts the subscription trial flow.
 msgctxt ""
 "Trailing CTA on the Subscriber exclusive section header in the model picker "
@@ -20499,6 +21162,12 @@ msgstr "免費試用"
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
 msgstr "免費試用！安全的 VPN、先進的& Private AI 等。"
+
+# smartling.placeholder_format=C
+#. Secondary text under the subscription row, pointing at the 7-day free trial.
+msgctxt "Subtitle under the Unlock advanced models row"
+msgid "Try free for 7 days"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
@@ -20526,6 +21195,12 @@ msgstr "試試我們的瀏覽器"
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
 msgstr "試試我們從來不會顯示這些訊息的首頁："
+
+# smartling.placeholder_format=C
+#. Onboarding checklist item: points the user to reasoning / extended-thinking mode.
+msgctxt "Product-tour checklist item title"
+msgid "Try reasoning"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words to get more results.
@@ -20639,7 +21314,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設定。 %3$s瞭解更多%4$s"
+msgstr ""
+"想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設"
+"定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -20647,7 +21324,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設定。 %3$s瞭解更多%4$s"
+msgstr ""
+"想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設"
+"定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -20769,6 +21448,12 @@ msgid "Turn on Duck Player to watch YouTube without targeted ads"
 msgstr "開啟 Duck Player 即可觀看不受廣告鎖定干擾的 YouTube 影片"
 
 # smartling.placeholder_format=C
+#. Button that enables the Search/Duck.ai toggle.
+msgctxt "new tab page"
+msgid "Turn on Duck.ai Toggle"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
@@ -20829,7 +21514,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延遲。"
+msgstr ""
+"在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延"
+"遲。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21080,7 +21767,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus 方案的使用上限。"
+msgstr ""
+"透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus "
+"方案的使用上限。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -21121,6 +21810,12 @@ msgstr "透過 DuckDuckGo，解鎖進階的 AI 模型"
 msgctxt "Text promotion"
 msgid "Unlock advanced AI with your subscription!"
 msgstr "訂閱後即可解鎖進階的 AI！"
+
+# smartling.placeholder_format=C
+#. Row on the tour-completion card that opens the Duck.ai subscription purchase modal. Leads with the subscription benefit (access to advanced AI models).
+msgctxt "Title of the row that opens the subscription modal"
+msgid "Unlock advanced models"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat duration limit modal for free users.
@@ -21438,7 +22133,9 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵害。對資訊保密。免費。不需要帳戶。"
+msgstr ""
+"私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵"
+"害。對資訊保密。免費。不需要帳戶。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -21473,6 +22170,12 @@ msgstr "用於Firefox"
 #. Link to download the DuckDuckGo extension for the Safari browser.
 msgid "Use in Safari"
 msgstr "用於Safari"
+
+# smartling.placeholder_format=C
+#. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
+msgctxt "Product-tour tooltip description"
+msgid "Use the Fire Button to delete a chat from history."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -21636,7 +22339,8 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
+msgstr ""
+"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -21644,7 +22348,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管理。"
+msgstr ""
+"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管"
+"理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -21686,8 +22392,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & Backup%4$s > "
-"%5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21697,8 +22403,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & "
-"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & Backup」下選取"
+"「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -21708,8 +22414,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設"
+"定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -21719,8 +22425,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在「Sync & "
-"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在"
+"「Sync & Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 "
+"PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -21915,7 +22622,9 @@ msgstr "在 Duck Player 中觀看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推播干擾。"
+msgstr ""
+"在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推"
+"播干擾。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -21935,8 +22644,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube "
-"沒有任何關係。"
+"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內"
+"容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube 沒有任何關係。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -21959,7 +22668,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo 分享此對話，以便我們調查並處理該問題。"
+msgstr ""
+"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo "
+"分享此對話，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -21970,7 +22681,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的提示詞與回覆內容，以便我們調查並處理該問題。"
+msgstr ""
+"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的"
+"提示詞與回覆內容，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -22010,7 +22723,8 @@ msgstr "我們不會儲存你的個人資訊。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr "我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
+msgstr ""
+"我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22031,7 +22745,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
+msgstr ""
+"本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -22070,7 +22785,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr "我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告商。"
+msgstr ""
+"我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告"
+"商。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -22095,7 +22812,9 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智慧。"
+msgstr ""
+"我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智"
+"慧。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22127,7 +22846,9 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主意。"
+msgstr ""
+"我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主"
+"意。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -22153,7 +22874,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立刻出現。"
+msgstr ""
+"我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立"
+"刻出現。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -22317,7 +23040,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
+msgstr ""
+"歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會"
+"用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -22325,7 +23050,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
+msgstr ""
+"歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名"
+"化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -22335,8 +23062,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這裡的所有聊天內容都是私密的，且永遠不會被 "
-"DuckDuckGo 儲存或用來訓練 AI 模型。"
+"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這"
+"裡的所有聊天內容都是私密的，且永遠不會被 DuckDuckGo 儲存或用來訓練 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -22462,8 +23189,9 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 DuckDuckGo 來源。將回應分成清晰的部分，並以 "
-"Duck.ai 整合和隱私保護為重點。對於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
+"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 "
+"DuckDuckGo 來源。將回應分成清晰的部分，並以 Duck.ai 整合和隱私保護為重點。對"
+"於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22573,6 +23301,12 @@ msgstr "您最在意的是什麼？"
 msgctxt "new user poll"
 msgid "What brought you back today?"
 msgstr "你今天為何又回來了？"
+
+# smartling.placeholder_format=C
+#. Placeholder user message in the disposable sample chat created by the 'Delete a chat' tour step.
+msgctxt "Sample user message inside the throwaway product-tour chat"
+msgid "What can you do?"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -22987,6 +23721,14 @@ msgid "Wintry Mix"
 msgstr "雨雪交雜"
 
 # smartling.placeholder_format=C
+#. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page. The placeholder is filled with the localized NTP_CUSTOMIZE button label (the button that opens the New Tab Page customization menu).
+msgctxt "new tab page"
+msgid ""
+"With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
+"on or off anytime in the '%s' menu."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
 msgctxt "AI Chat model switch dropdown section header"
 msgid "Without zero provider visibility"
@@ -23309,7 +24051,8 @@ msgstr "你最多可以附加 %1$s 個文字選擇。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
+msgstr ""
+"你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -23329,7 +24072,8 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
+msgstr ""
+"你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -23395,6 +24139,13 @@ msgstr "每次對話只能附加 %1$s 張圖片"
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
 msgstr "每次對話只能附加 %1$s 張圖片"
+
+# smartling.placeholder_format=C
+#. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
+msgctxt ""
+"Error message when the number of attached browser tabs exceeds the limit"
+msgid "You can only attach %s tabs at a time."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded.
@@ -23470,7 +24221,9 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高出 2 倍的使用上限。"
+msgstr ""
+"您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高"
+"出 2 倍的使用上限。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -23478,7 +24231,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 DuckDuckGo 訂閱保護功能。"
+msgstr ""
+"你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 "
+"DuckDuckGo 訂閱保護功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -23499,7 +24254,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr ""
+"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
+"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -23508,7 +24265,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr ""
+"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
+"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -23524,12 +24283,20 @@ msgid ""
 msgstr "一旦您擁有最新版本，您將收到自動 DuckDuckGo 應用程式更新。"
 
 # smartling.placeholder_format=C
+#. Celebration heading shown when the user has completed every step of the onboarding checklist.
+msgctxt "Heading shown while the completion celebration (confetti) plays"
+msgid "You're all set!"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. shown when DDG is selected after eu preference menu on android
 msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏覽。應用程式已經安裝完畢，而且可以："
+msgstr ""
+"你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏"
+"覽。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -23565,6 +24332,12 @@ msgstr "您已封鎖 %1$s 個網站"
 msgctxt "Organic result context menu"
 msgid "You've blocked 1 site"
 msgstr "您已封鎖 1 個網站"
+
+# smartling.placeholder_format=C
+#. Congratulatory title of the success modal shown when the user completes every onboarding checklist item.
+msgctxt "Product-tour success modal title"
+msgid "You've mastered the basics of Duck.ai"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Title shown when a user has reached their image generation limit.
@@ -23610,7 +24383,9 @@ msgctxt "Sync file storage limit modal description"
 msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
-msgstr "您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr ""
+"您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的"
+"聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -23619,7 +24394,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats. Delete the %s "
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
-msgstr "您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr ""
+"您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件"
+"聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -23632,7 +24409,9 @@ msgstr "你的儲存空間已用完"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/Google追蹤。"
+msgstr ""
+"YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/"
+"Google追蹤。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -23675,7 +24454,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
+msgstr ""
+"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
+"中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -23684,7 +24465,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
+msgstr ""
+"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
+"中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -23748,14 +24531,16 @@ msgstr "您的聊天內容是私密的，且絕不會用於訓練 AI 模型"
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr ""
+"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr ""
+"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -23783,7 +24568,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些步驟保留您的聊天記錄。"
+msgstr ""
+"您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些"
+"步驟保留您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -23822,7 +24609,8 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
+msgstr ""
+"你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -23864,7 +24652,10 @@ msgid ""
 "known as %sSHA-2%s. Only the key and associated settings file leave your "
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
-msgstr "我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔案。DuckDuckGo不會知道你的通關密語。"
+msgstr ""
+"我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。"
+"只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔"
+"案。DuckDuckGo不會知道你的通關密語。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23878,7 +24669,9 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者無法將你的對話與你連結起來。"
+msgstr ""
+"你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者"
+"無法將你的對話與你連結起來。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -23917,14 +24710,22 @@ msgid "Your searches can’t be tied back to you"
 msgstr "你的搜尋結果無法追溯到你本人"
 
 # smartling.placeholder_format=C
+#. Message shown in a modal on Firefox when the No AI extension is installed but disabled. The first two placeholders bold DuckDuckGo No AI.
+msgctxt "settings"
+msgid ""
+"Your settings are saved, but clearing cookies will reset them. Enable the "
+"%sDuckDuckGo No AI%s extension to make it permanent."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
 msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。 "
-"%3$s瞭解更多%4$s"
+"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No "
+"AI%2$s 擴充套件以使其永久生效。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
@@ -23943,7 +24744,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得更全面的保護。應用程式已經安裝完畢，而且可以："
+msgstr ""
+"你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得"
+"更全面的保護。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -23959,7 +24762,8 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
+msgstr ""
+"您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -24494,3 +25298,9 @@ msgstr "年"
 msgctxt "published date for videos"
 msgid "yr"
 msgstr "年"
+
+# smartling.placeholder_format=C
+#. Visible arrow that advances the first tooltip in the 'Delete a chat' onboarding step. Use the appropriate direction for the locale's reading direction; the control's accessible label is translated separately.
+msgctxt "Product-tour tooltip action"
+msgid "→"
+msgstr ""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localization-only updates to `.pot` and a single locale PO file; no runtime code or security-sensitive logic is modified.
> 
> **Overview**
> Adds a large batch of new **gettext strings** to `duckduckgo.pot` and supplies **Afrikaans (`af_ZA`) translations** in `locales/af_ZA/LC_MESSAGES/duckduckgo.po`.
> 
> The new tokens cover recently shipped **Duck.ai** UX: encrypted **chat/response sharing** (modal copy, scope toggles, link lifecycle), the **Explore Duck.ai** product-tour checklist and tooltips, **usage-limit** and Opus/reasoning warnings, **Chrome New Tab** Duck.ai promo and Search/Duck.ai toggle, **second-opinion** controls, shared-attachment captions, tab-attach limits, and related **settings** strings (tutorial reset, Firefox No AI “Enable Now”).
> 
> No application logic changes—only source strings and one locale’s `msgstr` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19a1422996fb8403e37c665eaf83be3a966af1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->